### PR TITLE
Add scope to client docs

### DIFF
--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -57,7 +57,7 @@ def main():
 
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
-         specs + ['-a', 'host', '-a', 'style', '-a', 'auth'] +
+         specs + ['-a', 'host', '-a', 'style', '-a', 'auth', '-a', 'scope'] +
          [
              '--',
               '-w', 'user,app,noauth',
@@ -71,7 +71,7 @@ def main():
 
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
-         specs + ['-a', 'host', '-a', 'style', '-a', 'auth'] +
+         specs + ['-a', 'host', '-a', 'style', '-a', 'auth', '-a', 'scope'] +
          [
              '--',
              '-w', 'team',

--- a/generate_base_client.py
+++ b/generate_base_client.py
@@ -58,14 +58,28 @@ def main():
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
          specs + ['-a', 'host', '-a', 'style', '-a', 'auth'] +
-         ['--', '-w', 'user,app,noauth', '-m', 'base', '-c', 'DropboxBase', '-t', 'dropbox']))
+         [
+             '--',
+              '-w', 'user,app,noauth',
+              '-m', 'base',
+              '-c', 'DropboxBase',
+              '-t', 'dropbox',
+              '-a', 'scope'
+         ]))
     if o:
         print('Output:', o)
 
     o = subprocess.check_output(
         (['python', '-m', 'stone.cli', 'python_client', dropbox_pkg_path] +
          specs + ['-a', 'host', '-a', 'style', '-a', 'auth'] +
-         ['--', '-w', 'team', '-m', 'base_team', '-c', 'DropboxTeamBase', '-t', 'dropbox']))
+         [
+             '--',
+             '-w', 'team',
+             '-m', 'base_team',
+             '-c', 'DropboxTeamBase',
+             '-t', 'dropbox',
+             '-a', 'scope'
+         ]))
     if o:
         print('Output:', o)
 


### PR DESCRIPTION
Adds the "scope" attribute to the exported clients, so that they appear in the docstrings of routes that have a scope defined.

After running:
```
python generate_base_client.py
tox -e docs
```

I checked the html build files and scopes are showing up as expected.

![Screen Shot 2022-01-24 at 3 16 18 PM](https://user-images.githubusercontent.com/204723/150880978-741b3c9c-5b93-4d20-bac4-c879badfa636.png)