### PR TITLE
Align docstring for several Dropbox API v2 methods

### DIFF
--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -1095,8 +1095,7 @@ class DropboxBase(object):
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the file to download.
         :param Nullable rev: Please specify revision in ``path`` instead.
-        :rtype: (:class:`dropbox.files.FileMetadata`,
-                 :class:`requests.models.Response`)
+        :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`dropbox.exceptions.ApiError`
 
         If this raises, ApiError.reason is of type:
@@ -1205,8 +1204,7 @@ class DropboxBase(object):
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the file to preview.
         :param Nullable rev: Please specify revision in ``path`` instead.
-        :rtype: (:class:`dropbox.files.FileMetadata`,
-                 :class:`requests.models.Response`)
+        :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`dropbox.exceptions.ApiError`
 
         If this raises, ApiError.reason is of type:
@@ -1306,8 +1304,7 @@ class DropboxBase(object):
         :type format: :class:`dropbox.files.ThumbnailFormat`
         :param size: The size for the thumbnail image.
         :type size: :class:`dropbox.files.ThumbnailSize`
-        :rtype: (:class:`dropbox.files.FileMetadata`,
-                 :class:`requests.models.Response`)
+        :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`dropbox.exceptions.ApiError`
 
         If this raises, ApiError.reason is of type:


### PR DESCRIPTION
Since several file related Dropbox API v2 methods save
file content explicitly the only return result is
dropbox.files.FileMetadat. So this should be reflected
in the documentation