### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ token for your own Dropbox account for development.  You can also find a variety
 
 `example/oauth <http://github.com/dropbox/dropbox-sdk-python/tree/master/example/oauth/>`_
 
-You can also view our OAuth `guide <https://www.dropbox.com/lp/developers/reference/oauth-guide.html>`_
+You can also view our OAuth `guide <https://www.dropbox.com/lp/developers/reference/oauth-guide>`_
 
 Example Applications
 --------------------


### PR DESCRIPTION
The current OAuth link includes .html which throws a 404. This update to #202 deletes the .html according to the link provided at https://www.dropbox.com/developers/reference