### PR TITLE
Small bug fix for OAuth2 finish, API v2 thumbnails and locale

### DIFF
--- a/dropbox/files.py
+++ b/dropbox/files.py
@@ -2844,19 +2844,19 @@ class ThumbnailSize(object):
         self._value = value
 
     def is_xs(self):
-        return self._tag == 'xs'
+        return self._tag == 'w32h32'
 
     def is_s(self):
-        return self._tag == 's'
+        return self._tag == 'w64h64'
 
     def is_m(self):
-        return self._tag == 'm'
+        return self._tag == 'w128h128'
 
     def is_l(self):
-        return self._tag == 'l'
+        return self._tag == 'w640h480'
 
     def is_xl(self):
-        return self._tag == 'xl'
+        return self._tag == 'w1024h768'
 
     def __repr__(self):
         return 'ThumbnailSize(%r)' % self._tag
@@ -4018,18 +4018,18 @@ ThumbnailSize._m_validator = bv.Void()
 ThumbnailSize._l_validator = bv.Void()
 ThumbnailSize._xl_validator = bv.Void()
 ThumbnailSize._tagmap = {
-    'xs': ThumbnailSize._xs_validator,
-    's': ThumbnailSize._s_validator,
-    'm': ThumbnailSize._m_validator,
-    'l': ThumbnailSize._l_validator,
-    'xl': ThumbnailSize._xl_validator,
+    'w32h32': ThumbnailSize._xs_validator,
+    'w64h64': ThumbnailSize._s_validator,
+    'w128h128': ThumbnailSize._m_validator,
+    'w640h480': ThumbnailSize._l_validator,
+    'w1024h768': ThumbnailSize._xl_validator,
 }
 
-ThumbnailSize.xs = ThumbnailSize('xs')
-ThumbnailSize.s = ThumbnailSize('s')
-ThumbnailSize.m = ThumbnailSize('m')
-ThumbnailSize.l = ThumbnailSize('l')
-ThumbnailSize.xl = ThumbnailSize('xl')
+ThumbnailSize.xs = ThumbnailSize('w32h32')
+ThumbnailSize.s = ThumbnailSize('w64h64')
+ThumbnailSize.m = ThumbnailSize('w128h128')
+ThumbnailSize.l = ThumbnailSize('w640h480')
+ThumbnailSize.xl = ThumbnailSize('w1024h768')
 
 ThumbnailFormat._jpeg_validator = bv.Void()
 ThumbnailFormat._png_validator = bv.Void()

--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -329,6 +329,10 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
         if self.csrf_token_session_key not in self.session:
             raise BadStateException('Missing CSRF token in session.')
         csrf_token_from_session = self.session[self.csrf_token_session_key]
+
+        if not isinstance(csrf_token_from_session, str):
+            csrf_token_from_session = str(csrf_token_from_session)
+
         if len(csrf_token_from_session) <= 20:
             raise AssertionError('CSRF token unexpectedly short: %r' %
                                  csrf_token_from_session)

--- a/dropbox/users.py
+++ b/dropbox/users.py
@@ -1082,7 +1082,7 @@ BasicAccount._all_fields_ = Account._all_fields_ + [('is_teammate', BasicAccount
 
 FullAccount._email_validator = bv.String()
 FullAccount._country_validator = bv.Nullable(bv.String(min_length=2, max_length=2))
-FullAccount._locale_validator = bv.String(min_length=2, max_length=2)
+FullAccount._locale_validator = bv.String(min_length=2, max_length=5)
 FullAccount._referral_link_validator = bv.String()
 FullAccount._team_validator = bv.Nullable(bv.Struct(Team))
 FullAccount._is_paired_validator = bv.Boolean()


### PR DESCRIPTION
Here you go, three patches!

When comparing with the CSRF token from Dropbox, expecting bytes rather than a string makes for the CsrfException.

Dropbox API v2, expecting 'w32h32' rather than 'xs' and 'w64h64' rather than 's' etc. returns an error message.

When getting the current account and the locale has more than two characters, like 'sv_SE' and 'en_GB' etc., the framework returns an error message.

Regards,
Alexander