### PR TITLE
add helper methods for path_root header

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -22,6 +22,11 @@ from .auth import (
     AuthError_validator,
     RateLimitError_validator,
 )
+from .common import (
+    PathRoot,
+    PathRoot_validator,
+    PathRootError_validator
+)
 from .base import DropboxBase
 from .base_team import DropboxTeamBase
 from .exceptions import (
@@ -29,6 +34,7 @@ from .exceptions import (
     AuthError,
     BadInputError,
     HttpError,
+    PathRootError,
     InternalServerError,
     RateLimitError,
 )
@@ -41,6 +47,9 @@ from .session import (
     HOST_NOTIFY,
     pinned_session,
 )
+
+PATH_ROOT_HEADER = 'Dropbox-API-Path-Root'
+HTTP_STATUS_INVALID_PATH_ROOT = 422
 
 class RouteResult(object):
     """The successful result of a call to a route."""
@@ -181,6 +190,35 @@ class _DropboxTransport(object):
                           HOST_NOTIFY: API_NOTIFICATION_HOST}
 
         self._timeout = timeout
+
+    def clone(
+            self,
+            oauth2_access_token=None,
+            max_retries_on_error=None,
+            max_retries_on_rate_limit=None,
+            user_agent=None,
+            session=None,
+            headers=None,
+            timeout=None):
+        """
+        Creates a new copy of the Dropbox client with the same defaults unless modified by
+        arguments to clone()
+
+        See constructor for original parameter descriptions.
+
+        :return: New instance of Dropbox clent
+        :rtype: Dropbox
+        """
+
+        return self.__class__(
+            oauth2_access_token or self._oauth2_access_token,
+            max_retries_on_error or self._max_retries_on_error,
+            max_retries_on_rate_limit or self._max_retries_on_rate_limit,
+            user_agent or self._user_agent,
+            session or self._session,
+            headers or self._headers,
+            timeout or self._timeout
+        )
 
     def request(self,
                 route,
@@ -421,6 +459,10 @@ class _DropboxTransport(object):
             err = stone_serializers.json_compat_obj_decode(
                 AuthError_validator, r.json()['error'])
             raise AuthError(request_id, err)
+        elif r.status_code == HTTP_STATUS_INVALID_PATH_ROOT:
+            err = stone_serializers.json_compat_obj_decode(
+                PathRootError_validator, r.json()['error'])
+            raise PathRootError(request_id, err)
         elif r.status_code == 429:
             err = None
             if r.headers.get('content-type') == 'application/json':
@@ -479,6 +521,28 @@ class _DropboxTransport(object):
                 for c in http_resp.iter_content(chunksize):
                     f.write(c)
 
+    def with_path_root(self, path_root):
+        """
+        Creates a clone of the Dropbox instance with the Dropbox-API-Path-Root header
+        as the appropriate serialized instance of PathRoot.
+
+        For more information, see
+        https://www.dropbox.com/developers/reference/namespace-guide#pathrootmodes
+
+        :param PathRoot path_root: instance of PathRoot to serialize into the headers field
+        :return: A :class: `Dropbox`
+        :rtype: Dropbox
+        """
+
+        if not isinstance(path_root, PathRoot):
+            raise ValueError("path_root must be an instance of PathRoot")
+
+        return self.clone(
+            headers={
+                PATH_ROOT_HEADER: stone_serializers.json_encode(PathRoot_validator, path_root)
+            }
+        )
+
 class Dropbox(_DropboxTransport, DropboxBase):
     """
     Use this class to make requests to the Dropbox API using a user's access
@@ -532,12 +596,4 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
 
         new_headers = self._headers.copy() if self._headers else {}
         new_headers[select_header_name] = team_member_id
-        return Dropbox(
-            self._oauth2_access_token,
-            max_retries_on_error=self._max_retries_on_error,
-            max_retries_on_rate_limit=self._max_retries_on_rate_limit,
-            timeout=self._timeout,
-            user_agent=self._raw_user_agent,
-            session=self._session,
-            headers=new_headers,
-        )
+        return self.clone(headers=new_headers)

--- a/dropbox/exceptions.py
+++ b/dropbox/exceptions.py
@@ -46,6 +46,17 @@ class HttpError(DropboxException):
             self.status_code, self.body)
 
 
+class PathRootError(HttpError):
+    """Error caused by an invalid path root."""
+
+    def __init__(self, request_id, error=None):
+        super(PathRootError, self).__init__(request_id, 422, None)
+        self.error = error
+
+    def __repr__(self):
+        return 'PathRootError({!r}, {!r})'.format(self.request_id, self.error)
+
+
 class BadInputError(HttpError):
     """Errors due to bad input parameters to an API Operation."""
 


### PR DESCRIPTION
2nd attempt at adding helper method support.  Most of this diff was lifted from #102, but with some slight changes to `with_path_root` to support.  