### PR TITLE
bump six requirement to >=1.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
     'requests >= 2.16.2',
-    'six >= 1.3.0',
+    'six >= 1.12.0',
 ]
 
 setup_requires = [


### PR DESCRIPTION
Dropbox uses some methods such as `six.ensure_str` which have been only added in 1.12.0, see https://github.com/benjaminp/six/blob/master/CHANGES.