### PR TITLE
Add Support for Scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ __pycache__/
 *.pyo
 *~
 .venv
+venv/
+venv3/

--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -141,12 +141,11 @@ class _DropboxTransport(object):
                  oauth2_refresh_token=None,
                  oauth2_access_token_expiration=None,
                  app_key=None,
-                 app_secret=None):
+                 app_secret=None,
+                 default_scope_list=None,):
         """
         :param str oauth2_access_token: OAuth2 access token for making client
             requests.
-        :param str oauth2_refresh_token: OAuth2 refresh token for refreshing access token
-        :param datetime oauth2_access_token_expiration: Expiration for oauth2_access_token
         :param int max_retries_on_error: On 5xx errors, the number of times to
             retry.
         :param Optional[int] max_retries_on_rate_limit: On 429 errors, the
@@ -165,6 +164,12 @@ class _DropboxTransport(object):
             server. After the timeout the client will give up on
             connection. If `None`, client will wait forever. Defaults
             to 30 seconds.
+        :param str oauth2_refresh_token: OAuth2 refresh token for refreshing access token
+        :param datetime oauth2_access_token_expiration: Expiration for oauth2_access_token
+        :param str app_key: application key of requesting application; used for token refresh
+        :param str app_secret: application secret of requesting application; used for token refresh
+        :param list default_scope_list: list of scopes to request on refresh.  If left blank,
+            refresh will request all available scopes for application
         """
 
         assert oauth2_access_token or oauth2_refresh_token, \
@@ -177,12 +182,17 @@ class _DropboxTransport(object):
             assert app_key and app_secret, \
                 "app_key and app_secret are required to refresh tokens"
 
+        if default_scope_list is not None:
+            assert isinstance(default_scope_list, list), \
+                "Scope list must be of type list"
+
         self._oauth2_access_token = oauth2_access_token
         self._oauth2_refresh_token = oauth2_refresh_token
         self._oauth2_access_token_expiration = oauth2_access_token_expiration
 
         self._app_key = app_key
         self._app_secret = app_secret
+        self._default_scope_list = default_scope_list
 
         self._max_retries_on_error = max_retries_on_error
         self._max_retries_on_rate_limit = max_retries_on_rate_limit
@@ -222,7 +232,8 @@ class _DropboxTransport(object):
             oauth2_refresh_token=None,
             oauth2_access_token_expiration=None,
             app_key=None,
-            app_secret=None):
+            app_secret=None,
+            default_scope_list=None):
         """
         Creates a new copy of the Dropbox client with the same defaults unless modified by
         arguments to clone()
@@ -245,6 +256,7 @@ class _DropboxTransport(object):
             oauth2_access_token_expiration or self._oauth2_access_token_expiration,
             app_key or self._app_key,
             app_secret or self._app_secret,
+            default_scope_list or self._default_scope_list
         )
 
     def request(self,
@@ -332,7 +344,6 @@ class _DropboxTransport(object):
     def check_and_refresh_access_token(self):
         """
         Checks if access token needs to be refreshed and refreshes if possible
-
         :return:
         """
         can_refresh = self._oauth2_refresh_token and self._app_key and self._app_secret
@@ -341,14 +352,20 @@ class _DropboxTransport(object):
             self._oauth2_access_token_expiration
         needs_token = not self._oauth2_access_token
         if (needs_refresh or needs_token) and can_refresh:
-            self.refresh_access_token()
+            self.refresh_access_token(scope_list=self._default_scope_list)
 
-    def refresh_access_token(self, host=API_HOST):
+    def refresh_access_token(self, host=API_HOST, scope_list=None):
         """
         Refreshes an access token via refresh token if available
 
+        :param host: host to hit token endpoint with
+        :param scope_list: list of permission scopes for access token
         :return:
         """
+
+        if scope_list is not None:
+            assert isinstance(scope_list, list), \
+                "Scope list must be of type list"
 
         if not (self._oauth2_refresh_token and self._app_key and self._app_secret):
             self._logger.warning('Unable to refresh access token without \
@@ -362,6 +379,9 @@ class _DropboxTransport(object):
                 'client_id': self._app_key,
                 'client_secret': self._app_secret,
                 }
+        if scope_list:
+            scope = " ".join(scope_list)
+            body['scope'] = scope
 
         res = self._session.post(url, data=body)
         if res.status_code == 400 and res.json()['error'] == 'invalid_grant':

--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -142,7 +142,7 @@ class _DropboxTransport(object):
                  oauth2_access_token_expiration=None,
                  app_key=None,
                  app_secret=None,
-                 default_scope_list=None,):
+                 scope=None,):
         """
         :param str oauth2_access_token: OAuth2 access token for making client
             requests.
