### PR TITLE
Import PoolManager directly from urllib3

### DIFF
--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -4,7 +4,7 @@ import ssl
 
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+from urllib3.poolmanager import PoolManager
 
 
 _TRUSTED_CERT_FILE = pkg_resources.resource_filename(__name__, 'trusted-certs.crt')


### PR DESCRIPTION
With the requests-2.16.0 packages has been removed so
import poolmanager from urllib3 directly.