### PR TITLE
Add ca_certs argument for oauth and dropbox client

### DIFF
--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -97,7 +97,7 @@ class RouteErrorResult(object):
         self.request_id = request_id
         self.obj_result = obj_result
 
-def create_session(max_connections=8, proxies=None):
+def create_session(max_connections=8, proxies=None, ca_certs=None):
     """
     Creates a session object that can be used by multiple :class:`Dropbox` and
     :class:`DropboxTeam` instances. This lets you share a connection pool
@@ -112,7 +112,7 @@ def create_session(max_connections=8, proxies=None):
         for more details.
     """
     # We only need as many pool_connections as we have unique hostnames.
-    session = pinned_session(pool_maxsize=max_connections)
+    session = pinned_session(pool_maxsize=max_connections, ca_certs=ca_certs)
     if proxies:
         session.proxies = proxies
     return session
@@ -151,7 +151,8 @@ class _DropboxTransport(object):
                  oauth2_access_token_expiration=None,
                  app_key=None,
                  app_secret=None,
-                 scope=None,):
+                 scope=None,
+                 ca_certs=None):
         """
         :param str oauth2_access_token: OAuth2 access token for making client
             requests.
@@ -180,6 +181,8 @@ class _DropboxTransport(object):
             Not required if PKCE was used to authorize the token
         :param list scope: list of scopes to request on refresh.  If left blank,
             refresh will request all available scopes for application
+        :param str ca_certs: path to CA certificate. If left blank, default certificate location \
+            will be used
         """
 
         if not (oauth2_access_token or oauth2_refresh_token or (app_key and app_secret)):
@@ -212,7 +215,7 @@ class _DropboxTransport(object):
                                         .format(session))
             self._session = session
         else:
-            self._session = create_session()
+            self._session = create_session(ca_certs=ca_certs)
         self._headers = headers
 
         base_user_agent = 'OfficialDropboxPythonSDKv2/' + __version__

--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -119,7 +119,8 @@ class OAuth2FlowResult(OAuth2FlowNoRedirectResult):
 class DropboxOAuth2FlowBase(object):
 
     def __init__(self, consumer_key, consumer_secret=None, locale=None, token_access_type=None,
-                 scope=None, include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT):
+                 scope=None, include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT,
+                 ca_certs=None):
         if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
             raise BadInputException("Scope list must be of type list")
         if token_access_type is not None and token_access_type not in TOKEN_ACCESS_TYPES:
@@ -134,7 +135,7 @@ class DropboxOAuth2FlowBase(object):
         self.consumer_secret = consumer_secret
         self.locale = locale
         self.token_access_type = token_access_type
-        self.requests_session = pinned_session()
+        self.requests_session = pinned_session(ca_certs=ca_certs)
         self.scope = scope
         self.include_granted_scopes = include_granted_scopes
         self._timeout = timeout
@@ -273,7 +274,8 @@ class DropboxOAuth2FlowNoRedirect(DropboxOAuth2FlowBase):
     """
 
     def __init__(self, consumer_key, consumer_secret=None, locale=None, token_access_type=None,
-                 scope=None, include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT):  # noqa: E501;
+                 scope=None, include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT,
+                 ca_certs=None):  # noqa: E501;
         """
         Construct an instance.
 
@@ -306,6 +308,8 @@ class DropboxOAuth2FlowNoRedirect(DropboxOAuth2FlowBase):
             client will wait for any single packet from the server. After the timeout the client
             will give up on connection. If `None`, client will wait forever. Defaults
             to 100 seconds.
+        :param str ca_cert: path to CA certificate. If left blank, default certificate location \
+            will be used
         """
         super(DropboxOAuth2FlowNoRedirect, self).__init__(
             consumer_key=consumer_key,
@@ -315,7 +319,8 @@ class DropboxOAuth2FlowNoRedirect(DropboxOAuth2FlowBase):
             scope=scope,
             include_granted_scopes=include_granted_scopes,
             use_pkce=use_pkce,
-            timeout=timeout
+            timeout=timeout,
+            ca_certs=ca_certs
         )
 
     def start(self):
@@ -360,7 +365,8 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
     def __init__(self, consumer_key, redirect_uri, session,
                  csrf_token_session_key, consumer_secret=None, locale=None,
                  token_access_type=None, scope=None,
-                 include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT):
+                 include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT,
+                 ca_certs=None):
         """
         Construct an instance.
 
