### PR TITLE
fix regression for as_user() and as_admin()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
     - "2.7"
     - pypy
-    - "3.3"
     - "3.4"
     - "3.5"
     - pypy3

--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -596,4 +596,12 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
 
         new_headers = self._headers.copy() if self._headers else {}
         new_headers[select_header_name] = team_member_id
-        return self.clone(headers=new_headers)
+        return Dropbox(
+            self._oauth2_access_token,
+            max_retries_on_error=self._max_retries_on_error,
+            max_retries_on_rate_limit=self._max_retries_on_rate_limit,
+            timeout=self._timeout,
+            user_agent=self._raw_user_agent,
+            session=self._session,
+            headers=new_headers,
+        )

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ dist = setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -144,6 +144,28 @@ class TestDropbox(unittest.TestCase):
             team_member_id = r.members[0].profile.team_member_id
             dbxt.as_user(team_member_id).files_list_folder('')
 
+    @dbx_team_from_env
+    def test_as_user(self, dbxt):
+        dbx_as_user = dbxt.as_user('1')
+        self.assertIsInstance(dbx_as_user, Dropbox)
+
+    @dbx_team_from_env
+    def test_as_admin(self, dbxt):
+        dbx_as_admin = dbxt.as_admin('1')
+        self.assertIsInstance(dbx_as_admin, Dropbox)
+
+    @dbx_from_env
+    def test_clone_when_user_linked(self, dbx):
+        new_dbx = dbx.clone()
+        self.assertIsNot(dbx, new_dbx)
+        self.assertIsInstance(new_dbx, dbx.__class__)
+
+    @dbx_team_from_env
+    def test_clone_when_team_linked(self, dbxt):
+        new_dbxt = dbxt.clone()
+        self.assertIsNot(dbxt, new_dbxt)
+        self.assertIsInstance(new_dbxt, dbxt.__class__)
+
     @dbx_from_env
     def test_with_path_root_constructor(self, dbx):
         # Verify valid mode types

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 
-envlist = py{27,32,33,34,35,36,py,py3},check,lint
+envlist = py{27,34,35,36,py,py3},check,lint
 skip_missing_interpreters = true
 
 [tox:travis]
 
 2.7 = lint
 pypy = lint
-3.3 = lint
 3.4 = lint
 3.5 = lint
 3.6 = check, lint


### PR DESCRIPTION
Fix my regression for `as_user()` and `as_admin()` where they were returning an instance of `DropboxTeam` instead of `Dropbox`. Also added unit tests to not make this mistake in the future.