### PR TITLE
Make with_path_root() update existing headers rather than overwrite them

### DIFF
--- a/dropbox/dropbox.py
+++ b/dropbox/dropbox.py
@@ -53,6 +53,10 @@ PATH_ROOT_HEADER = 'Dropbox-API-Path-Root'
 HTTP_STATUS_INVALID_PATH_ROOT = 422
 TOKEN_EXPIRATION_BUFFER = 300
 
+SELECT_ADMIN_HEADER = 'Dropbox-API-Select-Admin'
+
+SELECT_USER_HEADER = 'Dropbox-API-Select-User'
+
 class RouteResult(object):
     """The successful result of a call to a route."""
 
@@ -652,10 +656,11 @@ class _DropboxTransport(object):
         if not isinstance(path_root, PathRoot):
             raise ValueError("path_root must be an instance of PathRoot")
 
+        new_headers = self._headers.copy() if self._headers else {}
+        new_headers[PATH_ROOT_HEADER] = stone_serializers.json_encode(PathRoot_validator, path_root)
+
         return self.clone(
-            headers={
-                PATH_ROOT_HEADER: stone_serializers.json_encode(PathRoot_validator, path_root)
-            }
+            headers=new_headers
         )
 
 class Dropbox(_DropboxTransport, DropboxBase):
@@ -682,7 +687,7 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
             of this admin of the team.
         :rtype: Dropbox
         """
-        return self._get_dropbox_client_with_select_header('Dropbox-API-Select-Admin',
+        return self._get_dropbox_client_with_select_header(SELECT_ADMIN_HEADER,
                                                            team_member_id)
 
     def as_user(self, team_member_id):
@@ -695,7 +700,7 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
             of this member of the team.
         :rtype: Dropbox
         """
-        return self._get_dropbox_client_with_select_header('Dropbox-API-Select-User',
+        return self._get_dropbox_client_with_select_header(SELECT_USER_HEADER,
                                                            team_member_id)
 
     def _get_dropbox_client_with_select_header(self, select_header_name, team_member_id):

--- a/test/test_dropbox.py
+++ b/test/test_dropbox.py
@@ -24,7 +24,7 @@ from dropbox import (
     session,
     stone_serializers,
 )
-from dropbox.dropbox import PATH_ROOT_HEADER
+from dropbox.dropbox import PATH_ROOT_HEADER, SELECT_USER_HEADER
 from dropbox.exceptions import (
     ApiError,
     AuthError,
@@ -239,7 +239,15 @@ class TestDropboxTeam(unittest.TestCase):
     @dbx_team_from_env
     def test_as_user(self, dbxt):
         dbx_as_user = dbxt.as_user('1')
-        self.assertIsInstance(dbx_as_user, Dropbox)
+        path_root = PathRoot.root("123")
+
+        dbx_new = dbx_as_user.with_path_root(path_root)
+
+        self.assertIsInstance(dbx_new, Dropbox)
+        self.assertEqual(dbx_new._headers.get(SELECT_USER_HEADER), '1')
+
+        expected = stone_serializers.json_encode(PathRoot_validator, path_root)
+        self.assertEqual(dbx_new._headers.get(PATH_ROOT_HEADER), expected)
 
     @dbx_team_from_env
     def test_as_admin(self, dbxt):


### PR DESCRIPTION
When using the Python SDK with a team-based access token and accessing a user's root namespace you would typically perform the following steps:

team_dbx = dropbox.DropboxTeam("access token")
user_dbx = team_dbx.as_user("member id")
# get root namespace via get_current_account()
user_with_path_root_dbx = user_dbx.with_path_root(PathRoot.root("root ns"))

user_with_path_root_dbx.files_list_folder(path="")
...
When doing this, the Select-User header is overwritten inside with_path_root().

Headers before call to with_path_root():

{'Dropbox-API-Select-User': 'dbmid:AACJlzwHrjpPqqnHys__AnsTo9CLNUou6Ek'}
Headers after calling with_path_root():

{'Dropbox-API-Path-Root': '{".tag": "root", "root": "1337955185"}'}
Headers we want after calling with_path_root():

{'Dropbox-API-Path-Root': '{".tag": "root", "root": "1337955185"}', 'Dropbox-API-Select-User': 'dbmid:AACJlzwHrjpPqqnHys__AnsTo9CLNUou6Ek'}
with_path_root() should modify the headers rather than overwriting them.