### PR TITLE
Ensure Dropbox error is thrown in refresh access token

### DIFF
--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -591,7 +591,7 @@ class _DropboxTransport(object):
                                timeout=timeout,
                                )
         self.raise_dropbox_error_for_resp(r)
-        request_id = res.headers.get('x-dropbox-request-id')
+        request_id = r.headers.get('x-dropbox-request-id')
         if r.status_code in (403, 404, 409):
             raw_resp = r.content.decode('utf-8')
             return RouteErrorResult(request_id, raw_resp)

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -617,7 +617,9 @@ class _DropboxTransport(object):
         if res.status_code >= 500:
             raise InternalServerError(request_id, res.status_code, res.text)
         elif res.status_code == 400:
-            if res.json()['error'] == 'invalid_grant':
+            error = stone_serializers.json_compat_obj_decode(
+                AuthError_validator, res.json()['error'])
+            if error == 'invalid_grant':
                 request_id = res.headers.get('x-dropbox-request-id')
                 err = stone_serializers.json_compat_obj_decode(
                     AuthError_validator, 'invalid_access_token')

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -625,7 +625,7 @@ class _DropboxTransport(object):
                     raise AuthError(request_id, err)
                 else:
                     raise BadInputError(request_id, res.text)
-            except:
+            except ValueError:
                 raise BadInputError(request_id, res.text)
         elif res.status_code == 401:
             assert res.headers.get('content-type') == 'application/json', (

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -376,7 +376,6 @@ class _DropboxTransport(object):
         :param scope: list of permission scopes for access token
         :return:
         """
-
         if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
             raise BadInputException("Scope list must be of type list")
 
@@ -401,12 +400,7 @@ class _DropboxTransport(object):
         if self._timeout:
             timeout = self._timeout
         res = self._session.post(url, data=body, timeout=timeout)
-        if res.status_code == 400 and res.json()['error'] == 'invalid_grant':
-            request_id = res.headers.get('x-dropbox-request-id')
-            err = stone_serializers.json_compat_obj_decode(
-                AuthError_validator, 'invalid_access_token')
-            raise AuthError(request_id, err)
-        res.raise_for_status()
+        self.raise_dropbox_error_for_resp(res)
 
         token_content = res.json()
         self._oauth2_access_token = token_content["access_token"]
@@ -596,53 +590,69 @@ class _DropboxTransport(object):
                                verify=True,
                                timeout=timeout,
                                )
+        self.raise_dropbox_error_for_resp(r)
+        request_id = res.headers.get('x-dropbox-request-id')
+        if r.status_code in (403, 404, 409):
+            raw_resp = r.content.decode('utf-8')
+            return RouteErrorResult(request_id, raw_resp)
 
-        request_id = r.headers.get('x-dropbox-request-id')
-        if r.status_code >= 500:
-            raise InternalServerError(request_id, r.status_code, r.text)
-        elif r.status_code == 400:
-            raise BadInputError(request_id, r.text)
-        elif r.status_code == 401:
+        if route_style == self._ROUTE_STYLE_DOWNLOAD:
+            raw_resp = r.headers['dropbox-api-result']
+        else:
             assert r.headers.get('content-type') == 'application/json', (
                 'Expected content-type to be application/json, got %r' %
                 r.headers.get('content-type'))
-            err = stone_serializers.json_compat_obj_decode(
-                AuthError_validator, r.json()['error'])
-            raise AuthError(request_id, err)
-        elif r.status_code == HTTP_STATUS_INVALID_PATH_ROOT:
-            err = stone_serializers.json_compat_obj_decode(
-                PathRootError_validator, r.json()['error'])
-            raise PathRootError(request_id, err)
-        elif r.status_code == 429:
-            err = None
-            if r.headers.get('content-type') == 'application/json':
+            raw_resp = r.content.decode('utf-8')
+        if route_style == self._ROUTE_STYLE_DOWNLOAD:
+            return RouteResult(raw_resp, r)
+        else:
+            return RouteResult(raw_resp)
+
+    def raise_dropbox_error_for_resp(self, res):
+        """Checks for errors from a res and handles appropiately.
+
+        :param res: Response of an api request.
+        """
+        request_id = res.headers.get('x-dropbox-request-id')
+        if res.status_code >= 500:
+            raise InternalServerError(request_id, res.status_code, res.text)
+        elif res.status_code == 400:
+            if res.json()['error'] == 'invalid_grant':
+                request_id = res.headers.get('x-dropbox-request-id')
                 err = stone_serializers.json_compat_obj_decode(
-                    RateLimitError_validator, r.json()['error'])
+                    AuthError_validator, 'invalid_access_token')
+                raise AuthError(request_id, err)
+            else:
+                raise BadInputError(request_id, res.text)
+        elif res.status_code == 401:
+            assert res.headers.get('content-type') == 'application/json', (
+                'Expected content-type to be application/json, got %r' %
+                res.headers.get('content-type'))
+            err = stone_serializers.json_compat_obj_decode(
+                AuthError_validator, res.json()['error'])
+            raise AuthError(request_id, err)
+        elif res.status_code == HTTP_STATUS_INVALID_PATH_ROOT:
+            err = stone_serializers.json_compat_obj_decode(
+                PathRootError_validator, res.json()['error'])
+            raise PathRootError(request_id, err)
+        elif res.status_code == 429:
+            err = None
+            if res.headers.get('content-type') == 'application/json':
+                err = stone_serializers.json_compat_obj_decode(
+                    RateLimitError_validator, res.json()['error'])
                 retry_after = err.retry_after
             else:
-                retry_after_str = r.headers.get('retry-after')
+                retry_after_str = res.headers.get('retry-after')
                 if retry_after_str is not None:
                     retry_after = int(retry_after_str)
                 else:
                     retry_after = None
             raise RateLimitError(request_id, err, retry_after)
-        elif 200 <= r.status_code <= 299:
-            if route_style == self._ROUTE_STYLE_DOWNLOAD:
-                raw_resp = r.headers['dropbox-api-result']
-            else:
-                assert r.headers.get('content-type') == 'application/json', (
-                    'Expected content-type to be application/json, got %r' %
-                    r.headers.get('content-type'))
-                raw_resp = r.content.decode('utf-8')
-            if route_style == self._ROUTE_STYLE_DOWNLOAD:
-                return RouteResult(raw_resp, r)
-            else:
-                return RouteResult(raw_resp)
-        elif r.status_code in (403, 404, 409):
-            raw_resp = r.content.decode('utf-8')
-            return RouteErrorResult(request_id, raw_resp)
-        else:
-            raise HttpError(request_id, r.status_code, r.text)
+        elif res.status_code in (403, 404, 409):
+            # special case handled by requester
+            return
+        elif not (200 <= res.status_code <= 299):
+            raise HttpError(request_id, res.status_code, res.text)
 
     def _get_route_url(self, hostname, route_name):
         """Returns the URL of the route.

--- a/test/integration/test_dropbox.py
+++ b/test/integration/test_dropbox.py
@@ -26,7 +26,6 @@ from dropbox.dropbox_client import PATH_ROOT_HEADER, SELECT_USER_HEADER
 from dropbox.exceptions import (
     ApiError,
     AuthError,
-    BadInputError,
     PathRootError,
 )
 from dropbox.files import (

--- a/test/integration/test_dropbox.py
+++ b/test/integration/test_dropbox.py
@@ -26,6 +26,7 @@ from dropbox.dropbox_client import PATH_ROOT_HEADER, SELECT_USER_HEADER
 from dropbox.exceptions import (
     ApiError,
     AuthError,
+    BadInputError,
     PathRootError,
 )
 from dropbox.files import (
@@ -152,9 +153,9 @@ class TestDropbox:
     def test_bad_auth(self):
         # Test malformed token
         malformed_token_dbx = Dropbox(MALFORMED_TOKEN)
-        with pytest.raises(AuthError) as cm:
+        with pytest.raises(BadInputError,) as cm:
             malformed_token_dbx.files_list_folder('')
-        assert 'invalid_access_token' in cm.value.message
+        assert 'token is malformed' in cm.value.message
 
         # Test reasonable-looking invalid token
         invalid_token_dbx = Dropbox(INVALID_TOKEN)

--- a/test/integration/test_dropbox.py
+++ b/test/integration/test_dropbox.py
@@ -153,9 +153,9 @@ class TestDropbox:
     def test_bad_auth(self):
         # Test malformed token
         malformed_token_dbx = Dropbox(MALFORMED_TOKEN)
-        with pytest.raises(BadInputError) as cm:
+        with pytest.raises(AuthError) as cm:
             malformed_token_dbx.files_list_folder('')
-        assert 'token is malformed' in cm.value.message
+        assert 'invalid_access_token' in cm.value.message
 
         # Test reasonable-looking invalid token
         invalid_token_dbx = Dropbox(INVALID_TOKEN)


### PR DESCRIPTION
Separate out error handling into another method for the dropbox client so that it can be reused in `refresh_access_token` since it previously didn't throw a Dropbox error when the status code was anything other than a 400.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does `tox` pass?
- [ ] Do the tests pass?