### PR TITLE
Use default backoff if not specified

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -320,7 +320,7 @@ class _DropboxTransport(object):
                     backoff = e.backoff if e.backoff is not None else 5.0
                     self._logger.info(
                         'Ratelimit: Retrying in %.1f seconds.', backoff)
-                    time.sleep(e.backoff)
+                    time.sleep(backoff)
                 else:
                     raise
 


### PR DESCRIPTION
Pretty self explanatory... I was getting crashes with `TypeError: a float is required` (`None` is not a float...).