### PR TITLE
DropboxTeam as_user needs to instantiate Dropbox with max_retries_on_rate_limit

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -465,6 +465,7 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
         return Dropbox(
             self._oauth2_access_token,
             max_retries_on_error=self._max_retries_on_error,
+            max_retries_on_rate_limit=self._max_retries_on_rate_limit,
             user_agent=self._raw_user_agent,
             session=self._session,
             headers=new_headers,


### PR DESCRIPTION
Included the parameter as seen in the diff.