### PR TITLE
Decode csrf_token to be comaptiable with Django session in Python 3

### DIFF
--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -273,6 +273,8 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
             and approve your app.
         """
         csrf_token = base64.urlsafe_b64encode(os.urandom(16))
+        if six.PY3:
+            csrf_token = csrf_token.decode("utf-8")
         state = csrf_token
         if url_state is not None:
             state += "|" + url_state


### PR DESCRIPTION
With Python 3, DropboxOAuth2Flow(...).start() occurs TypeError
when saving csrf token in Django session object because csrf token is
binary. Decoding it to utf-8 string should fix the issue.

Testing: Ran tox (without checking team related tests)