### PR TITLE
Improve experience for contributors

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -193,7 +193,6 @@ class Dropbox(DropboxBase):
 
         deserialized_result = babel_serializers.json_compat_obj_decode(
             returned_data_type, obj, strict=False)
-        print(deserialized_result)
 
         if isinstance(res, RouteErrorResult):
             raise ApiError(deserialized_result,

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -115,9 +115,10 @@ class BaseClientTests(unittest.TestCase):
 
         self.test_dir = "/Test/%s" % str(datetime.datetime.utcnow())
 
-        self.foo = 'foo.txt'
-        self.frog = 'Costa Rican Frog.jpg'
-        self.song = 'dropbox_song.mp3'
+        local_test_dir = os.path.dirname(__file__)
+        self.foo = os.path.join(local_test_dir, 'foo.txt')
+        self.frog = os.path.join(local_test_dir, 'Costa Rican Frog.jpg')
+        self.song = os.path.join(local_test_dir, 'dropbox_song.mp3')
 
     def tearDown(self):
         try:

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -44,7 +44,7 @@ class TestDropbox(unittest.TestCase):
         invalid_token_dbx = Dropbox(INVALID_TOKEN)
         with self.assertRaises(AuthError) as cm:
             invalid_token_dbx.files_list_folder('')
-        self.assertEqual(cm.exception.reason['error']['.tag'],
+        self.assertEqual(cm.exception.error['error']['.tag'],
                          'invalid_access_token')
 
     def test_rpc(self):
@@ -55,7 +55,7 @@ class TestDropbox(unittest.TestCase):
                              ''.join(random.sample(string.ascii_letters, 15))
         with self.assertRaises(ApiError) as cm:
             self.dbx.files_list_folder(random_folder_path)
-        self.assertIsInstance(cm.exception.reason, ListFolderError)
+        self.assertIsInstance(cm.exception.error, ListFolderError)
 
     def test_upload_download(self):
         # Upload file


### PR DESCRIPTION
Hi,

You left a print statement in an earlier commit, so I wanted to make a pull request for removing it. While doing so, I forked the repo and launched the tests, and it failed because you need to be inside the test folder for it to run correctly, but that's just because the files around are accessed through a direct path, so I propose a small change that gives room for more flexibility.

Finally, 2 of your tests were initially failing after the recent ".reason"/".error" refactoring, so I fixed them.

If you prefer, 3 different pull requests, just tell me.

Would you be ok to using [tox](https://tox.readthedocs.org/en/latest/) instead of calling "python2" and "python3" directly in runtests. For those using virtualenvs instead of globally installing packages, that can smooth this a lot.