### PR TITLE
generate clients with multiple auth modes in stone

### DIFF
--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -250,32 +250,6 @@ class DropboxBase(object):
         )
         return None
 
-    def file_properties_templates_add_for_team(self,
-                                               name,
-                                               description,
-                                               fields):
-        """
-        Add a template associated with a team. See
-        :meth:`file_properties_properties_add` to add properties to a file or
-        folder. Note: this endpoint will create team-owned templates.
-
-        :rtype: :class:`dropbox.file_properties.AddTemplateResult`
-        :raises: :class:`.exceptions.ApiError`
-
-        If this raises, ApiError will contain:
-            :class:`dropbox.file_properties.ModifyTemplateError`
-        """
-        arg = file_properties.AddTemplateArg(name,
-                                             description,
-                                             fields)
-        r = self.request(
-            file_properties.templates_add_for_team,
-            'file_properties',
-            arg,
-            None,
-        )
-        return r
-
     def file_properties_templates_add_for_user(self,
                                                name,
                                                description,
@@ -296,29 +270,6 @@ class DropboxBase(object):
                                              fields)
         r = self.request(
             file_properties.templates_add_for_user,
-            'file_properties',
-            arg,
-            None,
-        )
-        return r
-
-    def file_properties_templates_get_for_team(self,
-                                               template_id):
-        """
-        Get the schema for a specified template.
-
-        :param str template_id: An identifier for template added by route  See
-            :meth:`file_properties_templates_add_for_user` or
-            :meth:`file_properties_templates_add_for_team`.
-        :rtype: :class:`dropbox.file_properties.GetTemplateResult`
-        :raises: :class:`.exceptions.ApiError`
-
-        If this raises, ApiError will contain:
-            :class:`dropbox.file_properties.TemplateError`
-        """
-        arg = file_properties.GetTemplateArg(template_id)
-        r = self.request(
-            file_properties.templates_get_for_team,
             'file_properties',
             arg,
             None,
@@ -349,26 +300,6 @@ class DropboxBase(object):
         )
         return r
 
