### PR TITLE
Add route versioning support to transport module of Python SDK

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -249,6 +249,8 @@ class _DropboxTransport(object):
         """
         host = route.attrs['host'] or 'api'
         route_name = namespace + '/' + route.name
+        if route.version > 1:
+            route_name += '_v{}'.format(route.version)
         route_style = route.attrs['style'] or 'rpc'
         serialized_arg = stone_serializers.json_encode(route.arg_type,
                                                        request_arg)

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -196,7 +196,6 @@ class TestDropbox(unittest.TestCase):
     def test_versioned_route(self, dbx):
         # Upload a test file
         path = '/test.txt'
-        test_contents = DUMMY_PAYLOAD
         dbx.files_upload(DUMMY_PAYLOAD, path)
 
         # Delete the file with v2 route

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -32,6 +32,7 @@ from dropbox.exceptions import (
     PathRootError,
 )
 from dropbox.files import (
+    DeleteResult,
     ListFolderError,
 )
 from dropbox.common import (
@@ -190,6 +191,18 @@ class TestDropbox(unittest.TestCase):
         with self.assertRaises(PathRootError) as cm:
             dbxpr.files_list_folder('')
         self.assertTrue(cm.exception.error.is_invalid_root())
+
+    @dbx_from_env
+    def test_versioned_route(self, dbx):
+        # Upload a test file
+        path = '/test.txt'
+        test_contents = DUMMY_PAYLOAD
+        dbx.files_upload(DUMMY_PAYLOAD, path)
+
+        # Delete the file with v2 route
+        resp = dbx.files_delete_v2(path)
+        # Verify response type is of v2 route
+        self.assertIsInstance(resp, DeleteResult)
 
 class TestDropboxTeam(unittest.TestCase):
     @dbx_team_from_env


### PR DESCRIPTION
This made the SDK to properly attach the version number when making API requests to server.