### PR TITLE
Pass file data instead of file handle to upload example

### DIFF
--- a/example/back-up-and-restore/backup-and-restore-example.py
+++ b/example/back-up-and-restore/backup-and-restore-example.py
@@ -23,7 +23,7 @@ def backup():
         # are changed on upload
         print("Uploading " + LOCALFILE + " to Dropbox as " + BACKUPPATH + "...")
         try:
-            dbx.files_upload(f, BACKUPPATH, mode=WriteMode('overwrite'))
+            dbx.files_upload(f.read(), BACKUPPATH, mode=WriteMode('overwrite'))
         except ApiError as err:
             # This checks for the specific error where a user doesn't have
             # enough Dropbox space quota to upload this file


### PR DESCRIPTION
Fixes the following error in the example.

`TypeError: expected request_binary as binary type, got <type 'file'>`

[files_upload](https://dropbox-sdk-python.readthedocs.io/en/master/moduledoc.html#dropbox.dropbox.Dropbox.files_upload) expects data, not a file handle. 