### PR TITLE
Fix *_HOST environment variable overrides

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -9,7 +9,6 @@ __version__ = '7.2.1'
 import contextlib
 import json
 import logging
-import os
 import random
 import six
 import time
@@ -31,7 +30,15 @@ from .exceptions import (
     InternalServerError,
     RateLimitError,
 )
-from .session import pinned_session
+from .session import (
+    API_CONTENT_HOST,
+    API_HOST,
+    API_NOTIFICATION_HOST,
+    HOST_API,
+    HOST_CONTENT,
+    HOST_NOTIFY,
+    pinned_session,
+)
 
 
 class RouteResult(object):
@@ -97,17 +104,6 @@ class _DropboxTransport(object):
     """
 
     _API_VERSION = '2'
-
-    _DEFAULT_DOMAIN = '.dropboxapi.com'
-
-    # Host for RPC-style routes.
-    _HOST_API = 'api'
-
-    # Host for upload and download-style routes.
-    _HOST_CONTENT = 'content'
-
-    # Host for longpoll routes.
-    _HOST_NOTIFY = 'notify'
 
     # Download style means that the route argument goes in a Dropbox-API-Arg
     # header, and the result comes back in a Dropbox-API-Result header. The
@@ -183,16 +179,9 @@ class _DropboxTransport(object):
 
         self._logger = logging.getLogger('dropbox')
 
-        self._domain = os.environ.get('DROPBOX_DOMAIN', Dropbox._DEFAULT_DOMAIN)
-        self._api_hostname = os.environ.get(
-            'DROPBOX_API_HOST', 'api' + self._domain)
-        self._api_content_hostname = os.environ.get(
-            'DROPBOX_API_CONTENT_HOST', 'content' + self._domain)
-        self._api_notify_hostname = os.environ.get(
-            'DROPBOX_API_NOTIFY_HOST', 'notify' + self._domain)
-        self._host_map = {self._HOST_API: self._api_hostname,
-                          self._HOST_CONTENT: self._api_content_hostname,
-                          self._HOST_NOTIFY: self._api_notify_hostname}
+        self._host_map = {HOST_API: API_HOST,
+                          HOST_CONTENT: API_CONTENT_HOST,
+                          HOST_NOTIFY: API_NOTIFICATION_HOST}
 
         self._timeout = timeout
 
@@ -389,7 +378,7 @@ class _DropboxTransport(object):
         url = self._get_route_url(fq_hostname, func_name)
 
         headers = {'User-Agent': self._user_agent}
-        if host != self._HOST_NOTIFY:
+        if host != HOST_NOTIFY:
             headers['Authorization'] = 'Bearer %s' % self._oauth2_access_token
             if self._headers:
                 headers.update(self._headers)

--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -1,3 +1,4 @@
+import os
 import pkg_resources
 import ssl
 import sys
@@ -52,6 +53,24 @@ else:
     url_path_quote = urllib.parse.quote
     url_encode = urllib.parse.urlencode
 
+DOMAIN = os.environ.get('DROPBOX_DOMAIN', '.dropboxapi.com')
+
+# Default short hostname for RPC-style routes.
+HOST_API = 'api'
+
+# Default short hostname for upload and download-style routes.
+HOST_CONTENT = 'content'
+
+# Default short hostname for longpoll routes.
+HOST_NOTIFY = 'notify'
+
+# Default short hostname for the Drobox website.
+HOST_WWW = 'www'
+
+API_HOST = os.environ.get('DROPBOX_API_HOST', HOST_API + DOMAIN)
+API_CONTENT_HOST = os.environ.get('DROPBOX_API_CONTENT_HOST', HOST_CONTENT + DOMAIN)
+API_NOTIFICATION_HOST = os.environ.get('DROPBOX_API_NOTIFY_HOST', HOST_NOTIFY + DOMAIN)
+WEB_HOST = os.environ.get('DROPBOX_WEB_HOST', HOST_WWW + DOMAIN)
 
 class OAuthToken(object):
     """
@@ -64,11 +83,6 @@ class OAuthToken(object):
 
 class BaseSession(object):
     API_VERSION = 1
-
-    API_HOST = "api.dropbox.com"
-    WEB_HOST = "www.dropbox.com"
-    API_CONTENT_HOST = "api-content.dropbox.com"
-    API_NOTIFICATION_HOST = "api-notify.dropbox.com"
 
     def __init__(self, consumer_key, consumer_secret, access_type="auto", locale=None, rest_client=rest.RESTClient):
         """Initialize a DropboxSession object.
@@ -150,6 +164,11 @@ class BaseSession(object):
             - The full API URL.
         """
         return "https://%s%s" % (host, self.build_path(target, params))
+
+BaseSession.API_HOST = API_HOST
+BaseSession.API_CONTENT_HOST = API_CONTENT_HOST
+BaseSession.API_NOTIFICATION_HOST = API_NOTIFICATION_HOST
+BaseSession.WEB_HOST = WEB_HOST
 
 class DropboxSession(BaseSession):
 
@@ -251,8 +270,6 @@ class DropboxSession(BaseSession):
         """Build OAuth access headers for a future request.
 
         Args:
-            - ``method``: The HTTP method being used (e.g. 'GET' or 'POST').
-            - ``resource_url``: The full url the request will be made to.
             - ``params``: A dictionary of parameters to add to what's already on the url.
               Typically, this would consist of POST parameters.
 


### PR DESCRIPTION
The various `*_HOST` environment variable overrides were not working correctly for v1. This fix ensures that environmental host overrides for both v1 and v2 APIs, which is necessary for testing.