### PR TITLE
#9 add check to ensure csrf_token is in string form

### DIFF
--- a/dropbox/client.py
+++ b/dropbox/client.py
@@ -1507,6 +1507,7 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
             Tell the user to visit this URL and approve your app.
         """
         csrf_token = base64.urlsafe_b64encode(os.urandom(16))
+        csrf_token = csrf_token.decode('UTF-8') if not isinstance(csrf_token, str)
         state = csrf_token
         if url_state is not None:
             state += "|" + url_state

--- a/dropbox/client.py
+++ b/dropbox/client.py
@@ -1507,7 +1507,8 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
             Tell the user to visit this URL and approve your app.
         """
         csrf_token = base64.urlsafe_b64encode(os.urandom(16))
-        csrf_token = csrf_token.decode('UTF-8') if not isinstance(csrf_token, str)
+        if not isinstance(csrf_token, str):
+            csrf_token = csrf_token.decode('UTF-8')
         state = csrf_token
         if url_state is not None:
             state += "|" + url_state


### PR DESCRIPTION
Check for CSRF_TOKEN being a string when generating the urlsafe 64 bit encoding and placing it in our session.