### PR TITLE
Changed :type: to :class: in dropbox.file_properties

### DIFF
--- a/dropbox/file_properties.py
+++ b/dropbox/file_properties.py
@@ -8,11 +8,11 @@ This namespace contains helpers for property and template metadata endpoints.
 
 These endpoints enable you to tag arbitrary key/value data to Dropbox files.
 
-The most basic unit in this namespace is the :type:`PropertyField`. These fields encapsulate the actual key/value data.
+The most basic unit in this namespace is the :class:`PropertyField`. These fields encapsulate the actual key/value data.
 
-Fields are added to a Dropbox file using a :type:`PropertyGroup`. Property groups contain a reference to a Dropbox file and a :type:`PropertyGroupTemplate`. Property groups are uniquely identified by the combination of their associated Dropbox file and template.
+Fields are added to a Dropbox file using a :class:`PropertyGroup`. Property groups contain a reference to a Dropbox file and a :class:`PropertyGroupTemplate`. Property groups are uniquely identified by the combination of their associated Dropbox file and template.
 
-The :type:`PropertyGroupTemplate` is a way of restricting the possible key names and value types of the data within a property group. The possible key names and value types are explicitly enumerated using :type:`PropertyFieldTemplate` objects.
+The :class:`PropertyGroupTemplate` is a way of restricting the possible key names and value types of the data within a property group. The possible key names and value types are explicitly enumerated using :class:`PropertyFieldTemplate` objects.
 
 You can think of a property group template as a class definition for a particular key/value metadata object, and the property groups themselves as the instantiations of these objects.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

Changed :type: to :class:, which gets correctly rendered by readthedocs. 

**Before:**
<img width="713" alt="Screenshot 2020-09-27 at 19 49 46" src="https://user-images.githubusercontent.com/10774221/94371977-a4b3c180-00fa-11eb-9839-ac2f15ca9d07.png">

**After:**
<img width="823" alt="Screenshot 2020-09-27 at 19 49 22" src="https://user-images.githubusercontent.com/10774221/94371981-ab423900-00fa-11eb-81a6-a97f740bfaa4.png">


## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `tox` pass?
- [x] Do the tests pass?