### PR TITLE
Fix 'WSGIRequest' object does not support item assignment error

### DIFF
--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -266,15 +266,15 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
                 "dropbox-auth-csrf-token")
 
         # URL handler for /dropbox-auth-start
-        def dropbox_auth_start(web_app_session, request):
-            authorize_url = get_dropbox_auth_flow(web_app_session).start()
+        def dropbox_auth_start(web_app_session):
+            authorize_url = get_dropbox_auth_flow(web_app_session.session).start()
             redirect_to(authorize_url)
 
         # URL handler for /dropbox-auth-finish
-        def dropbox_auth_finish(web_app_session, request):
+        def dropbox_auth_finish(web_app_session):
             try:
                 oauth_result = \\
-                        get_dropbox_auth_flow(web_app_session).finish(
+                        get_dropbox_auth_flow(web_app_session.session).finish(
                             request.query_params)
             except BadRequestException, e:
                 http_status(400)


### PR DESCRIPTION
- Delete request arguments in functions. It is redundant as the first argument is usually the request object
- Reference the session object on the request (web_app_session.session). This fixes `self.session[self.csrf_token_session_key] = csrf_token` error