-    def file_properties_templates_list_for_team(self):
-        """
-        Get the template identifiers for a team. To get the schema of each
-        template use :meth:`file_properties_templates_get_for_team`.
-
-        :rtype: :class:`dropbox.file_properties.ListTemplateResult`
-        :raises: :class:`.exceptions.ApiError`
-
-        If this raises, ApiError will contain:
-            :class:`dropbox.file_properties.TemplateError`
-        """
-        arg = None
-        r = self.request(
-            file_properties.templates_list_for_team,
-            'file_properties',
-            arg,
-            None,
-        )
-        return r
-
     def file_properties_templates_list_for_user(self):
         """
         Get the template identifiers for a team. To get the schema of each
@@ -389,32 +320,6 @@ class DropboxBase(object):
             None,
         )
         return r
-
-    def file_properties_templates_remove_for_team(self,
-                                                  template_id):
-        """
-        Permanently removes the specified template created from
-        :meth:`file_properties_templates_add_for_user`. All properties
-        associated with the template will also be removed. This action cannot be
-        undone.
-
-        :param str template_id: An identifier for a template created by
-            :meth:`file_properties_templates_add_for_user` or
-            :meth:`file_properties_templates_add_for_team`.
-        :rtype: None
-        :raises: :class:`.exceptions.ApiError`
-
-        If this raises, ApiError will contain:
-            :class:`dropbox.file_properties.TemplateError`
-        """
-        arg = file_properties.RemoveTemplateArg(template_id)
-        r = self.request(
-            file_properties.templates_remove_for_team,
-            'file_properties',
-            arg,
-            None,
-        )
-        return None
 
     def file_properties_templates_remove_for_user(self,
                                                   template_id):
@@ -441,44 +346,6 @@ class DropboxBase(object):
             None,
         )
         return None
-
-    def file_properties_templates_update_for_team(self,
-                                                  template_id,
-                                                  name=None,
-                                                  description=None,
-                                                  add_fields=None):
-        """
-        Update a template associated with a team. This route can update the
-        template name, the template description and add optional properties to
-        templates.
-
-        :param str template_id: An identifier for template added by  See
-            :meth:`file_properties_templates_add_for_user` or
-            :meth:`file_properties_templates_add_for_team`.
-        :param Nullable name: A display name for the template. template names
-            can be up to 256 bytes.
-        :param Nullable description: Description for the new template. Template
-            descriptions can be up to 1024 bytes.
-        :param Nullable add_fields: Property field templates to be added to the
-            group template. There can be up to 32 properties in a single
-            template.
-        :rtype: :class:`dropbox.file_properties.UpdateTemplateResult`
-        :raises: :class:`.exceptions.ApiError`
-
-        If this raises, ApiError will contain:
-            :class:`dropbox.file_properties.ModifyTemplateError`
-        """
-        arg = file_properties.UpdateTemplateArg(template_id,
-                                                name,
-                                                description,
-                                                add_fields)
-        r = self.request(
-            file_properties.templates_update_for_team,
-            'file_properties',
-            arg,
-            None,
-        )
-        return r
 
     def file_properties_templates_update_for_user(self,
                                                   template_id,
@@ -4183,6 +4050,12 @@ class DropboxBase(object):
             None,
         )
         return r
+
+    # ------------------------------------------
+    # Routes in team namespace
+
+    # ------------------------------------------
+    # Routes in team_log namespace
 
     # ------------------------------------------
     # Routes in users namespace

--- a/dropbox/base_team.py
+++ b/dropbox/base_team.py
@@ -33,6 +33,157 @@ class DropboxTeamBase(object):
         pass
 
     # ------------------------------------------
+    # Routes in auth namespace
+
+    # ------------------------------------------
+    # Routes in file_properties namespace
+
+    def file_properties_templates_add_for_team(self,
+                                               name,
+                                               description,
+                                               fields):
+        """
+        Add a template associated with a team. See
+        :meth:`file_properties_properties_add` to add properties to a file or
+        folder. Note: this endpoint will create team-owned templates.
+
+        :rtype: :class:`dropbox.file_properties.AddTemplateResult`
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.file_properties.ModifyTemplateError`
+        """
+        arg = file_properties.AddTemplateArg(name,
+                                             description,
+                                             fields)
+        r = self.request(
+            file_properties.templates_add_for_team,
+            'file_properties',
+            arg,
+            None,
+        )
+        return r
+
+    def file_properties_templates_get_for_team(self,
+                                               template_id):
+        """
+        Get the schema for a specified template.
+
+        :param str template_id: An identifier for template added by route  See
+            :meth:`file_properties_templates_add_for_user` or
+            :meth:`file_properties_templates_add_for_team`.
+        :rtype: :class:`dropbox.file_properties.GetTemplateResult`
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.file_properties.TemplateError`
+        """
+        arg = file_properties.GetTemplateArg(template_id)
+        r = self.request(
+            file_properties.templates_get_for_team,
+            'file_properties',
+            arg,
+            None,
+        )
+        return r
+
+    def file_properties_templates_list_for_team(self):
+        """
+        Get the template identifiers for a team. To get the schema of each
+        template use :meth:`file_properties_templates_get_for_team`.
+
+        :rtype: :class:`dropbox.file_properties.ListTemplateResult`
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.file_properties.TemplateError`
+        """
+        arg = None
+        r = self.request(
+            file_properties.templates_list_for_team,
+            'file_properties',
+            arg,
+            None,
+        )
+        return r
+
+    def file_properties_templates_remove_for_team(self,
+                                                  template_id):
+        """
+        Permanently removes the specified template created from
+        :meth:`file_properties_templates_add_for_user`. All properties
+        associated with the template will also be removed. This action cannot be
+        undone.
+
+        :param str template_id: An identifier for a template created by
+            :meth:`file_properties_templates_add_for_user` or
+            :meth:`file_properties_templates_add_for_team`.
+        :rtype: None
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.file_properties.TemplateError`
+        """
+        arg = file_properties.RemoveTemplateArg(template_id)
+        r = self.request(
+            file_properties.templates_remove_for_team,
+            'file_properties',
+            arg,
+            None,
+        )
+        return None
+
+    def file_properties_templates_update_for_team(self,
+                                                  template_id,
+                                                  name=None,
+                                                  description=None,
+                                                  add_fields=None):
+        """
+        Update a template associated with a team. This route can update the
+        template name, the template description and add optional properties to
+        templates.
+
+        :param str template_id: An identifier for template added by  See
+            :meth:`file_properties_templates_add_for_user` or
+            :meth:`file_properties_templates_add_for_team`.
+        :param Nullable name: A display name for the template. template names
+            can be up to 256 bytes.
+        :param Nullable description: Description for the new template. Template
+            descriptions can be up to 1024 bytes.
+        :param Nullable add_fields: Property field templates to be added to the
+            group template. There can be up to 32 properties in a single
+            template.
+        :rtype: :class:`dropbox.file_properties.UpdateTemplateResult`
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.file_properties.ModifyTemplateError`
+        """
+        arg = file_properties.UpdateTemplateArg(template_id,
+                                                name,
+                                                description,
+                                                add_fields)
+        r = self.request(
+            file_properties.templates_update_for_team,
+            'file_properties',
+            arg,
+            None,
+        )
+        return r
+
+    # ------------------------------------------
+    # Routes in file_requests namespace
+
+    # ------------------------------------------
+    # Routes in files namespace
+
+    # ------------------------------------------
+    # Routes in paper namespace
+
+    # ------------------------------------------
+    # Routes in sharing namespace
+
+    # ------------------------------------------
     # Routes in team namespace
 
     def team_devices_list_member_devices(self,
@@ -1750,4 +1901,7 @@ class DropboxTeamBase(object):
             None,
         )
         return r
+
+    # ------------------------------------------
+    # Routes in users namespace
 

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -69,7 +69,7 @@ def main():
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
          specs + ['-a', 'host', '-a', 'style','-a', 'auth'] +
-         ['--', '-w','user,app','-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox']),
+         ['--', '-w','user,app,noauth','-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox']),
         cwd=stone_path)
     if o:
         print('Output:', o)

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -31,14 +31,6 @@ _cmdline_parser.add_argument(
     help='Path to clone of stone repository.',
 )
 
-# List of namespaces for business endpoints
-TEAM_NAMESPACES = [
-    'team',
-    'team_common',
-    'team_log',
-    'team_policies',
-]
-
 def main():
     """The entry point for the program."""
 
@@ -74,24 +66,18 @@ def main():
     if verbose:
         print('Generating Python client')
 
-    blacklist_namespace_args = []
-    for namespace in TEAM_NAMESPACES:
-        blacklist_namespace_args.extend(('-b', namespace))
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
-         specs + ['-a', 'host', '-a', 'style'] + blacklist_namespace_args +
-         ['--', '-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox']),
+         specs + ['-a', 'host', '-a', 'style','-a', 'auth'] +
+         ['--', '-w','user,app','-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox']),
         cwd=stone_path)
     if o:
         print('Output:', o)
 
-    whitelist_namespace_args = []
-    for namespace in TEAM_NAMESPACES:
-        whitelist_namespace_args.extend(('-w', namespace))
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
-         specs + ['-a', 'host', '-a', 'style'] + whitelist_namespace_args +
-         ['--', '-m', 'base_team', '-c', 'DropboxTeamBase', '-t', 'dropbox']),
+         specs + ['-a', 'host', '-a', 'style','-a', 'auth'] +
+         ['--', '-w','team','-m', 'base_team', '-c', 'DropboxTeamBase', '-t', 'dropbox']),
         cwd=stone_path)
     if o:
         print('Output:', o)


### PR DESCRIPTION
Note that the previous python SDK client generation logic had a flaw because it was putting 5 team API end points ( that need auth_type='team' as declared in file_properties.stone stone spec) erroneously in the dropbox/base.py instead of dropbox/dropbox_team.py. This was never supposed to work.

With this new enhancement, we are checking by the 'auth' route attr in stone spec and putting them in base_team.py. The stone spec files now support comma separated auth modes like "user,app" or "user,team,app" etc.