### PR TITLE
Fixes oauth.py (v2) to target dropbox api v2 and not v1.

### DIFF
--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -24,8 +24,6 @@ else:
     url_path_quote = urllib.quote
     url_encode = urllib.urlencode
 
-OAUTH_ROUTE_VERSION = '1'
-
 
 class OAuth2FlowNoRedirectResult(object):
     """
@@ -153,9 +151,9 @@ class DropboxOAuth2FlowBase(object):
 
         if params:
             query_string = _params_to_urlencoded(params)
-            return "/%s%s?%s" % (OAUTH_ROUTE_VERSION, target_path, query_string)
+            return "%s?%s" % (target_path, query_string)
         else:
-            return "/%s%s" % (OAUTH_ROUTE_VERSION, target_path)
+            return target_path
 
     def build_url(self, target, params=None):
         """Build an API URL.


### PR DESCRIPTION
It looks like that "oauth.py" should be used for using oauth2 with dropbox api v2.
(instead of oauth2 classes coming from client.py)

But strangely, it is still targeting the "v1" endpoint of dropbox api.
It is strange that no one did notice this before because in my opinion it can't work as otherwise this code is trying to use the "v2" syntax with the "v1" endpoint.

To use the "v2", my patch remove the "route_version" component as stated in the official api documentation. 