@@ -399,6 +405,8 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
         :param Optional[float] timeout: Maximum duration in seconds that client will wait for any
             single packet from the server. After the timeout the client will give up on connection.
             If `None`, client will wait forever. Defaults to 100 seconds.
+        :param str ca_cert: path to CA certificate. If left blank, default certificate location \
+            will be used
         """
 
         super(DropboxOAuth2Flow, self).__init__(
@@ -409,7 +417,8 @@ class DropboxOAuth2Flow(DropboxOAuth2FlowBase):
             scope=scope,
             include_granted_scopes=include_granted_scopes,
             use_pkce=use_pkce,
-            timeout=timeout
+            timeout=timeout,
+            ca_certs=ca_certs
         )
         self.redirect_uri = redirect_uri
         self.session = session

--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -45,7 +45,7 @@ class _SSLAdapter(HTTPAdapter):
     def __init__(self, *args, **kwargs):
         self._ca_certs = kwargs.pop("ca_certs", None) or _TRUSTED_CERT_FILE
         if not self._ca_certs:
-            raise FileNotFoundError("CA certificate not found")
+            raise AttributeError("CA certificate not set")
         super(_SSLAdapter, self).__init__(*args, **kwargs)
 
     def init_poolmanager(self, connections, maxsize, block=False, **_):

--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -32,22 +32,33 @@ WEB_HOST = os.environ.get('DROPBOX_WEB_HOST', HOST_WWW + WEB_DOMAIN)
 # This is the default longest time we'll block on receiving data from the server
 DEFAULT_TIMEOUT = 100
 
-_TRUSTED_CERT_FILE = pkg_resources.resource_filename(__name__, 'trusted-certs.crt')
+try:
+    _TRUSTED_CERT_FILE = pkg_resources.resource_filename(__name__, 'trusted-certs.crt')
+except NotImplementedError:  # Package is used inside python archive
+    _TRUSTED_CERT_FILE = None
+
 
 # TODO(kelkabany): We probably only want to instantiate this once so that even
 # if multiple Dropbox objects are instantiated, they all share the same pool.
 class _SSLAdapter(HTTPAdapter):
+
+    def __init__(self, *args, **kwargs):
+        self._ca_certs = kwargs.pop("ca_certs", None) or _TRUSTED_CERT_FILE
+        if not self._ca_certs:
+            raise FileNotFoundError("CA certificate not found")
+        super(_SSLAdapter, self).__init__(*args, **kwargs)
+
     def init_poolmanager(self, connections, maxsize, block=False, **_):
         self.poolmanager = PoolManager(
             num_pools=connections,
             maxsize=maxsize,
             block=block,
             cert_reqs=ssl.CERT_REQUIRED,
-            ca_certs=_TRUSTED_CERT_FILE,
+            ca_certs=self._ca_certs,
         )
 
-def pinned_session(pool_maxsize=8):
-    http_adapter = _SSLAdapter(pool_connections=4, pool_maxsize=pool_maxsize)
+def pinned_session(pool_maxsize=8, ca_certs=None):
+    http_adapter = _SSLAdapter(pool_connections=4, pool_maxsize=pool_maxsize, ca_certs=ca_certs)
     _session = requests.session()
     _session.mount('https://', http_adapter)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
This change adds ca_certs str argument for oauth and dropbox client classes. It may be used  with applications that packed into executable archives (like python par or py2exe). It also may be useful with some security related scenarios.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [x] Example/Test Code Change

**Validation**
- [x] Does `tox` pass?
- [x] Do the tests pass? (no integration tests)