### PR TITLE
Respect default socket timeouts

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -14,6 +14,7 @@ import os
 import random
 import six
 import time
+import socket
 
 import requests
 
@@ -372,6 +373,7 @@ class _DropboxTransport(object):
                                data=body,
                                stream=stream,
                                verify=True,
+                               timeout=socket.getdefaulttimeout()
                                )
 
         request_id = r.headers.get('x-dropbox-request-id')


### PR DESCRIPTION
It looks like currently Dropbox SDK doesn't pass any timeout value to
requests module. Requests itself uses urllib3 that currently doesn't
have reasonable default for socket timeout. And default None value means
no timeout at all.

This fix passes socket.getdefaulttimeout() to requests so client code
can use socket.setdefaulttimeout() to adjust timeout.