### PR TITLE
update defualt ssl_version

### DIFF
--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -41,7 +41,6 @@ class _SSLAdapter(HTTPAdapter):
             block=block,
             cert_reqs=ssl.CERT_REQUIRED,
             ca_certs=_TRUSTED_CERT_FILE,
-            ssl_version=ssl.PROTOCOL_TLSv1,
         )
 
 def pinned_session(pool_maxsize=8):


### PR DESCRIPTION
 to no longer use specifically TLSv1 but instead use the defualt TLS and require no sslV2 and V3.