### PR TITLE
Fix lists introduced in #226

### DIFF
--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -296,16 +296,20 @@ class DropboxOAuth2FlowNoRedirect(DropboxOAuth2FlowBase):
             By default, the server uses "en_US".
         :param str token_access_type: the type of token to be requested.
             From the following enum:
+
             * legacy - creates one long-lived token with no expiration
             * online - create one short-lived token with an expiration
             * offline - create one short-lived token with an expiration with a refresh token
+
         :param list scope: list of scopes to request in base oauth flow.  If left blank,
             will default to all scopes for app.
         :param str include_granted_scopes: which scopes to include from previous grants
             From the following enum:
+
             * user - include user scopes in the grant
             * team - include team scopes in the grant
             * Note: if this user has never linked the app, include_granted_scopes must be None
+
         :param bool use_pkce: Whether or not to use Sha256 based PKCE. PKCE should be only use on
             client apps which doesn't call your server. It is less secure than non-PKCE flow but
             can be used if you are unable to safely retrieve your app secret.
@@ -390,16 +394,20 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
             By default, the server uses "en_US".
         :param str token_access_type: the type of token to be requested.
             From the following enum:
+
             * legacy - creates one long-lived token with no expiration
             * online - create one short-lived token with an expiration
             * offline - create one short-lived token with an expiration with a refresh token
+
         :param list scope: list of scopes to request in base oauth flow.  If left blank,
             will default to all scopes for app.
         :param str include_granted_scopes: which scopes to include from previous grants
             From the following enum:
+
             * user - include user scopes in the grant
             * team - include team scopes in the grant
-            Note: if this user has never linked the app, include_granted_scopes must be None
+            * Note: if this user has never linked the app, include_granted_scopes must be None
+
         :param bool use_pkce: Whether or not to use Sha256 based PKCE
         :param Optional[float] timeout: Maximum duration in seconds that
             client will wait for any single packet from the


### PR DESCRIPTION
A list needs to have a linebreak before and after in order to be correctly rendered by readthedocs.

I had already mentioned that as a suspicion in #226 but could only confirm it after merging. This should fix it but I would still suggest that someone at DropBox has a look at this and decides if it's the correct formatting. @greg-db  