@@ -168,7 +168,7 @@ class _DropboxTransport(object):
         :param datetime oauth2_access_token_expiration: Expiration for oauth2_access_token
         :param str app_key: application key of requesting application; used for token refresh
         :param str app_secret: application secret of requesting application; used for token refresh
-        :param list default_scope_list: list of scopes to request on refresh.  If left blank,
+        :param list scope: list of scopes to request on refresh.  If left blank,
             refresh will request all available scopes for application
         """
 
@@ -182,8 +182,8 @@ class _DropboxTransport(object):
             assert app_key and app_secret, \
                 "app_key and app_secret are required to refresh tokens"
 
-        if default_scope_list is not None:
-            assert isinstance(default_scope_list, list), \
+        if scope is not None:
+            assert not scope or isinstance(scope, list), \
                 "Scope list must be of type list"
 
         self._oauth2_access_token = oauth2_access_token
@@ -192,7 +192,7 @@ class _DropboxTransport(object):
 
         self._app_key = app_key
         self._app_secret = app_secret
-        self._default_scope_list = default_scope_list
+        self._scope = scope
 
         self._max_retries_on_error = max_retries_on_error
         self._max_retries_on_rate_limit = max_retries_on_rate_limit
@@ -233,7 +233,7 @@ class _DropboxTransport(object):
             oauth2_access_token_expiration=None,
             app_key=None,
             app_secret=None,
-            default_scope_list=None):
+            scope=None):
         """
         Creates a new copy of the Dropbox client with the same defaults unless modified by
         arguments to clone()
@@ -256,7 +256,7 @@ class _DropboxTransport(object):
             oauth2_access_token_expiration or self._oauth2_access_token_expiration,
             app_key or self._app_key,
             app_secret or self._app_secret,
-            default_scope_list or self._default_scope_list
+            scope or self._scope
         )
 
     def request(self,
@@ -352,19 +352,19 @@ class _DropboxTransport(object):
             self._oauth2_access_token_expiration
         needs_token = not self._oauth2_access_token
         if (needs_refresh or needs_token) and can_refresh:
-            self.refresh_access_token(scope_list=self._default_scope_list)
+            self.refresh_access_token(scope=self._scope)
 
-    def refresh_access_token(self, host=API_HOST, scope_list=None):
+    def refresh_access_token(self, host=API_HOST, scope=None):
         """
         Refreshes an access token via refresh token if available
 
         :param host: host to hit token endpoint with
-        :param scope_list: list of permission scopes for access token
+        :param scope: list of permission scopes for access token
         :return:
         """
 
-        if scope_list is not None:
-            assert isinstance(scope_list, list), \
+        if scope is not None:
+            assert not scope or isinstance(scope, list), \
                 "Scope list must be of type list"
 
         if not (self._oauth2_refresh_token and self._app_key and self._app_secret):
@@ -379,8 +379,8 @@ class _DropboxTransport(object):
                 'client_id': self._app_key,
                 'client_secret': self._app_secret,
                 }
-        if scope_list:
-            scope = " ".join(scope_list)
+        if scope:
+            scope = " ".join(scope)
             body['scope'] = scope
 
         res = self._session.post(url, data=body)

--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -183,7 +183,7 @@ class _DropboxTransport(object):
                 "app_key and app_secret are required to refresh tokens"
 
         if scope is not None:
-            assert not scope or isinstance(scope, list), \
+            assert len(scope) > 0 and isinstance(scope, list), \
                 "Scope list must be of type list"
 
         self._oauth2_access_token = oauth2_access_token
