### PR TITLE
raise timeout

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -117,7 +117,7 @@ class _DropboxTransport(object):
     _ROUTE_STYLE_RPC = 'rpc'
 
     # This is the default longest time we'll block on receiving data from the server
-    _DEFAULT_TIMEOUT = 30
+    _DEFAULT_TIMEOUT = 100
 
     def __init__(self,
                  oauth2_access_token,


### PR DESCRIPTION
Dropbox's HTTP servers have 90s timeouts.  30s is too low and results in spurious time outs when the client would have received data.