@@ -364,7 +364,7 @@ class _DropboxTransport(object):
         """
 
         if scope is not None:
-            assert not scope or isinstance(scope, list), \
+            assert len(scope) > 0 and isinstance(scope, list), \
                 "Scope list must be of type list"
 
         if not (self._oauth2_refresh_token and self._app_key and self._app_secret):

--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -123,7 +123,7 @@ class DropboxOAuth2FlowBase(object):
     def __init__(self, consumer_key, consumer_secret, locale=None, token_access_type='legacy',
                  scope=None, include_granted_scopes=None):
         if scope is not None:
-            assert not scope or isinstance(scope, list), \
+            assert len(scope) > 0 and isinstance(scope, list), \
                 "Scope list must be of type list"
 
         self.consumer_key = consumer_key

--- a/example/commandline-oauth.py
+++ b/example/commandline-oauth.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import dropbox
+from dropbox import DropboxOAuth2FlowNoRedirect
+
+APP_KEY = ""
+APP_SECRET = ""
+
+auth_flow = DropboxOAuth2FlowNoRedirect(APP_KEY, APP_SECRET, scope_list=['files.metadata.read'],
+                                        token_access_type='offline')
+
+authorize_url = auth_flow.start()
+print("1. Go to: " + authorize_url)
+print("2. Click \"Allow\" (you might have to log in first).")
+print("3. Copy the authorization code.")
+auth_code = input("Enter the authorization code here: ").strip()
+
+try:
+    oauth_result = auth_flow.finish(auth_code)
+    print(oauth_result)
+except Exception as e:
+    print('Error: %s' % (e,))
+
+dbx = dropbox.Dropbox(oauth2_refresh_token=oauth_result.refresh_token,
+                      app_key=APP_KEY, app_secret=APP_SECRET)
+dbx.users_get_current_account()

--- a/example/commandline-oauth.py
+++ b/example/commandline-oauth.py
@@ -6,8 +6,7 @@ from dropbox import DropboxOAuth2FlowNoRedirect
 APP_KEY = ""
 APP_SECRET = ""
 
-auth_flow = DropboxOAuth2FlowNoRedirect(APP_KEY, APP_SECRET, scope_list=['files.metadata.read'],
-                                        token_access_type='offline')
+auth_flow = DropboxOAuth2FlowNoRedirect(APP_KEY, APP_SECRET)
 
 authorize_url = auth_flow.start()
 print("1. Go to: " + authorize_url)
@@ -21,6 +20,6 @@ try:
 except Exception as e:
     print('Error: %s' % (e,))
 
-dbx = dropbox.Dropbox(oauth2_refresh_token=oauth_result.refresh_token,
+dbx = dropbox.Dropbox(oauth2_access_token=oauth_result.access_token,
                       app_key=APP_KEY, app_secret=APP_SECRET)
 dbx.users_get_current_account()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,3 @@
+pytest
 mock
 pytest-mock

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -120,6 +120,14 @@ class TestDropbox(unittest.TestCase):
     def test_refresh(self, dbx):
         dbx.users_get_current_account()
 
+    @refresh_dbx_from_env
+    def test_downscope(self, dbx):
+        dbx.users_get_current_account()
+        dbx.refresh_access_token(scope_list=['files.metadata.read'])
+        with self.assertRaises(AuthError):
+            # Should fail because downscoped to not include needed scope
+            dbx.users_get_current_account()
+
     @dbx_from_env
     def test_rpc(self, dbx):
         dbx.files_list_folder('')

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -123,7 +123,7 @@ class TestDropbox(unittest.TestCase):
     @refresh_dbx_from_env
     def test_downscope(self, dbx):
         dbx.users_get_current_account()
-        dbx.refresh_access_token(scope_list=['files.metadata.read'])
+        dbx.refresh_access_token(scope=['files.metadata.read'])
         with self.assertRaises(AuthError):
             # Should fail because downscoped to not include needed scope
             dbx.users_get_current_account()

--- a/test/test_dropbox_unit.py
+++ b/test/test_dropbox_unit.py
@@ -7,7 +7,7 @@ import pytest
 # Tests OAuth Flow
 from dropbox import DropboxOAuth2Flow, session, Dropbox, create_session
 from dropbox.exceptions import AuthError
-from dropbox.oauth import OAuth2FlowNoRedirectResult
+from dropbox.oauth import OAuth2FlowNoRedirectResult, DropboxOAuth2FlowNoRedirect
 from datetime import datetime, timedelta
 
 APP_KEY = 'dummy_app_key'
@@ -17,7 +17,7 @@ REFRESH_TOKEN = 'dummy_refresh_token'
 EXPIRES_IN = 14400
 ACCOUNT_ID = 'dummy_account_id'
 USER_ID = 'dummy_user_id'
-SCOPE_LIST = 'files.metadata'
+SCOPE_LIST = ['files.metadata.read', 'files.metadata.write']
 EXPIRATION = datetime.utcnow() + timedelta(seconds=EXPIRES_IN)
 
 EXPIRATION_BUFFER = timedelta(minutes=5)
@@ -106,7 +106,7 @@ class TestOAuth:
         assert abs(result_obj.expires_at - EXPIRATION) < EXPIRATION_BUFFER
         assert result_obj.account_id == ACCOUNT_ID
         assert result_obj.user_id == USER_ID
-        assert result_obj.scope_list == SCOPE_LIST
+        assert result_obj.scope == SCOPE_LIST
 
     def test_OAuth2FlowNoRedirectResult_online(self):
         # Test online result
@@ -121,6 +121,46 @@ class TestOAuth:
         result_obj = OAuth2FlowNoRedirectResult(ACCESS_TOKEN, ACCOUNT_ID, USER_ID,
                                                 REFRESH_TOKEN, EXPIRATION, SCOPE_LIST)
         assert result_obj.expires_at == EXPIRATION
+
+    @pytest.fixture(scope='function')
+    def auth_flow_offline_with_scopes(self, mocker):
+        auth_flow = DropboxOAuth2FlowNoRedirect(APP_KEY, APP_SECRET, token_access_type='offline',
+                                                scope=SCOPE_LIST)
+        session = mock.MagicMock()
+        post_response = mock.MagicMock(status_code=200)
+        post_response.json.return_value = {"access_token": ACCESS_TOKEN, "refresh_token":
+            REFRESH_TOKEN, "expires_in": EXPIRES_IN, "uid": USER_ID, "account_id": ACCOUNT_ID,
+                                           "scope": " ".join(SCOPE_LIST)}
+        mocker.patch.object(session, 'post', return_value=post_response)
+        auth_flow.requests_session = session
+        return auth_flow
+
+    def test_NoRedirect_whole_flow(self, auth_flow_offline_with_scopes):
+        authorization_url = auth_flow_offline_with_scopes.start()
+
+        assert authorization_url.startswith('https://{}/oauth2/authorize?'
+                                            .format(session.WEB_HOST))
+        assert 'client_id={}'.format(APP_KEY) in authorization_url
+        assert 'response_type=code' in authorization_url
+        mycode = 'test oauth code'
+        auth_result = auth_flow_offline_with_scopes.finish(mycode)
+        assert auth_result.access_token == ACCESS_TOKEN
+        assert auth_result.refresh_token == REFRESH_TOKEN
+        assert abs(auth_result.expires_at - EXPIRATION) < EXPIRATION_BUFFER
+        assert auth_result.user_id == USER_ID
+        assert auth_result.account_id == ACCOUNT_ID
+        assert auth_result.scope == " ".join(SCOPE_LIST)
+
+        auth_flow_offline_with_scopes.requests_session.post.assert_called_once()
+        token_call_args = auth_flow_offline_with_scopes.requests_session.post.call_args_list
+        assert len(token_call_args) == 1
+        first_call_args = token_call_args[0]._get_call_arguments()
+        assert first_call_args[0][0] == 'https://{}/oauth2/token'.format(session.API_HOST)
+        call_data = first_call_args[1]['data']
+        assert call_data['client_id'] == APP_KEY
+        assert call_data['grant_type'] == 'authorization_code'
+        assert call_data['client_secret'] == APP_SECRET
+        assert call_data['code'] == mycode
 
 class TestClient:
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,14 +23,19 @@ max-line-length = 100
 [testenv]
 
 commands =
-    python setup.py test {posargs}
+    pytest {posargs}
 
 passenv =
+    DROPBOX_REFRESH_TOKEN
+    DROPBOX_APP_KEY
+    DROPBOX_APP_SECRET
     DROPBOX_DOMAIN
     DROPBOX_TEAM_TOKEN
     DROPBOX_TOKEN
     DROPBOX_WEB_HOST
 
+deps =
+    -rtest/requirements.txt
 
 [testenv:check]
 


### PR DESCRIPTION
- Add option for requesting specific scopes and including already granted scopes in pauth flow
- Add support for default scope list in Dropbox client
- Add support for requesting specific scopes on token refresh
- Update oauth command line documentation to work with python3
- Update tox.ini to run pytest instead of outdated python setup.py test
- Add venv to .gitignore