### PR TITLE
Automated Spec Update

### DIFF
--- a/dropbox/account.py
+++ b/dropbox/account.py
@@ -248,9 +248,9 @@ set_profile_photo = bb.Route(
     SetProfilePhotoArg_validator,
     SetProfilePhotoResult_validator,
     SetProfilePhotoError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/auth.py
+++ b/dropbox/auth.py
@@ -679,9 +679,9 @@ token_from_oauth1 = bb.Route(
     TokenFromOAuth1Arg_validator,
     TokenFromOAuth1Result_validator,
     TokenFromOAuth1Error_validator,
-    {'auth': u'app',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'app',
+     'host': 'api',
+     'style': 'rpc'},
 )
 token_revoke = bb.Route(
     'token/revoke',
@@ -690,9 +690,9 @@ token_revoke = bb.Route(
     bv.Void(),
     bv.Void(),
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -42,6 +42,9 @@ class DropboxBase(object):
         """
         Sets a user's profile photo.
 
+        Route attributes:
+            scope: account_info.write
+
         :param photo: Image to set as the user's new profile photo.
         :type photo: :class:`dropbox.account.PhotoSourceArg`
         :rtype: :class:`dropbox.account.SetProfilePhotoResult`
@@ -110,7 +113,7 @@ class DropboxBase(object):
     # Routes in check namespace
 
     def check_app(self,
-                  query=u''):
+                  query=''):
         """
         This endpoint performs App Authentication, validating the supplied app
         key and secret, and returns the supplied string, to allow you to test
@@ -132,7 +135,7 @@ class DropboxBase(object):
         return r
 
     def check_user(self,
-                   query=u''):
+                   query=''):
         """
         This endpoint performs User Authentication, validating the supplied
         access token, and returns the supplied string, to allow you to test your
@@ -140,6 +143,9 @@ class DropboxBase(object):
         receive an HTTP 200 response with the supplied query, it indicates at
         least part of the Dropbox API infrastructure is working and that the
         access token is valid.
+
+        Route attributes:
+            scope: account_info.read
 
         :param str query: The string that you'd like to be echoed back to you.
         :rtype: :class:`dropbox.check.EchoResult`
@@ -162,6 +168,9 @@ class DropboxBase(object):
         on your team or who you imported. New contacts will be added when you
         share.
 
+        Route attributes:
+            scope: contacts.write
+
         :rtype: None
         """
         arg = None
@@ -177,6 +186,9 @@ class DropboxBase(object):
                                               email_addresses):
         """
         Removes manually added contacts from the given list.
+
+        Route attributes:
+            scope: contacts.write
 
         :param List[str] email_addresses: List of manually added contacts to be
             deleted.
@@ -205,6 +217,9 @@ class DropboxBase(object):
         Add property groups to a Dropbox file. See
         :meth:`file_properties_templates_add_for_user` or
         :meth:`file_properties_templates_add_for_team` to create new templates.
+
+        Route attributes:
+            scope: files.metadata.write
 
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.file_properties.PropertyGroup`]
@@ -237,6 +252,9 @@ class DropboxBase(object):
         "delta". In other words, this endpoint will delete all omitted fields
         from a property group, whereas :meth:`file_properties_properties_update`
         will only delete fields that are explicitly marked for deletion.
+
+        Route attributes:
+            scope: files.metadata.write
 
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.file_properties.PropertyGroup`]
@@ -271,6 +289,9 @@ class DropboxBase(object):
         see :meth:`file_properties_templates_remove_for_user` or
         :meth:`file_properties_templates_remove_for_team`.
 
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[str] property_template_ids: A list of identifiers for a
             template created by :meth:`file_properties_templates_add_for_user`
@@ -296,6 +317,9 @@ class DropboxBase(object):
                                           template_filter=file_properties.TemplateFilter.filter_none):
         """
         Search across property templates for particular property field values.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param List[:class:`dropbox.file_properties.PropertiesSearchQuery`]
             queries: Queries to search.
@@ -324,6 +348,9 @@ class DropboxBase(object):
         Once a cursor has been retrieved from
         :meth:`file_properties_properties_search`, use this to paginate through
         all search results.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str cursor: The cursor returned by your last call to
             :meth:`file_properties_properties_search` or
@@ -355,6 +382,9 @@ class DropboxBase(object):
         group, whereas :meth:`file_properties_properties_overwrite` will delete
         any fields that are omitted from a property group.
 
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.file_properties.PropertyGroupUpdate`]
             update_property_groups: The property groups "delta" updates to
@@ -384,6 +414,9 @@ class DropboxBase(object):
         :meth:`file_properties_properties_add` to add properties to a file. This
         endpoint can't be called on a team member or admin's behalf.
 
+        Route attributes:
+            scope: files.metadata.write
+
         :rtype: :class:`dropbox.file_properties.AddTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -406,6 +439,9 @@ class DropboxBase(object):
         """
         Get the schema for a specified template. This endpoint can't be called
         on a team member or admin's behalf.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str template_id: An identifier for template added by route  See
             :meth:`file_properties_templates_add_for_user` or
@@ -431,6 +467,9 @@ class DropboxBase(object):
         template use :meth:`file_properties_templates_get_for_user`. This
         endpoint can't be called on a team member or admin's behalf.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :rtype: :class:`dropbox.file_properties.ListTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -453,6 +492,9 @@ class DropboxBase(object):
         :meth:`file_properties_templates_add_for_user`. All properties
         associated with the template will also be removed. This action cannot be
         undone.
+
+        Route attributes:
+            scope: files.metadata.write
 
         :param str template_id: An identifier for a template created by
             :meth:`file_properties_templates_add_for_user` or
@@ -482,6 +524,9 @@ class DropboxBase(object):
         template name, the template description and add optional properties to
         templates. This endpoint can't be called on a team member or admin's
         behalf.
+
+        Route attributes:
+            scope: files.metadata.write
 
         :param str template_id: An identifier for template added by  See
             :meth:`file_properties_templates_add_for_user` or
@@ -520,6 +565,9 @@ class DropboxBase(object):
         Returns the total number of file requests owned by this user. Includes
         both open and closed file requests.
 
+        Route attributes:
+            scope: file_requests.read
+
         :rtype: :class:`dropbox.file_requests.CountFileRequestsResult`
         """
         arg = None
@@ -539,6 +587,9 @@ class DropboxBase(object):
                              description=None):
         """
         Creates a file request for this user.
+
+        Route attributes:
+            scope: file_requests.write
 
         :param str title: The title of the file request. Must not be empty.
         :param str destination: The path of the folder in the Dropbox where
@@ -575,6 +626,9 @@ class DropboxBase(object):
         """
         Delete a batch of closed file requests.
 
+        Route attributes:
+            scope: file_requests.write
+
         :param List[str] ids: List IDs of the file requests to delete.
         :rtype: :class:`dropbox.file_requests.DeleteFileRequestsResult`
         :raises: :class:`.exceptions.ApiError`
@@ -595,6 +649,9 @@ class DropboxBase(object):
         """
         Delete all closed file requests owned by this user.
 
+        Route attributes:
+            scope: file_requests.write
+
         :rtype: :class:`dropbox.file_requests.DeleteAllClosedFileRequestsResult`
         """
         arg = None
@@ -610,6 +667,9 @@ class DropboxBase(object):
                           id):
         """
         Returns the specified file request.
+
+        Route attributes:
+            scope: file_requests.read
 
         :param str id: The ID of the file request to retrieve.
         :rtype: :class:`dropbox.file_requests.FileRequest`
@@ -630,6 +690,9 @@ class DropboxBase(object):
         app folder permission, this will only return file requests with
         destinations in the app folder.
 
+        Route attributes:
+            scope: file_requests.read
+
         :param int limit: The maximum number of file requests that should be
             returned per request.
         :rtype: :class:`dropbox.file_requests.ListFileRequestsV2Result`
@@ -649,6 +712,9 @@ class DropboxBase(object):
         app folder permission, this will only return file requests with
         destinations in the app folder.
 
+        Route attributes:
+            scope: file_requests.read
+
         :rtype: :class:`dropbox.file_requests.ListFileRequestsResult`
         """
         arg = None
@@ -667,6 +733,9 @@ class DropboxBase(object):
         this to paginate through all file requests. The cursor must come from a
         previous call to :meth:`file_requests_list_v2` or
         :meth:`file_requests_list_continue`.
+
+        Route attributes:
+            scope: file_requests.read
 
         :param str cursor: The cursor returned by the previous API call
             specified in the endpoint description.
@@ -694,6 +763,9 @@ class DropboxBase(object):
                              description=None):
         """
         Update a file request.
+
+        Route attributes:
+            scope: file_requests.write
 
         :param str id: The ID of the file request to update.
         :param Nullable[str] title: The new title of the file request. Must not
@@ -738,6 +810,9 @@ class DropboxBase(object):
         compatible with the properties API. Note: Metadata for the root folder
         is unsupported.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param Nullable[List[str]] include_property_templates: If set to a valid
             list of template IDs, ``FileMetadata.property_groups`` is set for
             files with custom properties.
@@ -781,6 +856,9 @@ class DropboxBase(object):
         larger than 150 MB. Instead, create an upload session with
         :meth:`files_upload_session_start`.
 
+        Route attributes:
+            scope: files.content.write
+
         :param bytes f: Contents to upload.
         :rtype: :class:`dropbox.files.FileMetadata`
         """
@@ -812,6 +890,9 @@ class DropboxBase(object):
         """
         Copy a file or folder to a different location in the user's Dropbox. If
         the source path is a folder all its contents will be copied.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool autorename: If there's a conflict, have the Dropbox server
@@ -847,6 +928,9 @@ class DropboxBase(object):
         """
         Copy a file or folder to a different location in the user's Dropbox. If
         the source path is a folder all its contents will be copied.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool autorename: If there's a conflict, have the Dropbox server
@@ -889,6 +973,9 @@ class DropboxBase(object):
         copy job in background. Please use :meth:`files_copy_batch_check_v2` to
         check the job status.
 
+        Route attributes:
+            scope: files.content.write
+
         :param List[:class:`dropbox.files.RelocationPath`] entries: List of
             entries to be moved or copied. Each entry is
             :class:`dropbox.files.RelocationPath`.
@@ -916,6 +1003,9 @@ class DropboxBase(object):
         user's Dropbox. This route will return job ID immediately and do the
         async copy job in background. Please use :meth:`files_copy_batch_check`
         to check the job status.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool allow_ownership_transfer: Allow moves by owner even if it
@@ -945,6 +1035,9 @@ class DropboxBase(object):
         Returns the status of an asynchronous job for
         :meth:`files_copy_batch_v2`. It returns list of results for each entry.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.files.RelocationBatchV2JobStatus`
@@ -967,6 +1060,9 @@ class DropboxBase(object):
         """
         Returns the status of an asynchronous job for :meth:`files_copy_batch`.
         If success, it returns list of results for each entry.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -996,6 +1092,9 @@ class DropboxBase(object):
         used to save that file or folder to another user's Dropbox by passing it
         to :meth:`files_copy_reference_save`.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str path: The path to the file or folder you want to get a copy
             reference to.
         :rtype: :class:`dropbox.files.GetCopyReferenceResult`
@@ -1019,6 +1118,9 @@ class DropboxBase(object):
         """
         Save a copy reference returned by :meth:`files_copy_reference_get` to
         the user's Dropbox.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str copy_reference: A copy reference returned by
             :meth:`files_copy_reference_get`.
@@ -1045,6 +1147,9 @@ class DropboxBase(object):
         """
         Create a folder at a given path.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str path: Path in the user's Dropbox to create.
         :param bool autorename: If there's a conflict, have the Dropbox server
             try to autorename the folder to avoid the conflict.
@@ -1069,6 +1174,9 @@ class DropboxBase(object):
                             autorename=False):
         """
         Create a folder at a given path.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str path: Path in the user's Dropbox to create.
         :param bool autorename: If there's a conflict, have the Dropbox server
@@ -1105,6 +1213,9 @@ class DropboxBase(object):
         behaviour by using the ``CreateFolderBatchArg.force_async`` flag.  Use
         :meth:`files_create_folder_batch_check` to check the job status.
 
+        Route attributes:
+            scope: files.content.write
+
         :param List[str] paths: List of paths to be created in the user's
             Dropbox. Duplicate path arguments in the batch are considered only
             once.
@@ -1131,6 +1242,9 @@ class DropboxBase(object):
         Returns the status of an asynchronous job for
         :meth:`files_create_folder_batch`. If success, it returns list of result
         for each entry.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -1159,6 +1273,9 @@ class DropboxBase(object):
         corresponding :class:`dropbox.files.FileMetadata` or
         :class:`dropbox.files.FolderMetadata` for the item at time of deletion,
         and not a :class:`dropbox.files.DeletedMetadata` object.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str path: Path in the user's Dropbox to delete.
         :param Nullable[str] parent_rev: Perform delete if given "rev" matches
@@ -1191,6 +1308,9 @@ class DropboxBase(object):
         :class:`dropbox.files.FolderMetadata` for the item at time of deletion,
         and not a :class:`dropbox.files.DeletedMetadata` object.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str path: Path in the user's Dropbox to delete.
         :param Nullable[str] parent_rev: Perform delete if given "rev" matches
             the existing file's latest "rev". This field does not support
@@ -1222,6 +1342,9 @@ class DropboxBase(object):
         returns a job ID immediately and runs the delete batch asynchronously.
         Use :meth:`files_delete_batch_check` to check the job status.
 
+        Route attributes:
+            scope: files.content.write
+
         :type entries: List[:class:`dropbox.files.DeleteArg`]
         :rtype: :class:`dropbox.files.DeleteBatchLaunch`
         """
@@ -1240,6 +1363,9 @@ class DropboxBase(object):
         Returns the status of an asynchronous job for
         :meth:`files_delete_batch`. If success, it returns list of result for
         each entry.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -1263,6 +1389,9 @@ class DropboxBase(object):
                        rev=None):
         """
         Download a file from a user's Dropbox.
+
+        Route attributes:
+            scope: files.content.read
 
         :param str path: The path of the file to download.
         :param Nullable[str] rev: Please specify revision in ``path`` instead.
@@ -1296,6 +1425,9 @@ class DropboxBase(object):
         """
         Download a file from a user's Dropbox.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the file to download.
         :param Nullable[str] rev: Please specify revision in ``path`` instead.
@@ -1324,6 +1456,9 @@ class DropboxBase(object):
         than 4 GB in size. The resulting zip must have fewer than 10,000 total
         file and folder entries, including the top level folder. The input
         cannot be a single file.
+
+        Route attributes:
+            scope: files.content.read
 
         :param str path: The path of the folder to download.
         :rtype: (:class:`dropbox.files.DownloadZipResult`,
@@ -1358,6 +1493,9 @@ class DropboxBase(object):
         file and folder entries, including the top level folder. The input
         cannot be a single file.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the folder to download.
         :rtype: :class:`dropbox.files.DownloadZipResult`
@@ -1383,6 +1521,9 @@ class DropboxBase(object):
         Export a file from a user's Dropbox. This route only supports exporting
         files that cannot be downloaded directly  and whose
         ``ExportResult.file_metadata`` has ``ExportInfo.export_as`` populated.
+
+        Route attributes:
+            scope: files.content.read
 
         :param str path: The path of the file to be exported.
         :param Nullable[str] export_format: The file format to which the file
@@ -1422,6 +1563,9 @@ class DropboxBase(object):
         files that cannot be downloaded directly  and whose
         ``ExportResult.file_metadata`` has ``ExportInfo.export_as`` populated.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the file to be exported.
         :param Nullable[str] export_format: The file format to which the file
@@ -1451,6 +1595,9 @@ class DropboxBase(object):
         """
         Return the lock metadata for the given list of paths.
 
+        Route attributes:
+            scope: files.content.read
+
         :param List[:class:`dropbox.files.LockFileArg`] entries: List of
             'entries'. Each 'entry' contains a path of the file which will be
             locked or queried. Duplicate path arguments in the batch are
@@ -1479,6 +1626,9 @@ class DropboxBase(object):
         """
         Returns the metadata for a file or folder. Note: Metadata for the root
         folder is unsupported.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str path: The path of a file or folder on Dropbox.
         :param bool include_media_info: If true, ``FileMetadata.media_info`` is
@@ -1524,6 +1674,9 @@ class DropboxBase(object):
         extensions: .csv, .ods, .xls, .xlsm, .gsheet, .xlsx. Other formats will
         return an unsupported extension error.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str path: The path of the file to preview.
         :param Nullable[str] rev: Please specify revision in ``path`` instead.
         :rtype: (:class:`dropbox.files.FileMetadata`,
@@ -1561,6 +1714,9 @@ class DropboxBase(object):
         extensions: .csv, .ods, .xls, .xlsm, .gsheet, .xlsx. Other formats will
         return an unsupported extension error.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param str path: The path of the file to preview.
         :param Nullable[str] rev: Please specify revision in ``path`` instead.
@@ -1588,6 +1744,9 @@ class DropboxBase(object):
         in four hours and afterwards you will get 410 Gone. This URL should not
         be used to display content directly in the browser. The Content-Type of
         the link is determined automatically by the file's mime type.
+
+        Route attributes:
+            scope: files.content.read
 
         :param str path: The path to the file you want a temporary link to.
         :rtype: :class:`dropbox.files.GetTemporaryLinkResult`
@@ -1640,6 +1799,9 @@ class DropboxBase(object):
         unsuccessful temporary upload link consumption response: Temporary
         upload link has been recently consumed.
 
+        Route attributes:
+            scope: files.content.write
+
         :param commit_info: Contains the path and other optional modifiers for
             the future upload commit. Equivalent to the parameters provided to
             :meth:`files_upload`.
@@ -1669,6 +1831,9 @@ class DropboxBase(object):
         the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm
         and bmp. Photos that are larger than 20MB in size won't be converted to
         a thumbnail.
+
+        Route attributes:
+            scope: files.content.read
 
         :param str path: The path to the image file you want to thumbnail.
         :param format: The format for the thumbnail image, jpeg (default) or
@@ -1717,6 +1882,9 @@ class DropboxBase(object):
         and bmp. Photos that are larger than 20MB in size won't be converted to
         a thumbnail.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param str path: The path to the image file you want to thumbnail.
         :param format: The format for the thumbnail image, jpeg (default) or
@@ -1757,6 +1925,9 @@ class DropboxBase(object):
         the following file extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm
         and bmp. Photos that are larger than 20MB in size won't be converted to
         a thumbnail.
+
+        Route attributes:
+            scope: files.content.read
 
         :param resource: Information specifying which file to preview. This
             could be a path to a file, a shared link pointing to a file, or a
@@ -1808,6 +1979,9 @@ class DropboxBase(object):
         and bmp. Photos that are larger than 20MB in size won't be converted to
         a thumbnail.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :param resource: Information specifying which file to preview. This
             could be a path to a file, a shared link pointing to a file, or a
@@ -1849,6 +2023,9 @@ class DropboxBase(object):
         file extensions: jpg, jpeg, png, tiff, tif, gif, webp, ppm and bmp.
         Photos that are larger than 20MB in size won't be converted to a
         thumbnail.
+
+        Route attributes:
+            scope: files.content.read
 
         :param List[:class:`dropbox.files.ThumbnailArg`] entries: List of files
             to get thumbnails.
@@ -1903,6 +2080,9 @@ class DropboxBase(object):
         with same parameters are made simultaneously by same API app for same
         user. If your app implements retry logic, please hold off the retry
         until the previous request finishes.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str path: A unique identifier for the file.
         :param bool recursive: If true, the list folder operation will be
@@ -1964,6 +2144,9 @@ class DropboxBase(object):
         this to paginate through all files and retrieve updates to the folder,
         following the same rules as documented for :meth:`files_list_folder`.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str cursor: The cursor returned by your last call to
             :meth:`files_list_folder` or :meth:`files_list_folder_continue`.
         :rtype: :class:`dropbox.files.ListFolderResult`
@@ -1998,6 +2181,9 @@ class DropboxBase(object):
         doesn't return any entries. This endpoint is for app which only needs to
         know about new files and modifications and doesn't need to know about
         files that already exist in Dropbox.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str path: A unique identifier for the file.
         :param bool recursive: If true, the list folder operation will be
@@ -2064,6 +2250,9 @@ class DropboxBase(object):
         server-side notifications, check out our `webhooks documentation
         <https://www.dropbox.com/developers/reference/webhooks>`_.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str cursor: A cursor as returned by :meth:`files_list_folder` or
             :meth:`files_list_folder_continue`. Cursors retrieved by setting
             ``ListFolderArg.include_media_info`` to ``True`` are not supported.
@@ -2103,6 +2292,9 @@ class DropboxBase(object):
         ``ListRevisionsMode.id``. The ``ListRevisionsMode.id`` mode is useful to
         retrieve revisions for a given file across moves or renames.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str path: The path to the file you want to see the revisions of.
         :param mode: Determines the behavior of the API in listing the revisions
             for a given file path or id.
@@ -2133,6 +2325,9 @@ class DropboxBase(object):
         been locked. Returns a list of the locked file paths and their metadata
         after this operation.
 
+        Route attributes:
+            scope: files.content.write
+
         :param List[:class:`dropbox.files.LockFileArg`] entries: List of
             'entries'. Each 'entry' contains a path of the file which will be
             locked or queried. Duplicate path arguments in the batch are
@@ -2162,6 +2357,9 @@ class DropboxBase(object):
         Move a file or folder to a different location in the user's Dropbox. If
         the source path is a folder all its contents will be moved. Note that we
         do not currently support case-only renaming.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool autorename: If there's a conflict, have the Dropbox server
@@ -2197,6 +2395,9 @@ class DropboxBase(object):
         """
         Move a file or folder to a different location in the user's Dropbox. If
         the source path is a folder all its contents will be moved.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool autorename: If there's a conflict, have the Dropbox server
@@ -2241,6 +2442,9 @@ class DropboxBase(object):
         move job in background. Please use :meth:`files_move_batch_check_v2` to
         check the job status.
 
+        Route attributes:
+            scope: files.content.write
+
         :param bool allow_ownership_transfer: Allow moves by owner even if it
             would result in an ownership transfer for the content being moved.
             This does not apply to copies.
@@ -2267,6 +2471,9 @@ class DropboxBase(object):
         user's Dropbox. This route will return job ID immediately and do the
         async moving job in background. Please use
         :meth:`files_move_batch_check` to check the job status.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bool allow_shared_folder: This flag has no effect.
         :param bool allow_ownership_transfer: Allow moves by owner even if it
@@ -2296,6 +2503,9 @@ class DropboxBase(object):
         Returns the status of an asynchronous job for
         :meth:`files_move_batch_v2`. It returns list of results for each entry.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.files.RelocationBatchV2JobStatus`
@@ -2318,6 +2528,9 @@ class DropboxBase(object):
         """
         Returns the status of an asynchronous job for :meth:`files_move_batch`.
         If success, it returns list of results for each entry.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -2346,6 +2559,9 @@ class DropboxBase(object):
                            import_format):
         """
         Creates a new Paper doc with the provided content.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param str path: The fully qualified path to the location in the user's
@@ -2377,6 +2593,9 @@ class DropboxBase(object):
                            paper_revision=None):
         """
         Updates an existing Paper doc with the provided content.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param str path: Path in the user's Dropbox to update. The path must
@@ -2417,6 +2636,9 @@ class DropboxBase(object):
         route to successfully delete, then fail to permanently delete. Note:
         This endpoint is only available for Dropbox Business apps.
 
+        Route attributes:
+            scope: files.permanent_delete
+
         :param str path: Path in the user's Dropbox to delete.
         :param Nullable[str] parent_rev: Perform delete if given "rev" matches
             the existing file's latest "rev". This field does not support
@@ -2441,6 +2663,9 @@ class DropboxBase(object):
                              path,
                              property_groups):
         """
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.files.PropertyGroup`] property_groups: The
             property groups which are to be added to a Dropbox file. No two
@@ -2469,6 +2694,9 @@ class DropboxBase(object):
                                    path,
                                    property_groups):
         """
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.files.PropertyGroup`] property_groups: The
             property groups "snapshot" updates to force apply. No two groups in
@@ -2497,6 +2725,9 @@ class DropboxBase(object):
                                 path,
                                 property_template_ids):
         """
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[str] property_template_ids: A list of identifiers for a
             template created by :meth:`files_templates_add_for_user` or
@@ -2524,6 +2755,9 @@ class DropboxBase(object):
     def files_properties_template_get(self,
                                       template_id):
         """
+        Route attributes:
+            scope: files.metadata.read
+
         :param str template_id: An identifier for template added by route  See
             :meth:`files_templates_add_for_user` or
             :meth:`files_templates_add_for_team`.
@@ -2547,6 +2781,16 @@ class DropboxBase(object):
         return r
 
     def files_properties_template_list(self):
+        """
+        Route attributes:
+            scope: files.metadata.read
+
+        :rtype: :class:`dropbox.files.ListTemplateResult`
+        :raises: :class:`.exceptions.ApiError`
+
+        If this raises, ApiError will contain:
+            :class:`dropbox.files.TemplateError`
+        """
         warnings.warn(
             'properties/template/list is deprecated.',
             DeprecationWarning,
@@ -2564,6 +2808,9 @@ class DropboxBase(object):
                                 path,
                                 update_property_groups):
         """
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: A unique identifier for the file or folder.
         :param List[:class:`dropbox.files.PropertyGroupUpdate`]
             update_property_groups: The property groups "delta" updates to
@@ -2594,6 +2841,9 @@ class DropboxBase(object):
         """
         Restore a specific revision of a file to the given path.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str path: The path to save the restored file.
         :param str rev: The revision to restore.
         :rtype: :class:`dropbox.files.FileMetadata`
@@ -2622,6 +2872,9 @@ class DropboxBase(object):
         exists, the file will be renamed to avoid the conflict (e.g. myfile
         (1).txt).
 
+        Route attributes:
+            scope: files.content.write
+
         :param str path: The path in Dropbox where the URL will be saved to.
         :param str url: The URL to be saved.
         :rtype: :class:`dropbox.files.SaveUrlResult`
@@ -2644,6 +2897,9 @@ class DropboxBase(object):
                                         async_job_id):
         """
         Check the status of a :meth:`files_save_url` job.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -2672,6 +2928,9 @@ class DropboxBase(object):
         Searches for files and folders. Note: Recent changes will be reflected
         in search results within a few seconds and older revisions of existing
         files may still match your query for up to a few days.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param str path: The path in the user's Dropbox to search. Should
             probably be a folder.
@@ -2722,6 +2981,9 @@ class DropboxBase(object):
         search results due to a short delay in indexing. Duplicate results may
         be returned across pages. Some results may not be returned.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str query: The string to search for. May match across multiple
             fields based on the request arguments.
         :param Nullable[:class:`dropbox.files.SearchOptions`] options: Options
@@ -2758,6 +3020,9 @@ class DropboxBase(object):
         search results due to a short delay in indexing. Duplicate results may
         be returned across pages. Some results may not be returned.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str cursor: The cursor returned by your last call to
             :meth:`files_search_v2`. Used to fetch the next page of results.
         :rtype: :class:`dropbox.files.SearchV2Result`
@@ -2782,6 +3047,9 @@ class DropboxBase(object):
         Add a tag to an item. A tag is a string. No more than 20 tags can be
         added to a given item.
 
+        Route attributes:
+            scope: files.metadata.write
+
         :param str path: Path to the item to be tagged.
         :param str tag_text: The value of the tag to add.
         :rtype: None
@@ -2805,6 +3073,9 @@ class DropboxBase(object):
         """
         Get list of tags assigned to items.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param List[str] paths: Path to the items.
         :rtype: :class:`dropbox.files.GetTagsResult`
         :raises: :class:`.exceptions.ApiError`
@@ -2826,6 +3097,9 @@ class DropboxBase(object):
                           tag_text):
         """
         Remove a tag from an item.
+
+        Route attributes:
+            scope: files.metadata.write
 
         :param str path: Path to the item to tag.
         :param str tag_text: The tag to remove.
@@ -2852,6 +3126,9 @@ class DropboxBase(object):
         by the lock holder or, if a business account, a team admin. A successful
         response indicates that the file has been unlocked. Returns a list of
         the unlocked file paths and their metadata after this operation.
+
+        Route attributes:
+            scope: files.content.write
 
         :param List[:class:`dropbox.files.UnlockFileArg`] entries: List of
             'entries'. Each 'entry' contains a path of the file which will be
@@ -2889,6 +3166,9 @@ class DropboxBase(object):
         limit on the number of data transport calls allowed per month. For more
         information, see the `Data transport limit page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param str path: Path in the user's Dropbox to save the file.
@@ -2950,6 +3230,9 @@ class DropboxBase(object):
         transport limit page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
 
+        Route attributes:
+            scope: files.content.write
+
         :param bytes f: Contents to upload.
         :param cursor: Contains the upload session ID and the offset.
         :type cursor: :class:`dropbox.files.UploadSessionCursor`
@@ -2985,6 +3268,9 @@ class DropboxBase(object):
         number of data transport calls allowed per month. For more information,
         see the `Data transport limit page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param str session_id: The upload session ID (returned by
@@ -3025,6 +3311,9 @@ class DropboxBase(object):
         allowed per month. For more information, see the `Data transport limit
         page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param cursor: Contains the upload session ID and the offset.
@@ -3072,6 +3361,9 @@ class DropboxBase(object):
         information, see the `Data transport limit page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
 
+        Route attributes:
+            scope: files.content.write
+
         :param List[:class:`dropbox.files.UploadSessionFinishArg`] entries:
             Commit information for each file in the batch.
         :rtype: :class:`dropbox.files.UploadSessionFinishBatchLaunch`
@@ -3109,6 +3401,9 @@ class DropboxBase(object):
         information, see the `Data transport limit page
         <https://www.dropbox.com/developers/reference/data-transport-limit>`_.
 
+        Route attributes:
+            scope: files.content.write
+
         :param List[:class:`dropbox.files.UploadSessionFinishArg`] entries:
             Commit information for each file in the batch.
         :rtype: :class:`dropbox.files.UploadSessionFinishBatchResult`
@@ -3128,6 +3423,9 @@ class DropboxBase(object):
         Returns the status of an asynchronous job for
         :meth:`files_upload_session_finish_batch`. If success, it returns list
         of result for each entry.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -3186,6 +3484,9 @@ class DropboxBase(object):
         ``UploadSessionStartArg.close`` to ``True``, that may contain any
         remaining data).
 
+        Route attributes:
+            scope: files.content.write
+
         :param bytes f: Contents to upload.
         :param bool close: If true, the current session will be closed, at which
             point you won't be able to call
@@ -3226,6 +3527,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for more information.
 
+        Route attributes:
+            scope: files.content.write
+
         :param str doc_id: The Paper doc ID.
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
@@ -3259,6 +3563,9 @@ class DropboxBase(object):
         retired in September 2020. Refer to the `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for more information.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param Nullable[str] parent_folder_id: The Paper folder ID where the
@@ -3298,6 +3605,9 @@ class DropboxBase(object):
         `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: files.content.read
 
         :type export_format: :class:`dropbox.paper.ExportFormat`
         :rtype: (:class:`dropbox.paper.PaperDocExportResult`,
@@ -3341,6 +3651,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: files.content.read
+
         :param str download_path: Path on local machine to save file.
         :type export_format: :class:`dropbox.paper.ExportFormat`
         :rtype: :class:`dropbox.paper.PaperDocExportResult`
@@ -3380,6 +3693,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.read
+
         :param int limit: Size limit per batch. The maximum number of users that
             can be retrieved per batch is 1000. Higher value results in invalid
             arguments error.
@@ -3416,6 +3732,9 @@ class DropboxBase(object):
         version of Paper. Refer to the `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str cursor: The cursor obtained from
             :meth:`paper_docs_folder_users_list` or
@@ -3458,6 +3777,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str doc_id: The Paper doc ID.
         :rtype: :class:`dropbox.paper.FoldersContainingPaperDoc`
         :raises: :class:`.exceptions.ApiError`
@@ -3494,6 +3816,9 @@ class DropboxBase(object):
         Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: files.metadata.read
 
         :param filter_by: Allows user to specify how the Paper docs should be
             filtered.
@@ -3537,6 +3862,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: files.metadata.read
+
         :param str cursor: The cursor obtained from :meth:`paper_docs_list` or
             :meth:`paper_docs_list_continue`. Allows for pagination.
         :rtype: :class:`dropbox.paper.ListPaperDocsResponse`
@@ -3571,6 +3899,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: files.permanent_delete
+
         :param str doc_id: The Paper doc ID.
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
@@ -3602,6 +3933,9 @@ class DropboxBase(object):
         Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str doc_id: The Paper doc ID.
         :rtype: :class:`dropbox.paper.SharingPolicy`
@@ -3638,6 +3972,9 @@ class DropboxBase(object):
         version of Paper. Refer to the `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: sharing.write
 
         :param sharing_policy: The default sharing policy to be set for the
             Paper doc.
@@ -3677,6 +4014,9 @@ class DropboxBase(object):
         retired in September 2020. Refer to the `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for more information.
+
+        Route attributes:
+            scope: files.content.write
 
         :param bytes f: Contents to upload.
         :param doc_update_policy: The policy used for the current update call.
@@ -3725,6 +4065,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.write
+
         :param List[:class:`dropbox.paper.AddMember`] members: User which should
             be added to the Paper doc. Specify only email address or Dropbox
             account ID.
@@ -3771,6 +4114,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.read
+
         :param int limit: Size limit per batch. The maximum number of users that
             can be retrieved per batch is 1000. Higher value results in invalid
             arguments error.
@@ -3812,6 +4158,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str cursor: The cursor obtained from
             :meth:`paper_docs_users_list` or
             :meth:`paper_docs_users_list_continue`. Allows for pagination.
@@ -3849,6 +4198,9 @@ class DropboxBase(object):
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
 
+        Route attributes:
+            scope: sharing.write
+
         :param member: User which should be removed from the Paper doc. Specify
             only email address or Dropbox account ID.
         :type member: :class:`dropbox.paper.MemberSelector`
@@ -3885,6 +4237,9 @@ class DropboxBase(object):
         Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_
         for migration information.
+
+        Route attributes:
+            scope: files.content.write
 
         :param str name: The name of the new Paper folder.
         :param Nullable[str] parent_folder_id: The encrypted Paper folder Id
@@ -3931,6 +4286,9 @@ class DropboxBase(object):
         """
         Adds specified members to a file.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str file: File to which to add members.
         :param List[:class:`dropbox.sharing.MemberSelector`] members: Members to
             add. Note that even an email address is given, this may result in a
@@ -3938,8 +4296,8 @@ class DropboxBase(object):
             user's main account email.
         :param Nullable[str] custom_message: Message to send to added members in
             their invitation.
-        :param bool quiet: Whether added members should be notified via device
-            notifications of their invitation.
+        :param bool quiet: Whether added members should be notified via email
+            and device notifications of their invitation.
         :param access_level: AccessLevel union object, describing what access
             level we want to give new members.
         :type access_level: :class:`dropbox.sharing.AccessLevel`
@@ -3976,6 +4334,9 @@ class DropboxBase(object):
         the functionality for this folder, you will need to call
         :meth:`sharing_mount_folder` on their behalf.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str shared_folder_id: The ID for the shared folder.
         :param List[:class:`dropbox.sharing.AddMember`] members: The intended
             list of members to add.  Added members will receive invites to join
@@ -4007,6 +4368,9 @@ class DropboxBase(object):
         """
         Returns the status of an asynchronous job.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.sharing.JobStatus`
@@ -4029,6 +4393,9 @@ class DropboxBase(object):
         """
         Returns the status of an asynchronous job for sharing a folder.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.sharing.RemoveMemberJobStatus`
@@ -4050,6 +4417,9 @@ class DropboxBase(object):
                                        async_job_id):
         """
         Returns the status of an asynchronous job for sharing a folder.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -4079,6 +4449,9 @@ class DropboxBase(object):
         folder. In the future, this will no longer be the case, so your app
         shouldn't rely on this behavior. Instead, if your app needs to revoke a
         shared link, use :meth:`sharing_revoke_shared_link`.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str path: The path to share.
         :type short_url: bool
@@ -4117,6 +4490,9 @@ class DropboxBase(object):
         visibility, though, may depend on other aspects such as team and shared
         folder settings).
 
+        Route attributes:
+            scope: sharing.write
+
         :param str path: The path to be shared by the shared link.
         :param Nullable[:class:`dropbox.sharing.SharedLinkSettings`] settings:
             The requested settings for the newly created shared link.
@@ -4141,6 +4517,9 @@ class DropboxBase(object):
                                   actions=None):
         """
         Returns shared file metadata.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str file: The file to query.
         :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
@@ -4170,6 +4549,9 @@ class DropboxBase(object):
         """
         Returns shared file metadata.
 
+        Route attributes:
+            scope: sharing.read
+
         :param List[str] files: The files to query.
         :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
             list of `FileAction`s corresponding to `FilePermission`s that should
@@ -4197,6 +4579,9 @@ class DropboxBase(object):
                                     actions=None):
         """
         Returns shared folder metadata by its folder ID.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str shared_folder_id: The ID for the shared folder.
         :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
@@ -4226,6 +4611,9 @@ class DropboxBase(object):
                                      link_password=None):
         """
         Download the shared link's file from a user's Dropbox.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str url: URL of the shared link.
         :param Nullable[str] path: If the shared link is to a folder, this
@@ -4265,6 +4653,9 @@ class DropboxBase(object):
         """
         Download the shared link's file from a user's Dropbox.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str download_path: Path on local machine to save file.
         :param str url: URL of the shared link.
         :param Nullable[str] path: If the shared link is to a folder, this
@@ -4296,6 +4687,9 @@ class DropboxBase(object):
                                          link_password=None):
         """
         Get the shared link's metadata.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str url: URL of the shared link.
         :param Nullable[str] path: If the shared link is to a folder, this
@@ -4330,6 +4724,9 @@ class DropboxBase(object):
         all shared links that allow access to the given path.  Collection links
         are never returned in this case.
 
+        Route attributes:
+            scope: sharing.read
+
         :param Nullable[str] path: See :meth:`sharing_get_shared_links`
             description.
         :rtype: :class:`dropbox.sharing.GetSharedLinksResult`
@@ -4359,6 +4756,9 @@ class DropboxBase(object):
         """
         Use to obtain the members who have been invited to a file, both
         inherited and uninherited members.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str file: The file for which you want to see members.
         :param Nullable[List[:class:`dropbox.sharing.MemberAction`]] actions:
@@ -4395,6 +4795,9 @@ class DropboxBase(object):
         Inherited users and groups are not included in the result, and
         permissions are not returned for this endpoint.
 
+        Route attributes:
+            scope: sharing.read
+
         :param List[str] files: Files for which to return members.
         :param int limit: Number of members to return max per query. Defaults to
             10 if no limit is specified.
@@ -4420,6 +4823,9 @@ class DropboxBase(object):
         Once a cursor has been retrieved from :meth:`sharing_list_file_members`
         or :meth:`sharing_list_file_members_batch`, use this to paginate through
         all shared file members.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str cursor: The cursor returned by your last call to
             :meth:`sharing_list_file_members`,
@@ -4447,6 +4853,9 @@ class DropboxBase(object):
         """
         Returns shared folder membership by its folder ID.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str shared_folder_id: The ID for the shared folder.
         :rtype: :class:`dropbox.sharing.SharedFolderMembers`
         :raises: :class:`.exceptions.ApiError`
@@ -4472,6 +4881,9 @@ class DropboxBase(object):
         :meth:`sharing_list_folder_members`, use this to paginate through all
         shared folder members.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str cursor: The cursor returned by your last call to
             :meth:`sharing_list_folder_members` or
             :meth:`sharing_list_folder_members_continue`.
@@ -4495,6 +4907,9 @@ class DropboxBase(object):
                              actions=None):
         """
         Return the list of all shared folders the current user has access to.
+
+        Route attributes:
+            scope: sharing.read
 
         :param int limit: The maximum number of results to return per request.
         :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
@@ -4522,6 +4937,9 @@ class DropboxBase(object):
         previous call to :meth:`sharing_list_folders` or
         :meth:`sharing_list_folders_continue`.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str cursor: The cursor returned by the previous API call
             specified in the endpoint description.
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
@@ -4545,6 +4963,9 @@ class DropboxBase(object):
         """
         Return the list of all shared folders the current user can mount or
         unmount.
+
+        Route attributes:
+            scope: sharing.read
 
         :param int limit: The maximum number of results to return per request.
         :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
@@ -4573,6 +4994,9 @@ class DropboxBase(object):
         :meth:`sharing_list_mountable_folders` or
         :meth:`sharing_list_mountable_folders_continue`.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str cursor: The cursor returned by the previous API call
             specified in the endpoint description.
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
@@ -4597,6 +5021,9 @@ class DropboxBase(object):
         Returns a list of all files shared with current user.  Does not include
         files the user has received via shared folders, and does  not include
         unclaimed invitations.
+
+        Route attributes:
+            scope: sharing.read
 
         :param int limit: Number of files to return max per query. Defaults to
             100 if no limit is specified.
@@ -4625,6 +5052,9 @@ class DropboxBase(object):
                                              cursor):
         """
         Get more results with a cursor from :meth:`sharing_list_received_files`.
+
+        Route attributes:
+            scope: sharing.read
 
         :param str cursor: Cursor in ``ListFilesResult.cursor``.
         :rtype: :class:`dropbox.sharing.ListFilesResult`
@@ -4657,6 +5087,9 @@ class DropboxBase(object):
         access to the given path - direct links to the given path and links to
         parent folders of the given path. Links to parent folders can be
         suppressed by setting direct_only to true.
+
+        Route attributes:
+            scope: sharing.read
 
         :param Nullable[str] path: See :meth:`sharing_list_shared_links`
             description.
@@ -4695,6 +5128,9 @@ class DropboxBase(object):
         ``LinkPermissions.requested_visibility`` will reflect the requested
         visibility.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str url: URL of the shared link to change its settings.
         :param settings: Set of settings for the shared link.
         :type settings: :class:`dropbox.sharing.SharedLinkSettings`
@@ -4724,6 +5160,9 @@ class DropboxBase(object):
         a user after they have been added as a member. Once mounted, the shared
         folder will appear in their Dropbox.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str shared_folder_id: The ID of the shared folder to mount.
         :rtype: :class:`dropbox.sharing.SharedFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
@@ -4746,6 +5185,9 @@ class DropboxBase(object):
         The current user relinquishes their membership in the designated file.
         Note that the current user may still have inherited access to this file
         through the parent folder.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str file: The path or id for the file.
         :rtype: None
@@ -4773,6 +5215,9 @@ class DropboxBase(object):
         synchronously if leave_a_copy is false, and asynchronously if
         leave_a_copy is true.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str shared_folder_id: The ID for the shared folder.
         :param bool leave_a_copy: Keep a copy of the folder's contents upon
             relinquishing membership. This must be set to false when the folder
@@ -4798,6 +5243,9 @@ class DropboxBase(object):
                                    member):
         """
         Identical to remove_file_member_2 but with less information returned.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str file: File from which to remove members.
         :param member: Member to remove from this file. Note that even if an
@@ -4831,6 +5279,9 @@ class DropboxBase(object):
         """
         Removes a specified member from the file.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str file: File from which to remove members.
         :param member: Member to remove from this file. Note that even if an
             email is specified, it may result in the removal of a user (not an
@@ -4860,6 +5311,9 @@ class DropboxBase(object):
         """
         Allows an owner or editor (if the ACL update policy allows) of a shared
         folder to remove another member.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str shared_folder_id: The ID for the shared folder.
         :param member: The member to remove from the folder.
@@ -4896,6 +5350,9 @@ class DropboxBase(object):
         :meth:`sharing_list_shared_links` with the file as the
         ``ListSharedLinksArg.path`` argument.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str url: URL of the shared link.
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
@@ -4921,6 +5378,9 @@ class DropboxBase(object):
         ``ShareFolderLaunch.async_job_id`` is returned, you'll need to call
         :meth:`sharing_check_share_job_status` until the action completes to get
         the metadata for the folder.
+
+        Route attributes:
+            scope: sharing.write
 
         :param access_inheritance: The access inheritance settings for the
             folder.
@@ -4960,6 +5420,9 @@ class DropboxBase(object):
         :meth:`sharing_check_share_job_status` until the action completes to get
         the metadata for the folder.
 
+        Route attributes:
+            scope: sharing.write
+
         :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
             list of `FolderAction`s corresponding to `FolderPermission`s that
             should appear in the  response's
@@ -4998,6 +5461,9 @@ class DropboxBase(object):
         User must have ``AccessLevel.owner`` access to the shared folder to
         perform a transfer.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str shared_folder_id: The ID for the shared folder.
         :param str to_dropbox_id: A account or team member ID to transfer
             ownership to.
@@ -5023,6 +5489,9 @@ class DropboxBase(object):
         The current user unmounts the designated folder. They can re-mount the
         folder at a later time using :meth:`sharing_mount_folder`.
 
+        Route attributes:
+            scope: sharing.write
+
         :param str shared_folder_id: The ID for the shared folder.
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
@@ -5043,6 +5512,9 @@ class DropboxBase(object):
                              file):
         """
         Remove all members from this file. Does not remove inherited members.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str file: The file to unshare.
         :rtype: None
@@ -5067,6 +5539,9 @@ class DropboxBase(object):
         Allows a shared folder owner to unshare the folder. You'll need to call
         :meth:`sharing_check_job_status` to determine if the action has
         completed successfully.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str shared_folder_id: The ID for the shared folder.
         :param bool leave_a_copy: If true, members of this shared folder will
@@ -5095,6 +5570,9 @@ class DropboxBase(object):
                                    access_level):
         """
         Changes a member's access on a shared file.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str file: File for which we are changing a member's access.
         :param member: The member whose access we are changing.
@@ -5125,6 +5603,9 @@ class DropboxBase(object):
         """
         Allows an owner or editor of a shared folder to update another member's
         permissions.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str shared_folder_id: The ID for the shared folder.
         :param member: The member of the shared folder to update.  Only the
@@ -5162,6 +5643,9 @@ class DropboxBase(object):
         Update the sharing policies for a shared folder. User must have
         ``AccessLevel.owner`` access to the shared folder to update its
         policies.
+
+        Route attributes:
+            scope: sharing.write
 
         :param str shared_folder_id: The ID for the shared folder.
         :param Nullable[:class:`dropbox.sharing.MemberPolicy`] member_policy:
@@ -5220,6 +5704,9 @@ class DropboxBase(object):
         Get a list of feature values that may be configured for the current
         account.
 
+        Route attributes:
+            scope: account_info.read
+
         :param List[:class:`dropbox.users.UserFeature`] features: A list of
             features in :class:`dropbox.users.UserFeature`. If the list is
             empty, this route will return
@@ -5244,6 +5731,9 @@ class DropboxBase(object):
         """
         Get information about a user's account.
 
+        Route attributes:
+            scope: sharing.read
+
         :param str account_id: A user's account identifier.
         :rtype: :class:`dropbox.users.BasicAccount`
         :raises: :class:`.exceptions.ApiError`
@@ -5266,6 +5756,9 @@ class DropboxBase(object):
         Get information about multiple user accounts.  At most 300 accounts may
         be queried per request.
 
+        Route attributes:
+            scope: sharing.read
+
         :param List[str] account_ids: List of user account identifiers.  Should
             not contain any duplicate account IDs.
         :rtype: List[:class:`dropbox.users.BasicAccount`]
@@ -5287,6 +5780,9 @@ class DropboxBase(object):
         """
         Get information about the current user's account.
 
+        Route attributes:
+            scope: account_info.read
+
         :rtype: :class:`dropbox.users.FullAccount`
         """
         arg = None
@@ -5301,6 +5797,9 @@ class DropboxBase(object):
     def users_get_space_usage(self):
         """
         Get the space usage information for the current user's account.
+
+        Route attributes:
+            scope: account_info.read
 
         :rtype: :class:`dropbox.users.SpaceUsage`
         """

--- a/dropbox/base_team.py
+++ b/dropbox/base_team.py
@@ -58,6 +58,9 @@ class DropboxTeamBase(object):
         :meth:`file_properties_properties_add` to add properties to a file or
         folder. Note: this endpoint will create team-owned templates.
 
+        Route attributes:
+            scope: files.team_metadata.write
+
         :rtype: :class:`dropbox.file_properties.AddTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -79,6 +82,9 @@ class DropboxTeamBase(object):
                                                template_id):
         """
         Get the schema for a specified template.
+
+        Route attributes:
+            scope: files.team_metadata.write
 
         :param str template_id: An identifier for template added by route  See
             :meth:`file_properties_templates_add_for_user` or
@@ -103,6 +109,9 @@ class DropboxTeamBase(object):
         Get the template identifiers for a team. To get the schema of each
         template use :meth:`file_properties_templates_get_for_team`.
 
+        Route attributes:
+            scope: files.team_metadata.write
+
         :rtype: :class:`dropbox.file_properties.ListTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -125,6 +134,9 @@ class DropboxTeamBase(object):
         :meth:`file_properties_templates_add_for_user`. All properties
         associated with the template will also be removed. This action cannot be
         undone.
+
+        Route attributes:
+            scope: files.team_metadata.write
 
         :param str template_id: An identifier for a template created by
             :meth:`file_properties_templates_add_for_user` or
@@ -153,6 +165,9 @@ class DropboxTeamBase(object):
         Update a template associated with a team. This route can update the
         template name, the template description and add optional properties to
         templates.
+
+        Route attributes:
+            scope: files.team_metadata.write
 
         :param str template_id: An identifier for template added by  See
             :meth:`file_properties_templates_add_for_user` or
@@ -206,6 +221,9 @@ class DropboxTeamBase(object):
         """
         List all device sessions of a team's member.
 
+        Route attributes:
+            scope: sessions.list
+
         :param str team_member_id: The team's member id.
         :param bool include_web_sessions: Whether to list web sessions of the
             team's member.
@@ -239,6 +257,9 @@ class DropboxTeamBase(object):
         """
         List all device sessions of a team. Permission : Team member file
         access.
+
+        Route attributes:
+            scope: sessions.list
 
         :param Nullable[str] cursor: At the first call to the
             :meth:`team_devices_list_members_devices` the cursor shouldn't be
@@ -278,6 +299,9 @@ class DropboxTeamBase(object):
         List all device sessions of a team. Permission : Team member file
         access.
 
+        Route attributes:
+            scope: sessions.list
+
         :param Nullable[str] cursor: At the first call to the
             :meth:`team_devices_list_team_devices` the cursor shouldn't be
             passed. Then, if the result of the call includes a cursor, the
@@ -316,6 +340,9 @@ class DropboxTeamBase(object):
         """
         Revoke a device session of a team's member.
 
+        Route attributes:
+            scope: sessions.modify
+
         :type arg: :class:`dropbox.team.RevokeDeviceSessionArg`
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
@@ -335,6 +362,9 @@ class DropboxTeamBase(object):
                                                  revoke_devices):
         """
         Revoke a list of device sessions of team members.
+
+        Route attributes:
+            scope: sessions.modify
 
         :type revoke_devices: List[:class:`dropbox.team.RevokeDeviceSessionArg`]
         :rtype: :class:`dropbox.team.RevokeDeviceSessionBatchResult`
@@ -359,6 +389,9 @@ class DropboxTeamBase(object):
         your account's capability for what feature you can access or what value
         you have for certain features. Permission : Team information.
 
+        Route attributes:
+            scope: team_info.read
+
         :param List[:class:`dropbox.team.Feature`] features: A list of features
             in :class:`dropbox.team.Feature`. If the list is empty, this route
             will return :class:`dropbox.team.FeaturesGetValuesBatchError`.
@@ -381,6 +414,9 @@ class DropboxTeamBase(object):
         """
         Retrieves information about a team.
 
+        Route attributes:
+            scope: team_info.read
+
         :rtype: :class:`dropbox.team.TeamGetInfoResult`
         """
         arg = None
@@ -400,6 +436,9 @@ class DropboxTeamBase(object):
         """
         Creates a new, empty group, with a requested name. Permission : Team
         member management.
+
+        Route attributes:
+            scope: groups.write
 
         :param str group_name: Group name.
         :param bool add_creator_as_owner: Automatically add the creator of the
@@ -435,6 +474,9 @@ class DropboxTeamBase(object):
         :meth:`team_groups_job_status_get` to determine whether this process has
         completed. Permission : Team member management.
 
+        Route attributes:
+            scope: groups.write
+
         :param arg: Argument for selecting a single group, either by group_id or
             by external group ID.
         :type arg: :class:`dropbox.team.GroupSelector`
@@ -458,6 +500,9 @@ class DropboxTeamBase(object):
         Retrieves information about one or more groups. Note that the optional
         field  ``GroupFullInfo.members`` is not returned for system-managed
         groups. Permission : Team Information.
+
+        Route attributes:
+            scope: groups.read
 
         :param arg: Argument for selecting a list of groups, either by
             group_ids, or external group IDs.
@@ -484,6 +529,9 @@ class DropboxTeamBase(object):
         use this method to poll the status of granting/revoking group members'
         access to group-owned resources. Permission : Team member management.
 
+        Route attributes:
+            scope: groups.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.team.PollEmptyResult`
@@ -506,6 +554,9 @@ class DropboxTeamBase(object):
         """
         Lists groups on a team. Permission : Team Information.
 
+        Route attributes:
+            scope: groups.read
+
         :param int limit: Number of results to return per call.
         :rtype: :class:`dropbox.team.GroupsListResult`
         """
@@ -523,6 +574,9 @@ class DropboxTeamBase(object):
         """
         Once a cursor has been retrieved from :meth:`team_groups_list`, use this
         to paginate through all groups. Permission : Team Information.
+
+        Route attributes:
+            scope: groups.read
 
         :param str cursor: Indicates from what point to get the next set of
             groups.
@@ -551,6 +605,9 @@ class DropboxTeamBase(object):
         :meth:`team_groups_job_status_get` to determine whether this process has
         completed. Permission : Team member management.
 
+        Route attributes:
+            scope: groups.write
+
         :param group: Group to which users will be added.
         :type group: :class:`dropbox.team.GroupSelector`
         :param List[:class:`dropbox.team.MemberAccess`] members: List of users
@@ -578,6 +635,9 @@ class DropboxTeamBase(object):
         """
         Lists members of a group. Permission : Team Information.
 
+        Route attributes:
+            scope: groups.read
+
         :param group: The group whose members are to be listed.
         :type group: :class:`dropbox.team.GroupSelector`
         :param int limit: Number of results to return per call.
@@ -603,6 +663,9 @@ class DropboxTeamBase(object):
         Once a cursor has been retrieved from :meth:`team_groups_members_list`,
         use this to paginate through all members of the group. Permission : Team
         information.
+
+        Route attributes:
+            scope: groups.read
 
         :param str cursor: Indicates from what point to get the next set of
             groups.
@@ -633,6 +696,9 @@ class DropboxTeamBase(object):
         group, even in cases where this is not possible via the web client.
         Permission : Team member management.
 
+        Route attributes:
+            scope: groups.write
+
         :param group: Group from which users will be removed.
         :type group: :class:`dropbox.team.GroupSelector`
         :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users
@@ -662,6 +728,9 @@ class DropboxTeamBase(object):
         """
         Sets a member's access type in a group. Permission : Team member
         management.
+
+        Route attributes:
+            scope: groups.write
 
         :param access_type: New group access type the user will have.
         :type access_type: :class:`dropbox.team.GroupAccessType`
@@ -696,6 +765,9 @@ class DropboxTeamBase(object):
         """
         Updates a group's name and/or external ID. Permission : Team member
         management.
+
+        Route attributes:
+            scope: groups.write
 
         :param group: Specify a group.
         :type group: :class:`dropbox.team.GroupSelector`
@@ -737,6 +809,9 @@ class DropboxTeamBase(object):
         Creates new legal hold policy. Note: Legal Holds is a paid add-on. Not
         all teams have the feature. Permission : Team member file access.
 
+        Route attributes:
+            scope: team_data.member
+
         :param str name: Policy name.
         :param Nullable[str] description: A description of the legal hold
             policy.
@@ -769,6 +844,9 @@ class DropboxTeamBase(object):
         Gets a legal hold by Id. Note: Legal Holds is a paid add-on. Not all
         teams have the feature. Permission : Team member file access.
 
+        Route attributes:
+            scope: team_data.member
+
         :param str id: The legal hold Id.
         :rtype: :class:`dropbox.team.LegalHoldPolicy`
         :raises: :class:`.exceptions.ApiError`
@@ -791,6 +869,9 @@ class DropboxTeamBase(object):
         List the file metadata that's under the hold. Note: Legal Holds is a
         paid add-on. Not all teams have the feature. Permission : Team member
         file access.
+
+        Route attributes:
+            scope: team_data.member
 
         :param str id: The legal hold Id.
         :rtype: :class:`dropbox.team.LegalHoldsListHeldRevisionResult`
@@ -815,6 +896,9 @@ class DropboxTeamBase(object):
         Continue listing the file metadata that's under the hold. Note: Legal
         Holds is a paid add-on. Not all teams have the feature. Permission :
         Team member file access.
+
+        Route attributes:
+            scope: team_data.member
 
         :param str id: The legal hold Id.
         :param Nullable[str] cursor: The cursor idicates where to continue
@@ -842,6 +926,9 @@ class DropboxTeamBase(object):
         Lists legal holds on a team. Note: Legal Holds is a paid add-on. Not all
         teams have the feature. Permission : Team member file access.
 
+        Route attributes:
+            scope: team_data.member
+
         :param bool include_released: Whether to return holds that were
             released.
         :rtype: :class:`dropbox.team.LegalHoldsListPoliciesResult`
@@ -864,6 +951,9 @@ class DropboxTeamBase(object):
         """
         Releases a legal hold by Id. Note: Legal Holds is a paid add-on. Not all
         teams have the feature. Permission : Team member file access.
+
+        Route attributes:
+            scope: team_data.member
 
         :param str id: The legal hold Id.
         :rtype: None
@@ -889,6 +979,9 @@ class DropboxTeamBase(object):
         """
         Updates a legal hold. Note: Legal Holds is a paid add-on. Not all teams
         have the feature. Permission : Team member file access.
+
+        Route attributes:
+            scope: team_data.member
 
         :param str id: The legal hold Id.
         :param Nullable[str] name: Policy new name.
@@ -919,6 +1012,9 @@ class DropboxTeamBase(object):
         List all linked applications of the team member. Note, this endpoint
         does not list any team-linked applications.
 
+        Route attributes:
+            scope: sessions.list
+
         :param str team_member_id: The team member id.
         :rtype: :class:`dropbox.team.ListMemberAppsResult`
         :raises: :class:`.exceptions.ApiError`
@@ -940,6 +1036,9 @@ class DropboxTeamBase(object):
         """
         List all applications linked to the team members' accounts. Note, this
         endpoint does not list any team-linked applications.
+
+        Route attributes:
+            scope: sessions.list
 
         :param Nullable[str] cursor: At the first call to the
             :meth:`team_linked_apps_list_members_linked_apps` the cursor
@@ -966,6 +1065,9 @@ class DropboxTeamBase(object):
         """
         List all applications linked to the team members' accounts. Note, this
         endpoint doesn't list any team-linked applications.
+
+        Route attributes:
+            scope: sessions.list
 
         :param Nullable[str] cursor: At the first call to the
             :meth:`team_linked_apps_list_team_linked_apps` the cursor shouldn't
@@ -998,6 +1100,9 @@ class DropboxTeamBase(object):
         """
         Revoke a linked application of the team member.
 
+        Route attributes:
+            scope: sessions.modify
+
         :param str app_id: The application's unique id.
         :param str team_member_id: The unique id of the member owning the
             device.
@@ -1026,6 +1131,9 @@ class DropboxTeamBase(object):
         """
         Revoke a list of linked applications of the team members.
 
+        Route attributes:
+            scope: sessions.modify
+
         :type revoke_linked_app:
         List[:class:`dropbox.team.RevokeLinkedApiAppArg`]
         :rtype: :class:`dropbox.team.RevokeLinkedAppBatchResult`
@@ -1047,6 +1155,9 @@ class DropboxTeamBase(object):
                                                     users=None):
         """
         Add users to member space limits excluded users list.
+
+        Route attributes:
+            scope: members.write
 
         :param Nullable[List[:class:`dropbox.team.UserSelectorArg`]] users: List
             of users to be added/removed.
@@ -1070,6 +1181,9 @@ class DropboxTeamBase(object):
         """
         List member space limits excluded users.
 
+        Route attributes:
+            scope: members.read
+
         :param int limit: Number of results to return per call.
         :rtype: :class:`dropbox.team.ExcludedUsersListResult`
         :raises: :class:`.exceptions.ApiError`
@@ -1090,6 +1204,9 @@ class DropboxTeamBase(object):
                                                               cursor):
         """
         Continue listing member space limits excluded users.
+
+        Route attributes:
+            scope: members.read
 
         :param str cursor: Indicates from what point to get the next set of
             users.
@@ -1112,6 +1229,9 @@ class DropboxTeamBase(object):
                                                        users=None):
         """
         Remove users from member space limits excluded users list.
+
+        Route attributes:
+            scope: members.write
 
         :param Nullable[List[:class:`dropbox.team.UserSelectorArg`]] users: List
             of users to be added/removed.
@@ -1136,6 +1256,9 @@ class DropboxTeamBase(object):
         Get users custom quota. Returns none as the custom quota if none was
         set. A maximum of 1000 members can be specified in a single call.
 
+        Route attributes:
+            scope: members.read
+
         :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users.
         :rtype: List[:class:`dropbox.team.CustomQuotaResult`]
         :raises: :class:`.exceptions.ApiError`
@@ -1158,6 +1281,9 @@ class DropboxTeamBase(object):
         Remove users custom quota. A maximum of 1000 members can be specified in
         a single call.
 
+        Route attributes:
+            scope: members.write
+
         :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users.
         :rtype: List[:class:`dropbox.team.RemoveCustomQuotaResult`]
         :raises: :class:`.exceptions.ApiError`
@@ -1179,6 +1305,9 @@ class DropboxTeamBase(object):
         """
         Set users custom quota. Custom quota has to be at least 15GB. A maximum
         of 1000 members can be specified in a single call.
+
+        Route attributes:
+            scope: members.read
 
         :param List[:class:`dropbox.team.UserCustomQuotaArg`] users_and_quotas:
             List of users and their custom quotas.
@@ -1213,6 +1342,9 @@ class DropboxTeamBase(object):
         for a user to use in the team invitation and for 'Perform as team
         member' actions taken on the user before they become 'active'.
 
+        Route attributes:
+            scope: members.write
+
         :param List[:class:`dropbox.team.MemberAddV2Arg`] new_members: Details
             of new members to be added to the team.
         :rtype: :class:`dropbox.team.MembersAddLaunchV2Result`
@@ -1243,6 +1375,9 @@ class DropboxTeamBase(object):
         for a user to use in the team invitation and for 'Perform as team
         member' actions taken on the user before they become 'active'.
 
+        Route attributes:
+            scope: members.write
+
         :param List[:class:`dropbox.team.MemberAddArg`] new_members: Details of
             new members to be added to the team.
         :rtype: :class:`dropbox.team.MembersAddLaunch`
@@ -1263,6 +1398,9 @@ class DropboxTeamBase(object):
         Once an async_job_id is returned from :meth:`team_members_add_v2` , use
         this to poll the status of the asynchronous request. Permission : Team
         member management.
+
+        Route attributes:
+            scope: members.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -1288,6 +1426,9 @@ class DropboxTeamBase(object):
         this to poll the status of the asynchronous request. Permission : Team
         member management.
 
+        Route attributes:
+            scope: members.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.team.MembersAddJobStatus`
@@ -1310,6 +1451,9 @@ class DropboxTeamBase(object):
         """
         Deletes a team member's profile photo. Permission : Team member
         management.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of the user whose profile photo will be deleted.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1334,6 +1478,9 @@ class DropboxTeamBase(object):
         Deletes a team member's profile photo. Permission : Team member
         management.
 
+        Route attributes:
+            scope: members.write
+
         :param user: Identity of the user whose profile photo will be deleted.
         :type user: :class:`dropbox.team.UserSelectorArg`
         :rtype: :class:`dropbox.team.TeamMemberInfo`
@@ -1357,6 +1504,9 @@ class DropboxTeamBase(object):
         :meth:`team_members_set_admin_permissions_v2`. Permission : Team member
         management.
 
+        Route attributes:
+            scope: members.read
+
         :rtype: :class:`dropbox.team.MembersGetAvailableTeamMemberRolesResult`
         """
         arg = None
@@ -1375,6 +1525,9 @@ class DropboxTeamBase(object):
         information This endpoint will return
         ``MembersGetInfoItem.id_not_found``, for IDs (or emails) that cannot be
         matched to a valid team member.
+
+        Route attributes:
+            scope: members.read
 
         :param List[:class:`dropbox.team.UserSelectorArg`] members: List of team
             members.
@@ -1401,6 +1554,9 @@ class DropboxTeamBase(object):
         ``MembersGetInfoItem.id_not_found``, for IDs (or emails) that cannot be
         matched to a valid team member.
 
+        Route attributes:
+            scope: members.read
+
         :param List[:class:`dropbox.team.UserSelectorArg`] members: List of team
             members.
         :rtype: List[:class:`dropbox.team.MembersGetInfoItem`]
@@ -1423,6 +1579,9 @@ class DropboxTeamBase(object):
                              include_removed=False):
         """
         Lists members of a team. Permission : Team information.
+
+        Route attributes:
+            scope: members.read
 
         :param int limit: Number of results to return per call.
         :param bool include_removed: Whether to return removed members.
@@ -1447,6 +1606,9 @@ class DropboxTeamBase(object):
                           include_removed=False):
         """
         Lists members of a team. Permission : Team information.
+
+        Route attributes:
+            scope: members.read
 
         :param int limit: Number of results to return per call.
         :param bool include_removed: Whether to return removed members.
@@ -1473,6 +1635,9 @@ class DropboxTeamBase(object):
         this to paginate through all team members. Permission : Team
         information.
 
+        Route attributes:
+            scope: members.read
+
         :param str cursor: Indicates from what point to get the next set of
             members.
         :rtype: :class:`dropbox.team.MembersListV2Result`
@@ -1496,6 +1661,9 @@ class DropboxTeamBase(object):
         Once a cursor has been retrieved from :meth:`team_members_list`, use
         this to paginate through all team members. Permission : Team
         information.
+
+        Route attributes:
+            scope: members.read
 
         :param str cursor: Indicates from what point to get the next set of
             members.
@@ -1524,6 +1692,9 @@ class DropboxTeamBase(object):
         the client should periodically poll
         :meth:`team_members_move_former_member_files_job_status_check`.
         Permission : Team member management.
+
+        Route attributes:
+            scope: members.write
 
         :param transfer_dest_id: Files from the deleted member account will be
             transferred to this user.
@@ -1555,6 +1726,9 @@ class DropboxTeamBase(object):
         :meth:`team_members_move_former_member_files` , use this to poll the
         status of the asynchronous request. Permission : Team member management.
 
+        Route attributes:
+            scope: members.write
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.team.PollEmptyResult`
@@ -1578,6 +1752,9 @@ class DropboxTeamBase(object):
         Recover a deleted member. Permission : Team member management Exactly
         one of team_member_id, email, or external_id must be provided to
         identify the user account.
+
+        Route attributes:
+            scope: members.delete
 
         :param user: Identity of user to recover.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1617,6 +1794,9 @@ class DropboxTeamBase(object):
         teams). This endpoint may initiate an asynchronous job. To obtain the
         final result of the job, the client should periodically poll
         :meth:`team_members_remove_job_status_get`.
+
+        Route attributes:
+            scope: members.delete
 
         :param Nullable[:class:`dropbox.team.UserSelectorArg`] transfer_dest_id:
             If provided, files from the deleted member account will be
@@ -1664,6 +1844,9 @@ class DropboxTeamBase(object):
         this to poll the status of the asynchronous request. Permission : Team
         member management.
 
+        Route attributes:
+            scope: members.delete
+
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
         :rtype: :class:`dropbox.team.PollEmptyResult`
@@ -1689,6 +1872,9 @@ class DropboxTeamBase(object):
         each email address not on a verified domain a verification email will be
         sent.
 
+        Route attributes:
+            scope: members.write
+
         :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
             new_secondary_emails: List of users and secondary emails to add.
         :rtype: :class:`dropbox.team.AddSecondaryEmailsResult`
@@ -1713,6 +1899,9 @@ class DropboxTeamBase(object):
         Users will be notified of deletions of verified secondary emails at both
         the secondary email and their primary email.
 
+        Route attributes:
+            scope: members.write
+
         :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
             emails_to_delete: List of users and their secondary emails to
             delete.
@@ -1732,6 +1921,9 @@ class DropboxTeamBase(object):
         """
         Resend secondary email verification emails. Permission : Team member
         management.
+
+        Route attributes:
+            scope: members.write
 
         :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
             emails_to_resend: List of users and secondary emails to resend
@@ -1754,6 +1946,9 @@ class DropboxTeamBase(object):
         management Exactly one of team_member_id, email, or external_id must be
         provided to identify the user account. No-op if team member is not
         pending.
+
+        Route attributes:
+            scope: members.write
 
         :param arg: Argument for selecting a single user, either by
             team_member_id, external_id or email.
@@ -1778,6 +1973,9 @@ class DropboxTeamBase(object):
         """
         Updates a team member's permissions. Permission : Team member
         management.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of user whose role will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1806,6 +2004,9 @@ class DropboxTeamBase(object):
         """
         Updates a team member's permissions. Permission : Team member
         management.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of user whose role will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1837,6 +2038,9 @@ class DropboxTeamBase(object):
                                     new_is_directory_restricted=None):
         """
         Updates a team member's profile. Permission : Team member management.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of user whose profile will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1880,6 +2084,9 @@ class DropboxTeamBase(object):
         """
         Updates a team member's profile. Permission : Team member management.
 
+        Route attributes:
+            scope: members.write
+
         :param user: Identity of user whose profile will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
         :param Nullable[str] new_email: New email for member.
@@ -1918,6 +2125,9 @@ class DropboxTeamBase(object):
         Updates a team member's profile photo. Permission : Team member
         management.
 
+        Route attributes:
+            scope: members.write
+
         :param user: Identity of the user whose profile photo will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
         :param photo: Image to set as the member's new profile photo.
@@ -1944,6 +2154,9 @@ class DropboxTeamBase(object):
         """
         Updates a team member's profile photo. Permission : Team member
         management.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of the user whose profile photo will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -1973,6 +2186,9 @@ class DropboxTeamBase(object):
         Exactly one of team_member_id, email, or external_id must be provided to
         identify the user account.
 
+        Route attributes:
+            scope: members.write
+
         :param bool wipe_data: If provided, controls if the user's data will be
             deleted on their linked devices.
         :rtype: None
@@ -1997,6 +2213,9 @@ class DropboxTeamBase(object):
         Unsuspend a member from a team. Permission : Team member management
         Exactly one of team_member_id, email, or external_id must be provided to
         identify the user account.
+
+        Route attributes:
+            scope: members.write
 
         :param user: Identity of user to unsuspend.
         :type user: :class:`dropbox.team.UserSelectorArg`
@@ -2025,6 +2244,9 @@ class DropboxTeamBase(object):
         folders may be owned by other users or other teams. Duplicates may occur
         in the list.
 
+        Route attributes:
+            scope: team_data.member
+
         :param int limit: Specifying a value here has no effect.
         :rtype: :class:`dropbox.team.TeamNamespacesListResult`
         :raises: :class:`.exceptions.ApiError`
@@ -2047,6 +2269,9 @@ class DropboxTeamBase(object):
         Once a cursor has been retrieved from :meth:`team_namespaces_list`, use
         this to paginate through all team-accessible namespaces. Duplicates may
         occur in the list.
+
+        Route attributes:
+            scope: team_data.member
 
         :param str cursor: Indicates from what point to get the next set of
             team-accessible namespaces.
@@ -2071,6 +2296,9 @@ class DropboxTeamBase(object):
                                      fields):
         """
         Permission : Team member file access.
+
+        Route attributes:
+            scope: files.team_metadata.write
 
         :rtype: :class:`dropbox.team.AddTemplateResult`
         :raises: :class:`.exceptions.ApiError`
@@ -2099,6 +2327,9 @@ class DropboxTeamBase(object):
         Permission : Team member file access. The scope for the route is
         files.team_metadata.write.
 
+        Route attributes:
+            scope: files.team_metadata.write
+
         :param str template_id: An identifier for template added by route  See
             :meth:`team_templates_add_for_user` or
             :meth:`team_templates_add_for_team`.
@@ -2126,6 +2357,9 @@ class DropboxTeamBase(object):
         Permission : Team member file access. The scope for the route is
         files.team_metadata.write.
 
+        Route attributes:
+            scope: files.team_metadata.write
+
         :rtype: :class:`dropbox.team.ListTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2152,6 +2386,9 @@ class DropboxTeamBase(object):
                                         add_fields=None):
         """
         Permission : Team member file access.
+
+        Route attributes:
+            scope: files.team_metadata.write
 
         :param str template_id: An identifier for template added by  See
             :meth:`team_templates_add_for_user` or
@@ -2192,6 +2429,9 @@ class DropboxTeamBase(object):
         Retrieves reporting data about a team's user activity. Deprecated: Will
         be removed on July 1st 2021.
 
+        Route attributes:
+            scope: team_info.read
+
         :param Nullable[datetime] start_date: Optional starting date
             (inclusive). If start_date is None or too long ago, this field will
             be set to 6 months ago.
@@ -2222,6 +2462,9 @@ class DropboxTeamBase(object):
         """
         Retrieves reporting data about a team's linked devices. Deprecated: Will
         be removed on July 1st 2021.
+
+        Route attributes:
+            scope: team_info.read
 
         :param Nullable[datetime] start_date: Optional starting date
             (inclusive). If start_date is None or too long ago, this field will
@@ -2254,6 +2497,9 @@ class DropboxTeamBase(object):
         Retrieves reporting data about a team's membership. Deprecated: Will be
         removed on July 1st 2021.
 
+        Route attributes:
+            scope: team_info.read
+
         :param Nullable[datetime] start_date: Optional starting date
             (inclusive). If start_date is None or too long ago, this field will
             be set to 6 months ago.
@@ -2285,6 +2531,9 @@ class DropboxTeamBase(object):
         Retrieves reporting data about a team's storage usage. Deprecated: Will
         be removed on July 1st 2021.
 
+        Route attributes:
+            scope: team_info.read
+
         :param Nullable[datetime] start_date: Optional starting date
             (inclusive). If start_date is None or too long ago, this field will
             be set to 6 months ago.
@@ -2315,6 +2564,9 @@ class DropboxTeamBase(object):
         Sets an archived team folder's status to active. Permission : Team
         member file access.
 
+        Route attributes:
+            scope: team_data.team_space
+
         :param str team_folder_id: The ID of the team folder.
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         """
@@ -2335,6 +2587,9 @@ class DropboxTeamBase(object):
         and file members. This endpoint cannot be used for teams that have a
         shared team space. Permission : Team member file access.
 
+        Route attributes:
+            scope: team_data.team_space
+
         :param bool force_async_off: Whether to force the archive to happen
             synchronously.
         :rtype: :class:`dropbox.team.TeamFolderArchiveLaunch`
@@ -2354,6 +2609,9 @@ class DropboxTeamBase(object):
         """
         Returns the status of an asynchronous job for archiving a team folder.
         Permission : Team member file access.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -2379,6 +2637,9 @@ class DropboxTeamBase(object):
         Creates a new, active, team folder with no members. This endpoint can
         only be used for teams that do not already have a shared team space.
         Permission : Team member file access.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param str name: Name for the new team folder.
         :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: The
@@ -2406,6 +2667,9 @@ class DropboxTeamBase(object):
         Retrieves metadata for team folders. Permission : Team member file
         access.
 
+        Route attributes:
+            scope: team_data.team_space
+
         :param List[str] team_folder_ids: The list of team folder IDs.
         :rtype: List[:class:`dropbox.team.TeamFolderGetInfoItem`]
         """
@@ -2422,6 +2686,9 @@ class DropboxTeamBase(object):
                               limit=1000):
         """
         Lists all team folders. Permission : Team member file access.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param int limit: The maximum number of results to return per request.
         :rtype: :class:`dropbox.team.TeamFolderListResult`
@@ -2445,6 +2712,9 @@ class DropboxTeamBase(object):
         Once a cursor has been retrieved from :meth:`team_team_folder_list`, use
         this to paginate through all team folders. Permission : Team member file
         access.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param str cursor: Indicates from what point to get the next set of team
             folders.
@@ -2470,6 +2740,9 @@ class DropboxTeamBase(object):
         used for teams that have a shared team space. Permission : Team member
         file access.
 
+        Route attributes:
+            scope: team_data.team_space
+
         :param str team_folder_id: The ID of the team folder.
         :rtype: None
         """
@@ -2488,6 +2761,9 @@ class DropboxTeamBase(object):
         """
         Changes an active team folder's name. Permission : Team member file
         access.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param str name: New team folder name.
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
@@ -2513,6 +2789,9 @@ class DropboxTeamBase(object):
         """
         Updates the sync settings on a team folder or its contents.  Use of this
         endpoint requires that the team has team selective sync enabled.
+
+        Route attributes:
+            scope: team_data.team_space
 
         :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: Sync
             setting to apply to the team folder itself. Only meaningful if the
@@ -2541,6 +2820,9 @@ class DropboxTeamBase(object):
         """
         Returns the member profile of the admin who generated the team access
         token used to make the call.
+
+        Route attributes:
+            scope: team_info.read
 
         :rtype: :class:`dropbox.team.TokenGetAuthenticatedAdminResult`
         :raises: :class:`.exceptions.ApiError`
@@ -2578,6 +2860,9 @@ class DropboxTeamBase(object):
         `features/get_values
         </developers/documentation/http/teams#team-features-get_values>`_ to
         check for this feature. Permission : Team Auditing.
+
+        Route attributes:
+            scope: events.read
 
         :param int limit: The maximal number of results to return per call. Note
             that some calls may not return ``limit`` number of events, and may
@@ -2619,6 +2904,9 @@ class DropboxTeamBase(object):
         """
         Once a cursor has been retrieved from :meth:`team_log_get_events`, use
         this to paginate through all events. Permission : Team Auditing.
+
+        Route attributes:
+            scope: events.read
 
         :param str cursor: Indicates from what point to get the next set of
             events.

--- a/dropbox/check.py
+++ b/dropbox/check.py
@@ -71,8 +71,8 @@ EchoResult.result.validator = bv.String()
 EchoResult._all_field_names_ = set(['result'])
 EchoResult._all_fields_ = [('result', EchoResult.result.validator)]
 
-EchoArg.query.default = u''
-EchoResult.result.default = u''
+EchoArg.query.default = ''
+EchoResult.result.default = ''
 app = bb.Route(
     'app',
     1,
@@ -80,9 +80,9 @@ app = bb.Route(
     EchoArg_validator,
     EchoResult_validator,
     bv.Void(),
-    {'auth': u'app',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'app',
+     'host': 'api',
+     'style': 'rpc'},
 )
 user = bb.Route(
     'user',
@@ -91,9 +91,9 @@ user = bb.Route(
     EchoArg_validator,
     EchoResult_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/common.py
+++ b/dropbox/common.py
@@ -283,16 +283,16 @@ class UserRootInfo(RootInfo):
 
 UserRootInfo_validator = bv.Struct(UserRootInfo)
 
-Date_validator = bv.Timestamp(u'%Y-%m-%d')
-DisplayName_validator = bv.String(pattern=u'[^/:?*<>"|]*')
+Date_validator = bv.Timestamp('%Y-%m-%d')
+DisplayName_validator = bv.String(pattern='[^/:?*<>"|]*')
 DisplayNameLegacy_validator = bv.String()
-DropboxTimestamp_validator = bv.Timestamp(u'%Y-%m-%dT%H:%M:%SZ')
-EmailAddress_validator = bv.String(max_length=255, pattern=u"^['#&A-Za-z0-9._%+-]+@[A-Za-z0-9-][A-Za-z0-9.-]*\\.[A-Za-z]{2,15}$")
+DropboxTimestamp_validator = bv.Timestamp('%Y-%m-%dT%H:%M:%SZ')
+EmailAddress_validator = bv.String(max_length=255, pattern="^['#&A-Za-z0-9._%+-]+@[A-Za-z0-9-][A-Za-z0-9.-]*\\.[A-Za-z]{2,15}$")
 # A ISO639-1 code.
 LanguageCode_validator = bv.String(min_length=2)
-NamePart_validator = bv.String(min_length=1, max_length=100, pattern=u'[^/:?*<>"|]*')
-NamespaceId_validator = bv.String(pattern=u'[-_0-9a-zA-Z:]+')
-OptionalNamePart_validator = bv.String(max_length=100, pattern=u'[^/:?*<>"|]*')
+NamePart_validator = bv.String(min_length=1, max_length=100, pattern='[^/:?*<>"|]*')
+NamespaceId_validator = bv.String(pattern='[-_0-9a-zA-Z:]+')
+OptionalNamePart_validator = bv.String(max_length=100, pattern='[^/:?*<>"|]*')
 SessionId_validator = bv.String()
 SharedFolderId_validator = NamespaceId_validator
 PathRoot._home_validator = bv.Void()
@@ -335,12 +335,12 @@ RootInfo._fields_ = [
 RootInfo._all_fields_ = RootInfo._fields_
 
 RootInfo._tag_to_subtype_ = {
-    (u'team',): TeamRootInfo_validator,
-    (u'user',): UserRootInfo_validator,
+    ('team',): TeamRootInfo_validator,
+    ('user',): UserRootInfo_validator,
 }
 RootInfo._pytype_to_tag_and_subtype_ = {
-    TeamRootInfo: ((u'team',), TeamRootInfo_validator),
-    UserRootInfo: ((u'user',), UserRootInfo_validator),
+    TeamRootInfo: (('team',), TeamRootInfo_validator),
+    UserRootInfo: (('user',), UserRootInfo_validator),
 }
 RootInfo._is_catch_all_ = True
 

--- a/dropbox/contacts.py
+++ b/dropbox/contacts.py
@@ -115,9 +115,9 @@ delete_manual_contacts = bb.Route(
     bv.Void(),
     bv.Void(),
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete_manual_contacts_batch = bb.Route(
     'delete_manual_contacts_batch',
@@ -126,9 +126,9 @@ delete_manual_contacts_batch = bb.Route(
     DeleteManualContactsArg_validator,
     bv.Void(),
     DeleteManualContactsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/file_properties.py
+++ b/dropbox/file_properties.py
@@ -1704,9 +1704,9 @@ class UpdateTemplateResult(bb.Struct):
 UpdateTemplateResult_validator = bv.Struct(UpdateTemplateResult)
 
 Id_validator = bv.String(min_length=1)
-PathOrId_validator = bv.String(pattern=u'/(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)')
+PathOrId_validator = bv.String(pattern='/(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)')
 PropertiesSearchCursor_validator = bv.String(min_length=1)
-TemplateId_validator = bv.String(min_length=1, pattern=u'(/|ptid:).*')
+TemplateId_validator = bv.String(min_length=1, pattern='(/|ptid:).*')
 AddPropertiesArg.path.validator = PathOrId_validator
 AddPropertiesArg.property_groups.validator = bv.List(PropertyGroup_validator)
 AddPropertiesArg._all_field_names_ = set([
@@ -2106,9 +2106,9 @@ properties_add = bb.Route(
     AddPropertiesArg_validator,
     bv.Void(),
     AddPropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_overwrite = bb.Route(
     'properties/overwrite',
@@ -2117,9 +2117,9 @@ properties_overwrite = bb.Route(
     OverwritePropertyGroupArg_validator,
     bv.Void(),
     InvalidPropertyGroupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_remove = bb.Route(
     'properties/remove',
@@ -2128,9 +2128,9 @@ properties_remove = bb.Route(
     RemovePropertiesArg_validator,
     bv.Void(),
     RemovePropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_search = bb.Route(
     'properties/search',
@@ -2139,9 +2139,9 @@ properties_search = bb.Route(
     PropertiesSearchArg_validator,
     PropertiesSearchResult_validator,
     PropertiesSearchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_search_continue = bb.Route(
     'properties/search/continue',
@@ -2150,9 +2150,9 @@ properties_search_continue = bb.Route(
     PropertiesSearchContinueArg_validator,
     PropertiesSearchResult_validator,
     PropertiesSearchContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_update = bb.Route(
     'properties/update',
@@ -2161,9 +2161,9 @@ properties_update = bb.Route(
     UpdatePropertiesArg_validator,
     bv.Void(),
     UpdatePropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_add_for_team = bb.Route(
     'templates/add_for_team',
@@ -2172,9 +2172,9 @@ templates_add_for_team = bb.Route(
     AddTemplateArg_validator,
     AddTemplateResult_validator,
     ModifyTemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_add_for_user = bb.Route(
     'templates/add_for_user',
@@ -2183,9 +2183,9 @@ templates_add_for_user = bb.Route(
     AddTemplateArg_validator,
     AddTemplateResult_validator,
     ModifyTemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_get_for_team = bb.Route(
     'templates/get_for_team',
@@ -2194,9 +2194,9 @@ templates_get_for_team = bb.Route(
     GetTemplateArg_validator,
     GetTemplateResult_validator,
     TemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_get_for_user = bb.Route(
     'templates/get_for_user',
@@ -2205,9 +2205,9 @@ templates_get_for_user = bb.Route(
     GetTemplateArg_validator,
     GetTemplateResult_validator,
     TemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_list_for_team = bb.Route(
     'templates/list_for_team',
@@ -2216,9 +2216,9 @@ templates_list_for_team = bb.Route(
     bv.Void(),
     ListTemplateResult_validator,
     TemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_list_for_user = bb.Route(
     'templates/list_for_user',
@@ -2227,9 +2227,9 @@ templates_list_for_user = bb.Route(
     bv.Void(),
     ListTemplateResult_validator,
     TemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_remove_for_team = bb.Route(
     'templates/remove_for_team',
@@ -2238,9 +2238,9 @@ templates_remove_for_team = bb.Route(
     RemoveTemplateArg_validator,
     bv.Void(),
     TemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_remove_for_user = bb.Route(
     'templates/remove_for_user',
@@ -2249,9 +2249,9 @@ templates_remove_for_user = bb.Route(
     RemoveTemplateArg_validator,
     bv.Void(),
     TemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_update_for_team = bb.Route(
     'templates/update_for_team',
@@ -2260,9 +2260,9 @@ templates_update_for_team = bb.Route(
     UpdateTemplateArg_validator,
     UpdateTemplateResult_validator,
     ModifyTemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 templates_update_for_user = bb.Route(
     'templates/update_for_user',
@@ -2271,9 +2271,9 @@ templates_update_for_user = bb.Route(
     UpdateTemplateArg_validator,
     UpdateTemplateResult_validator,
     ModifyTemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/file_requests.py
+++ b/dropbox/file_requests.py
@@ -1029,7 +1029,7 @@ class UpdateFileRequestError(FileRequestError):
 
 UpdateFileRequestError_validator = bv.Union(UpdateFileRequestError)
 
-FileRequestId_validator = bv.String(min_length=1, pattern=u'[-_0-9a-zA-Z]+')
+FileRequestId_validator = bv.String(min_length=1, pattern='[-_0-9a-zA-Z]+')
 FileRequestValidationError_validator = bv.Nullable(bv.String())
 GeneralFileRequestsError._disabled_for_team_validator = bv.Void()
 GeneralFileRequestsError._other_validator = bv.Void()
@@ -1287,9 +1287,9 @@ count = bb.Route(
     bv.Void(),
     CountFileRequestsResult_validator,
     CountFileRequestsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create = bb.Route(
     'create',
@@ -1298,9 +1298,9 @@ create = bb.Route(
     CreateFileRequestArgs_validator,
     FileRequest_validator,
     CreateFileRequestError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete = bb.Route(
     'delete',
@@ -1309,9 +1309,9 @@ delete = bb.Route(
     DeleteFileRequestArgs_validator,
     DeleteFileRequestsResult_validator,
     DeleteFileRequestError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete_all_closed = bb.Route(
     'delete_all_closed',
@@ -1320,9 +1320,9 @@ delete_all_closed = bb.Route(
     bv.Void(),
     DeleteAllClosedFileRequestsResult_validator,
     DeleteAllClosedFileRequestsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get = bb.Route(
     'get',
@@ -1331,9 +1331,9 @@ get = bb.Route(
     GetFileRequestArgs_validator,
     FileRequest_validator,
     GetFileRequestError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_v2 = bb.Route(
     'list',
@@ -1342,9 +1342,9 @@ list_v2 = bb.Route(
     ListFileRequestsArg_validator,
     ListFileRequestsV2Result_validator,
     ListFileRequestsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list = bb.Route(
     'list',
@@ -1353,9 +1353,9 @@ list = bb.Route(
     bv.Void(),
     ListFileRequestsResult_validator,
     ListFileRequestsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_continue = bb.Route(
     'list/continue',
@@ -1364,9 +1364,9 @@ list_continue = bb.Route(
     ListFileRequestsContinueArg_validator,
     ListFileRequestsV2Result_validator,
     ListFileRequestsContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 update = bb.Route(
     'update',
@@ -1375,9 +1375,9 @@ update = bb.Route(
     UpdateFileRequestArgs_validator,
     FileRequest_validator,
     UpdateFileRequestError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/files.py
+++ b/dropbox/files.py
@@ -5093,6 +5093,43 @@ class MoveBatchArg(RelocationBatchArgBase):
 
 MoveBatchArg_validator = bv.Struct(MoveBatchArg)
 
+class MoveIntoFamilyError(bb.Union):
+    """
+    This class acts as a tagged union. Only one of the ``is_*`` methods will
+    return true. To get the associated value of a tag (if one exists), use the
+    corresponding ``get_*`` method.
+
+    :ivar files.MoveIntoFamilyError.is_shared_folder: Moving shared folder into
+        Family Room folder is not allowed.
+    """
+
+    _catch_all = 'other'
+    # Attribute is overwritten below the class definition
+    is_shared_folder = None
+    # Attribute is overwritten below the class definition
+    other = None
+
+    def is_is_shared_folder(self):
+        """
+        Check if the union tag is ``is_shared_folder``.
+
+        :rtype: bool
+        """
+        return self._tag == 'is_shared_folder'
+
+    def is_other(self):
+        """
+        Check if the union tag is ``other``.
+
+        :rtype: bool
+        """
+        return self._tag == 'other'
+
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
+        super(MoveIntoFamilyError, self)._process_custom_annotations(annotation_type, field_path, processor)
+
+MoveIntoFamilyError_validator = bv.Union(MoveIntoFamilyError)
+
 class MoveIntoVaultError(bb.Union):
     """
     This class acts as a tagged union. Only one of the ``is_*`` methods will
@@ -6041,6 +6078,9 @@ class RelocationError(bb.Union):
     :ivar MoveIntoVaultError RelocationError.cant_move_into_vault: Some content
         cannot be moved into Vault under certain circumstances, see detailed
         error.
+    :ivar MoveIntoFamilyError RelocationError.cant_move_into_family: Some
+        content cannot be moved into the Family Room folder under certain
+        circumstances, see detailed error.
     """
 
     _catch_all = 'other'
@@ -6108,6 +6148,17 @@ class RelocationError(bb.Union):
         :rtype: RelocationError
         """
         return cls('cant_move_into_vault', val)
+
+    @classmethod
+    def cant_move_into_family(cls, val):
+        """
+        Create an instance of this class set to the ``cant_move_into_family``
+        tag with value ``val``.
+
+        :param MoveIntoFamilyError val:
+        :rtype: RelocationError
+        """
+        return cls('cant_move_into_family', val)
 
     def is_from_lookup(self):
         """
@@ -6213,6 +6264,14 @@ class RelocationError(bb.Union):
         """
         return self._tag == 'cant_move_into_vault'
 
+    def is_cant_move_into_family(self):
+        """
+        Check if the union tag is ``cant_move_into_family``.
+
+        :rtype: bool
+        """
+        return self._tag == 'cant_move_into_family'
+
     def is_other(self):
         """
         Check if the union tag is ``other``.
@@ -6262,6 +6321,19 @@ class RelocationError(bb.Union):
         """
         if not self.is_cant_move_into_vault():
             raise AttributeError("tag 'cant_move_into_vault' not set")
+        return self._value
+
+    def get_cant_move_into_family(self):
+        """
+        Some content cannot be moved into the Family Room folder under certain
+        circumstances, see detailed error.
+
+        Only call this if :meth:`is_cant_move_into_family` is true.
+
+        :rtype: MoveIntoFamilyError
+        """
+        if not self.is_cant_move_into_family():
+            raise AttributeError("tag 'cant_move_into_family' not set")
         return self._value
 
     def _process_custom_annotations(self, annotation_type, field_path, processor):
@@ -9155,9 +9227,13 @@ class UploadError(bb.Union):
     :ivar InvalidPropertyGroupError UploadError.properties_error: The supplied
         property group is invalid. The file has uploaded without property
         groups.
+    :ivar files.UploadError.payload_too_large: The request payload must be at
+        most 150 MB.
     """
 
     _catch_all = 'other'
+    # Attribute is overwritten below the class definition
+    payload_too_large = None
     # Attribute is overwritten below the class definition
     other = None
 
@@ -9198,6 +9274,14 @@ class UploadError(bb.Union):
         :rtype: bool
         """
         return self._tag == 'properties_error'
+
+    def is_payload_too_large(self):
+        """
+        Check if the union tag is ``payload_too_large``.
+
+        :rtype: bool
+        """
+        return self._tag == 'payload_too_large'
 
     def is_other(self):
         """
@@ -9619,6 +9703,8 @@ class UploadSessionFinishError(bb.Union):
         Concurrent upload sessions need to be closed before finishing.
     :ivar files.UploadSessionFinishError.concurrent_session_missing_data: Not
         all pieces of data were uploaded before trying to finish the session.
+    :ivar files.UploadSessionFinishError.payload_too_large: The request payload
+        must be at most 150 MB.
     """
 
     _catch_all = 'other'
@@ -9632,6 +9718,8 @@ class UploadSessionFinishError(bb.Union):
     concurrent_session_not_closed = None
     # Attribute is overwritten below the class definition
     concurrent_session_missing_data = None
+    # Attribute is overwritten below the class definition
+    payload_too_large = None
     # Attribute is overwritten below the class definition
     other = None
 
@@ -9732,6 +9820,14 @@ class UploadSessionFinishError(bb.Union):
         """
         return self._tag == 'concurrent_session_missing_data'
 
+    def is_payload_too_large(self):
+        """
+        Check if the union tag is ``payload_too_large``.
+
+        :rtype: bool
+        """
+        return self._tag == 'payload_too_large'
+
     def is_other(self):
         """
         Check if the union tag is ``other``.
@@ -9810,6 +9906,8 @@ class UploadSessionLookupError(bb.Union):
     :ivar files.UploadSessionLookupError.concurrent_session_invalid_data_size:
         For concurrent upload sessions, only chunks with size multiple of
         4194304 bytes can be uploaded.
+    :ivar files.UploadSessionLookupError.payload_too_large: The request payload
+        must be at most 150 MB.
     """
 
     _catch_all = 'other'
@@ -9825,6 +9923,8 @@ class UploadSessionLookupError(bb.Union):
     concurrent_session_invalid_offset = None
     # Attribute is overwritten below the class definition
     concurrent_session_invalid_data_size = None
+    # Attribute is overwritten below the class definition
+    payload_too_large = None
     # Attribute is overwritten below the class definition
     other = None
 
@@ -9894,6 +9994,14 @@ class UploadSessionLookupError(bb.Union):
         :rtype: bool
         """
         return self._tag == 'concurrent_session_invalid_data_size'
+
+    def is_payload_too_large(self):
+        """
+        Check if the union tag is ``payload_too_large``.
+
+        :rtype: bool
+        """
+        return self._tag == 'payload_too_large'
 
     def is_other(self):
         """
@@ -9998,6 +10106,8 @@ class UploadSessionStartError(bb.Union):
         Uploading data not allowed when starting concurrent upload session.
     :ivar files.UploadSessionStartError.concurrent_session_close_not_allowed:
         Can not start a closed concurrent upload session.
+    :ivar files.UploadSessionStartError.payload_too_large: The request payload
+        must be at most 150 MB.
     """
 
     _catch_all = 'other'
@@ -10005,6 +10115,8 @@ class UploadSessionStartError(bb.Union):
     concurrent_session_data_not_allowed = None
     # Attribute is overwritten below the class definition
     concurrent_session_close_not_allowed = None
+    # Attribute is overwritten below the class definition
+    payload_too_large = None
     # Attribute is overwritten below the class definition
     other = None
 
@@ -10023,6 +10135,14 @@ class UploadSessionStartError(bb.Union):
         :rtype: bool
         """
         return self._tag == 'concurrent_session_close_not_allowed'
+
+    def is_payload_too_large(self):
+        """
+        Check if the union tag is ``payload_too_large``.
+
+        :rtype: bool
+        """
+        return self._tag == 'payload_too_large'
 
     def is_other(self):
         """
@@ -10537,22 +10657,22 @@ WriteMode_validator = bv.Union(WriteMode)
 
 CopyBatchArg_validator = RelocationBatchArgBase_validator
 CopyBatchArg = RelocationBatchArgBase
-FileId_validator = bv.String(min_length=4, pattern=u'id:.+')
+FileId_validator = bv.String(min_length=4, pattern='id:.+')
 Id_validator = bv.String(min_length=1)
 ListFolderCursor_validator = bv.String(min_length=1)
 MalformedPathError_validator = bv.Nullable(bv.String())
-Path_validator = bv.String(pattern=u'/(.|[\\r\\n])*')
-PathOrId_validator = bv.String(pattern=u'/(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)')
-PathR_validator = bv.String(pattern=u'(/(.|[\\r\\n])*)?|(ns:[0-9]+(/.*)?)')
-PathROrId_validator = bv.String(pattern=u'(/(.|[\\r\\n])*)?|id:.*|(ns:[0-9]+(/.*)?)')
-ReadPath_validator = bv.String(pattern=u'(/(.|[\\r\\n])*|id:.*)|(rev:[0-9a-f]{9,})|(ns:[0-9]+(/.*)?)')
-Rev_validator = bv.String(min_length=9, pattern=u'[0-9a-f]+')
+Path_validator = bv.String(pattern='/(.|[\\r\\n])*')
+PathOrId_validator = bv.String(pattern='/(.|[\\r\\n])*|id:.*|(ns:[0-9]+(/.*)?)')
+PathR_validator = bv.String(pattern='(/(.|[\\r\\n])*)?|(ns:[0-9]+(/.*)?)')
+PathROrId_validator = bv.String(pattern='(/(.|[\\r\\n])*)?|id:.*|(ns:[0-9]+(/.*)?)')
+ReadPath_validator = bv.String(pattern='(/(.|[\\r\\n])*|id:.*)|(rev:[0-9a-f]{9,})|(ns:[0-9]+(/.*)?)')
+Rev_validator = bv.String(min_length=9, pattern='[0-9a-f]+')
 SearchV2Cursor_validator = bv.String(min_length=1)
 Sha256HexHash_validator = bv.String(min_length=64, max_length=64)
 SharedLinkUrl_validator = bv.String()
-TagText_validator = bv.String(min_length=1, max_length=32, pattern=u'[A-Za-z0-9_]+')
-WritePath_validator = bv.String(pattern=u'(/(.|[\\r\\n])*)|(ns:[0-9]+(/.*)?)')
-WritePathOrId_validator = bv.String(pattern=u'(/(.|[\\r\\n])*)|(ns:[0-9]+(/.*)?)|(id:.*)')
+TagText_validator = bv.String(min_length=1, max_length=32, pattern='[A-Za-z0-9_]+')
+WritePath_validator = bv.String(pattern='(/(.|[\\r\\n])*)|(ns:[0-9]+(/.*)?)')
+WritePathOrId_validator = bv.String(pattern='(/(.|[\\r\\n])*)|(ns:[0-9]+(/.*)?)|(id:.*)')
 AddTagArg.path.validator = Path_validator
 AddTagArg.tag_text.validator = TagText_validator
 AddTagArg._all_field_names_ = set([
@@ -10863,14 +10983,14 @@ Metadata._fields_ = [
 Metadata._all_fields_ = Metadata._fields_
 
 Metadata._tag_to_subtype_ = {
-    (u'file',): FileMetadata_validator,
-    (u'folder',): FolderMetadata_validator,
-    (u'deleted',): DeletedMetadata_validator,
+    ('file',): FileMetadata_validator,
+    ('folder',): FolderMetadata_validator,
+    ('deleted',): DeletedMetadata_validator,
 }
 Metadata._pytype_to_tag_and_subtype_ = {
-    FileMetadata: ((u'file',), FileMetadata_validator),
-    FolderMetadata: ((u'folder',), FolderMetadata_validator),
-    DeletedMetadata: ((u'deleted',), DeletedMetadata_validator),
+    FileMetadata: (('file',), FileMetadata_validator),
+    FolderMetadata: (('folder',), FolderMetadata_validator),
+    DeletedMetadata: (('deleted',), DeletedMetadata_validator),
 }
 Metadata._is_catch_all_ = False
 
@@ -11626,12 +11746,12 @@ MediaMetadata._fields_ = [
 MediaMetadata._all_fields_ = MediaMetadata._fields_
 
 MediaMetadata._tag_to_subtype_ = {
-    (u'photo',): PhotoMetadata_validator,
-    (u'video',): VideoMetadata_validator,
+    ('photo',): PhotoMetadata_validator,
+    ('video',): VideoMetadata_validator,
 }
 MediaMetadata._pytype_to_tag_and_subtype_ = {
-    PhotoMetadata: ((u'photo',), PhotoMetadata_validator),
-    VideoMetadata: ((u'video',), VideoMetadata_validator),
+    PhotoMetadata: (('photo',), PhotoMetadata_validator),
+    VideoMetadata: (('video',), VideoMetadata_validator),
 }
 MediaMetadata._is_catch_all_ = False
 
@@ -11675,6 +11795,16 @@ RelocationBatchArgBase._all_fields_ = [
 MoveBatchArg.allow_ownership_transfer.validator = bv.Boolean()
 MoveBatchArg._all_field_names_ = RelocationBatchArgBase._all_field_names_.union(set(['allow_ownership_transfer']))
 MoveBatchArg._all_fields_ = RelocationBatchArgBase._all_fields_ + [('allow_ownership_transfer', MoveBatchArg.allow_ownership_transfer.validator)]
+
+MoveIntoFamilyError._is_shared_folder_validator = bv.Void()
+MoveIntoFamilyError._other_validator = bv.Void()
+MoveIntoFamilyError._tagmap = {
+    'is_shared_folder': MoveIntoFamilyError._is_shared_folder_validator,
+    'other': MoveIntoFamilyError._other_validator,
+}
+
+MoveIntoFamilyError.is_shared_folder = MoveIntoFamilyError('is_shared_folder')
+MoveIntoFamilyError.other = MoveIntoFamilyError('other')
 
 MoveIntoVaultError._is_shared_folder_validator = bv.Void()
 MoveIntoVaultError._other_validator = bv.Void()
@@ -11919,6 +12049,7 @@ RelocationError._insufficient_quota_validator = bv.Void()
 RelocationError._internal_error_validator = bv.Void()
 RelocationError._cant_move_shared_folder_validator = bv.Void()
 RelocationError._cant_move_into_vault_validator = MoveIntoVaultError_validator
+RelocationError._cant_move_into_family_validator = MoveIntoFamilyError_validator
 RelocationError._other_validator = bv.Void()
 RelocationError._tagmap = {
     'from_lookup': RelocationError._from_lookup_validator,
@@ -11934,6 +12065,7 @@ RelocationError._tagmap = {
     'internal_error': RelocationError._internal_error_validator,
     'cant_move_shared_folder': RelocationError._cant_move_shared_folder_validator,
     'cant_move_into_vault': RelocationError._cant_move_into_vault_validator,
+    'cant_move_into_family': RelocationError._cant_move_into_family_validator,
     'other': RelocationError._other_validator,
 }
 
@@ -12583,13 +12715,16 @@ UnlockFileBatchArg._all_fields_ = [('entries', UnlockFileBatchArg.entries.valida
 
 UploadError._path_validator = UploadWriteFailed_validator
 UploadError._properties_error_validator = file_properties.InvalidPropertyGroupError_validator
+UploadError._payload_too_large_validator = bv.Void()
 UploadError._other_validator = bv.Void()
 UploadError._tagmap = {
     'path': UploadError._path_validator,
     'properties_error': UploadError._properties_error_validator,
+    'payload_too_large': UploadError._payload_too_large_validator,
     'other': UploadError._other_validator,
 }
 
+UploadError.payload_too_large = UploadError('payload_too_large')
 UploadError.other = UploadError('other')
 
 UploadErrorWithProperties._tagmap = {
@@ -12668,6 +12803,7 @@ UploadSessionFinishError._too_many_write_operations_validator = bv.Void()
 UploadSessionFinishError._concurrent_session_data_not_allowed_validator = bv.Void()
 UploadSessionFinishError._concurrent_session_not_closed_validator = bv.Void()
 UploadSessionFinishError._concurrent_session_missing_data_validator = bv.Void()
+UploadSessionFinishError._payload_too_large_validator = bv.Void()
 UploadSessionFinishError._other_validator = bv.Void()
 UploadSessionFinishError._tagmap = {
     'lookup_failed': UploadSessionFinishError._lookup_failed_validator,
@@ -12678,6 +12814,7 @@ UploadSessionFinishError._tagmap = {
     'concurrent_session_data_not_allowed': UploadSessionFinishError._concurrent_session_data_not_allowed_validator,
     'concurrent_session_not_closed': UploadSessionFinishError._concurrent_session_not_closed_validator,
     'concurrent_session_missing_data': UploadSessionFinishError._concurrent_session_missing_data_validator,
+    'payload_too_large': UploadSessionFinishError._payload_too_large_validator,
     'other': UploadSessionFinishError._other_validator,
 }
 
@@ -12686,6 +12823,7 @@ UploadSessionFinishError.too_many_write_operations = UploadSessionFinishError('t
 UploadSessionFinishError.concurrent_session_data_not_allowed = UploadSessionFinishError('concurrent_session_data_not_allowed')
 UploadSessionFinishError.concurrent_session_not_closed = UploadSessionFinishError('concurrent_session_not_closed')
 UploadSessionFinishError.concurrent_session_missing_data = UploadSessionFinishError('concurrent_session_missing_data')
+UploadSessionFinishError.payload_too_large = UploadSessionFinishError('payload_too_large')
 UploadSessionFinishError.other = UploadSessionFinishError('other')
 
 UploadSessionLookupError._not_found_validator = bv.Void()
@@ -12695,6 +12833,7 @@ UploadSessionLookupError._not_closed_validator = bv.Void()
 UploadSessionLookupError._too_large_validator = bv.Void()
 UploadSessionLookupError._concurrent_session_invalid_offset_validator = bv.Void()
 UploadSessionLookupError._concurrent_session_invalid_data_size_validator = bv.Void()
+UploadSessionLookupError._payload_too_large_validator = bv.Void()
 UploadSessionLookupError._other_validator = bv.Void()
 UploadSessionLookupError._tagmap = {
     'not_found': UploadSessionLookupError._not_found_validator,
@@ -12704,6 +12843,7 @@ UploadSessionLookupError._tagmap = {
     'too_large': UploadSessionLookupError._too_large_validator,
     'concurrent_session_invalid_offset': UploadSessionLookupError._concurrent_session_invalid_offset_validator,
     'concurrent_session_invalid_data_size': UploadSessionLookupError._concurrent_session_invalid_data_size_validator,
+    'payload_too_large': UploadSessionLookupError._payload_too_large_validator,
     'other': UploadSessionLookupError._other_validator,
 }
 
@@ -12713,6 +12853,7 @@ UploadSessionLookupError.not_closed = UploadSessionLookupError('not_closed')
 UploadSessionLookupError.too_large = UploadSessionLookupError('too_large')
 UploadSessionLookupError.concurrent_session_invalid_offset = UploadSessionLookupError('concurrent_session_invalid_offset')
 UploadSessionLookupError.concurrent_session_invalid_data_size = UploadSessionLookupError('concurrent_session_invalid_data_size')
+UploadSessionLookupError.payload_too_large = UploadSessionLookupError('payload_too_large')
 UploadSessionLookupError.other = UploadSessionLookupError('other')
 
 UploadSessionOffsetError.correct_offset.validator = bv.UInt64()
@@ -12732,15 +12873,18 @@ UploadSessionStartArg._all_fields_ = [
 
 UploadSessionStartError._concurrent_session_data_not_allowed_validator = bv.Void()
 UploadSessionStartError._concurrent_session_close_not_allowed_validator = bv.Void()
+UploadSessionStartError._payload_too_large_validator = bv.Void()
 UploadSessionStartError._other_validator = bv.Void()
 UploadSessionStartError._tagmap = {
     'concurrent_session_data_not_allowed': UploadSessionStartError._concurrent_session_data_not_allowed_validator,
     'concurrent_session_close_not_allowed': UploadSessionStartError._concurrent_session_close_not_allowed_validator,
+    'payload_too_large': UploadSessionStartError._payload_too_large_validator,
     'other': UploadSessionStartError._other_validator,
 }
 
 UploadSessionStartError.concurrent_session_data_not_allowed = UploadSessionStartError('concurrent_session_data_not_allowed')
 UploadSessionStartError.concurrent_session_close_not_allowed = UploadSessionStartError('concurrent_session_close_not_allowed')
+UploadSessionStartError.payload_too_large = UploadSessionStartError('payload_too_large')
 UploadSessionStartError.other = UploadSessionStartError('other')
 
 UploadSessionStartResult.session_id.validator = bv.String()
@@ -12890,9 +13034,9 @@ alpha_get_metadata = bb.Route(
     AlphaGetMetadataArg_validator,
     Metadata_validator,
     AlphaGetMetadataError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 alpha_upload = bb.Route(
     'alpha/upload',
@@ -12901,9 +13045,9 @@ alpha_upload = bb.Route(
     CommitInfoWithProperties_validator,
     FileMetadata_validator,
     UploadErrorWithProperties_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 copy_v2 = bb.Route(
     'copy',
@@ -12912,9 +13056,9 @@ copy_v2 = bb.Route(
     RelocationArg_validator,
     RelocationResult_validator,
     RelocationError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy = bb.Route(
     'copy',
@@ -12923,9 +13067,9 @@ copy = bb.Route(
     RelocationArg_validator,
     Metadata_validator,
     RelocationError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_batch_v2 = bb.Route(
     'copy_batch',
@@ -12934,9 +13078,9 @@ copy_batch_v2 = bb.Route(
     CopyBatchArg_validator,
     RelocationBatchV2Launch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_batch = bb.Route(
     'copy_batch',
@@ -12945,9 +13089,9 @@ copy_batch = bb.Route(
     RelocationBatchArg_validator,
     RelocationBatchLaunch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_batch_check_v2 = bb.Route(
     'copy_batch/check',
@@ -12956,9 +13100,9 @@ copy_batch_check_v2 = bb.Route(
     async_.PollArg_validator,
     RelocationBatchV2JobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_batch_check = bb.Route(
     'copy_batch/check',
@@ -12967,9 +13111,9 @@ copy_batch_check = bb.Route(
     async_.PollArg_validator,
     RelocationBatchJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_reference_get = bb.Route(
     'copy_reference/get',
@@ -12978,9 +13122,9 @@ copy_reference_get = bb.Route(
     GetCopyReferenceArg_validator,
     GetCopyReferenceResult_validator,
     GetCopyReferenceError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 copy_reference_save = bb.Route(
     'copy_reference/save',
@@ -12989,9 +13133,9 @@ copy_reference_save = bb.Route(
     SaveCopyReferenceArg_validator,
     SaveCopyReferenceResult_validator,
     SaveCopyReferenceError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_folder_v2 = bb.Route(
     'create_folder',
@@ -13000,9 +13144,9 @@ create_folder_v2 = bb.Route(
     CreateFolderArg_validator,
     CreateFolderResult_validator,
     CreateFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_folder = bb.Route(
     'create_folder',
@@ -13011,9 +13155,9 @@ create_folder = bb.Route(
     CreateFolderArg_validator,
     FolderMetadata_validator,
     CreateFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_folder_batch = bb.Route(
     'create_folder_batch',
@@ -13022,9 +13166,9 @@ create_folder_batch = bb.Route(
     CreateFolderBatchArg_validator,
     CreateFolderBatchLaunch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_folder_batch_check = bb.Route(
     'create_folder_batch/check',
@@ -13033,9 +13177,9 @@ create_folder_batch_check = bb.Route(
     async_.PollArg_validator,
     CreateFolderBatchJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete_v2 = bb.Route(
     'delete',
@@ -13044,9 +13188,9 @@ delete_v2 = bb.Route(
     DeleteArg_validator,
     DeleteResult_validator,
     DeleteError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete = bb.Route(
     'delete',
@@ -13055,9 +13199,9 @@ delete = bb.Route(
     DeleteArg_validator,
     Metadata_validator,
     DeleteError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete_batch = bb.Route(
     'delete_batch',
@@ -13066,9 +13210,9 @@ delete_batch = bb.Route(
     DeleteBatchArg_validator,
     DeleteBatchLaunch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 delete_batch_check = bb.Route(
     'delete_batch/check',
@@ -13077,9 +13221,9 @@ delete_batch_check = bb.Route(
     async_.PollArg_validator,
     DeleteBatchJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 download = bb.Route(
     'download',
@@ -13088,9 +13232,9 @@ download = bb.Route(
     DownloadArg_validator,
     FileMetadata_validator,
     DownloadError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 download_zip = bb.Route(
     'download_zip',
@@ -13099,9 +13243,9 @@ download_zip = bb.Route(
     DownloadZipArg_validator,
     DownloadZipResult_validator,
     DownloadZipError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 export = bb.Route(
     'export',
@@ -13110,9 +13254,9 @@ export = bb.Route(
     ExportArg_validator,
     ExportResult_validator,
     ExportError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 get_file_lock_batch = bb.Route(
     'get_file_lock_batch',
@@ -13121,9 +13265,9 @@ get_file_lock_batch = bb.Route(
     LockFileBatchArg_validator,
     LockFileBatchResult_validator,
     LockFileError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_metadata = bb.Route(
     'get_metadata',
@@ -13132,9 +13276,9 @@ get_metadata = bb.Route(
     GetMetadataArg_validator,
     Metadata_validator,
     GetMetadataError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_preview = bb.Route(
     'get_preview',
@@ -13143,9 +13287,9 @@ get_preview = bb.Route(
     PreviewArg_validator,
     FileMetadata_validator,
     PreviewError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 get_temporary_link = bb.Route(
     'get_temporary_link',
@@ -13154,9 +13298,9 @@ get_temporary_link = bb.Route(
     GetTemporaryLinkArg_validator,
     GetTemporaryLinkResult_validator,
     GetTemporaryLinkError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_temporary_upload_link = bb.Route(
     'get_temporary_upload_link',
@@ -13165,9 +13309,9 @@ get_temporary_upload_link = bb.Route(
     GetTemporaryUploadLinkArg_validator,
     GetTemporaryUploadLinkResult_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_thumbnail = bb.Route(
     'get_thumbnail',
@@ -13176,9 +13320,9 @@ get_thumbnail = bb.Route(
     ThumbnailArg_validator,
     FileMetadata_validator,
     ThumbnailError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 get_thumbnail_v2 = bb.Route(
     'get_thumbnail',
@@ -13187,9 +13331,9 @@ get_thumbnail_v2 = bb.Route(
     ThumbnailV2Arg_validator,
     PreviewResult_validator,
     ThumbnailV2Error_validator,
-    {'auth': u'app, user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'app, user',
+     'host': 'content',
+     'style': 'download'},
 )
 get_thumbnail_batch = bb.Route(
     'get_thumbnail_batch',
@@ -13198,9 +13342,9 @@ get_thumbnail_batch = bb.Route(
     GetThumbnailBatchArg_validator,
     GetThumbnailBatchResult_validator,
     GetThumbnailBatchError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'rpc'},
 )
 list_folder = bb.Route(
     'list_folder',
@@ -13209,9 +13353,9 @@ list_folder = bb.Route(
     ListFolderArg_validator,
     ListFolderResult_validator,
     ListFolderError_validator,
-    {'auth': u'app, user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'app, user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folder_continue = bb.Route(
     'list_folder/continue',
@@ -13220,9 +13364,9 @@ list_folder_continue = bb.Route(
     ListFolderContinueArg_validator,
     ListFolderResult_validator,
     ListFolderContinueError_validator,
-    {'auth': u'app, user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'app, user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folder_get_latest_cursor = bb.Route(
     'list_folder/get_latest_cursor',
@@ -13231,9 +13375,9 @@ list_folder_get_latest_cursor = bb.Route(
     ListFolderArg_validator,
     ListFolderGetLatestCursorResult_validator,
     ListFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folder_longpoll = bb.Route(
     'list_folder/longpoll',
@@ -13242,9 +13386,9 @@ list_folder_longpoll = bb.Route(
     ListFolderLongpollArg_validator,
     ListFolderLongpollResult_validator,
     ListFolderLongpollError_validator,
-    {'auth': u'noauth',
-     'host': u'notify',
-     'style': u'rpc'},
+    {'auth': 'noauth',
+     'host': 'notify',
+     'style': 'rpc'},
 )
 list_revisions = bb.Route(
     'list_revisions',
@@ -13253,9 +13397,9 @@ list_revisions = bb.Route(
     ListRevisionsArg_validator,
     ListRevisionsResult_validator,
     ListRevisionsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 lock_file_batch = bb.Route(
     'lock_file_batch',
@@ -13264,9 +13408,9 @@ lock_file_batch = bb.Route(
     LockFileBatchArg_validator,
     LockFileBatchResult_validator,
     LockFileError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move_v2 = bb.Route(
     'move',
@@ -13275,9 +13419,9 @@ move_v2 = bb.Route(
     RelocationArg_validator,
     RelocationResult_validator,
     RelocationError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move = bb.Route(
     'move',
@@ -13286,9 +13430,9 @@ move = bb.Route(
     RelocationArg_validator,
     Metadata_validator,
     RelocationError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move_batch_v2 = bb.Route(
     'move_batch',
@@ -13297,9 +13441,9 @@ move_batch_v2 = bb.Route(
     MoveBatchArg_validator,
     RelocationBatchV2Launch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move_batch = bb.Route(
     'move_batch',
@@ -13308,9 +13452,9 @@ move_batch = bb.Route(
     RelocationBatchArg_validator,
     RelocationBatchLaunch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move_batch_check_v2 = bb.Route(
     'move_batch/check',
@@ -13319,9 +13463,9 @@ move_batch_check_v2 = bb.Route(
     async_.PollArg_validator,
     RelocationBatchV2JobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 move_batch_check = bb.Route(
     'move_batch/check',
@@ -13330,9 +13474,9 @@ move_batch_check = bb.Route(
     async_.PollArg_validator,
     RelocationBatchJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 paper_create = bb.Route(
     'paper/create',
@@ -13341,9 +13485,9 @@ paper_create = bb.Route(
     PaperCreateArg_validator,
     PaperCreateResult_validator,
     PaperCreateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'upload'},
 )
 paper_update = bb.Route(
     'paper/update',
@@ -13352,9 +13496,9 @@ paper_update = bb.Route(
     PaperUpdateArg_validator,
     PaperUpdateResult_validator,
     PaperUpdateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'upload'},
 )
 permanently_delete = bb.Route(
     'permanently_delete',
@@ -13363,9 +13507,9 @@ permanently_delete = bb.Route(
     DeleteArg_validator,
     bv.Void(),
     DeleteError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_add = bb.Route(
     'properties/add',
@@ -13374,9 +13518,9 @@ properties_add = bb.Route(
     file_properties.AddPropertiesArg_validator,
     bv.Void(),
     file_properties.AddPropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_overwrite = bb.Route(
     'properties/overwrite',
@@ -13385,9 +13529,9 @@ properties_overwrite = bb.Route(
     file_properties.OverwritePropertyGroupArg_validator,
     bv.Void(),
     file_properties.InvalidPropertyGroupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_remove = bb.Route(
     'properties/remove',
@@ -13396,9 +13540,9 @@ properties_remove = bb.Route(
     file_properties.RemovePropertiesArg_validator,
     bv.Void(),
     file_properties.RemovePropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_get = bb.Route(
     'properties/template/get',
@@ -13407,9 +13551,9 @@ properties_template_get = bb.Route(
     file_properties.GetTemplateArg_validator,
     file_properties.GetTemplateResult_validator,
     file_properties.TemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_list = bb.Route(
     'properties/template/list',
@@ -13418,9 +13562,9 @@ properties_template_list = bb.Route(
     bv.Void(),
     file_properties.ListTemplateResult_validator,
     file_properties.TemplateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_update = bb.Route(
     'properties/update',
@@ -13429,9 +13573,9 @@ properties_update = bb.Route(
     file_properties.UpdatePropertiesArg_validator,
     bv.Void(),
     file_properties.UpdatePropertiesError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 restore = bb.Route(
     'restore',
@@ -13440,9 +13584,9 @@ restore = bb.Route(
     RestoreArg_validator,
     FileMetadata_validator,
     RestoreError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 save_url = bb.Route(
     'save_url',
@@ -13451,9 +13595,9 @@ save_url = bb.Route(
     SaveUrlArg_validator,
     SaveUrlResult_validator,
     SaveUrlError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 save_url_check_job_status = bb.Route(
     'save_url/check_job_status',
@@ -13462,9 +13606,9 @@ save_url_check_job_status = bb.Route(
     async_.PollArg_validator,
     SaveUrlJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 search = bb.Route(
     'search',
@@ -13473,9 +13617,9 @@ search = bb.Route(
     SearchArg_validator,
     SearchResult_validator,
     SearchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 search_v2 = bb.Route(
     'search',
@@ -13484,9 +13628,9 @@ search_v2 = bb.Route(
     SearchV2Arg_validator,
     SearchV2Result_validator,
     SearchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 search_continue_v2 = bb.Route(
     'search/continue',
@@ -13495,9 +13639,9 @@ search_continue_v2 = bb.Route(
     SearchV2ContinueArg_validator,
     SearchV2Result_validator,
     SearchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 tags_add = bb.Route(
     'tags/add',
@@ -13506,9 +13650,9 @@ tags_add = bb.Route(
     AddTagArg_validator,
     bv.Void(),
     AddTagError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 tags_get = bb.Route(
     'tags/get',
@@ -13517,9 +13661,9 @@ tags_get = bb.Route(
     GetTagsArg_validator,
     GetTagsResult_validator,
     BaseTagError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 tags_remove = bb.Route(
     'tags/remove',
@@ -13528,9 +13672,9 @@ tags_remove = bb.Route(
     RemoveTagArg_validator,
     bv.Void(),
     RemoveTagError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 unlock_file_batch = bb.Route(
     'unlock_file_batch',
@@ -13539,9 +13683,9 @@ unlock_file_batch = bb.Route(
     UnlockFileBatchArg_validator,
     LockFileBatchResult_validator,
     LockFileError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 upload = bb.Route(
     'upload',
@@ -13550,9 +13694,9 @@ upload = bb.Route(
     CommitInfo_validator,
     FileMetadata_validator,
     UploadError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 upload_session_append_v2 = bb.Route(
     'upload_session/append',
@@ -13561,9 +13705,9 @@ upload_session_append_v2 = bb.Route(
     UploadSessionAppendArg_validator,
     bv.Void(),
     UploadSessionLookupError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 upload_session_append = bb.Route(
     'upload_session/append',
@@ -13572,9 +13716,9 @@ upload_session_append = bb.Route(
     UploadSessionCursor_validator,
     bv.Void(),
     UploadSessionLookupError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 upload_session_finish = bb.Route(
     'upload_session/finish',
@@ -13583,9 +13727,9 @@ upload_session_finish = bb.Route(
     UploadSessionFinishArg_validator,
     FileMetadata_validator,
     UploadSessionFinishError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 upload_session_finish_batch = bb.Route(
     'upload_session/finish_batch',
@@ -13594,9 +13738,9 @@ upload_session_finish_batch = bb.Route(
     UploadSessionFinishBatchArg_validator,
     UploadSessionFinishBatchLaunch_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 upload_session_finish_batch_v2 = bb.Route(
     'upload_session/finish_batch',
@@ -13605,9 +13749,9 @@ upload_session_finish_batch_v2 = bb.Route(
     UploadSessionFinishBatchArg_validator,
     UploadSessionFinishBatchResult_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 upload_session_finish_batch_check = bb.Route(
     'upload_session/finish_batch/check',
@@ -13616,9 +13760,9 @@ upload_session_finish_batch_check = bb.Route(
     async_.PollArg_validator,
     UploadSessionFinishBatchJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 upload_session_start = bb.Route(
     'upload_session/start',
@@ -13627,9 +13771,9 @@ upload_session_start = bb.Route(
     UploadSessionStartArg_validator,
     UploadSessionStartResult_validator,
     UploadSessionStartError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'upload'},
 )
 
 ROUTES = {

--- a/dropbox/paper.py
+++ b/dropbox/paper.py
@@ -2981,9 +2981,9 @@ docs_archive = bb.Route(
     RefPaperDoc_validator,
     bv.Void(),
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_create = bb.Route(
     'docs/create',
@@ -2992,9 +2992,9 @@ docs_create = bb.Route(
     PaperDocCreateArgs_validator,
     PaperDocCreateUpdateResult_validator,
     PaperDocCreateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'upload'},
 )
 docs_download = bb.Route(
     'docs/download',
@@ -3003,9 +3003,9 @@ docs_download = bb.Route(
     PaperDocExport_validator,
     PaperDocExportResult_validator,
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'download'},
 )
 docs_folder_users_list = bb.Route(
     'docs/folder_users/list',
@@ -3014,9 +3014,9 @@ docs_folder_users_list = bb.Route(
     ListUsersOnFolderArgs_validator,
     ListUsersOnFolderResponse_validator,
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_folder_users_list_continue = bb.Route(
     'docs/folder_users/list/continue',
@@ -3025,9 +3025,9 @@ docs_folder_users_list_continue = bb.Route(
     ListUsersOnFolderContinueArgs_validator,
     ListUsersOnFolderResponse_validator,
     ListUsersCursorError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_get_folder_info = bb.Route(
     'docs/get_folder_info',
@@ -3036,9 +3036,9 @@ docs_get_folder_info = bb.Route(
     RefPaperDoc_validator,
     FoldersContainingPaperDoc_validator,
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_list = bb.Route(
     'docs/list',
@@ -3047,9 +3047,9 @@ docs_list = bb.Route(
     ListPaperDocsArgs_validator,
     ListPaperDocsResponse_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_list_continue = bb.Route(
     'docs/list/continue',
@@ -3058,9 +3058,9 @@ docs_list_continue = bb.Route(
     ListPaperDocsContinueArgs_validator,
     ListPaperDocsResponse_validator,
     ListDocsCursorError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_permanently_delete = bb.Route(
     'docs/permanently_delete',
@@ -3069,9 +3069,9 @@ docs_permanently_delete = bb.Route(
     RefPaperDoc_validator,
     bv.Void(),
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_sharing_policy_get = bb.Route(
     'docs/sharing_policy/get',
@@ -3080,9 +3080,9 @@ docs_sharing_policy_get = bb.Route(
     RefPaperDoc_validator,
     SharingPolicy_validator,
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_sharing_policy_set = bb.Route(
     'docs/sharing_policy/set',
@@ -3091,9 +3091,9 @@ docs_sharing_policy_set = bb.Route(
     PaperDocSharingPolicy_validator,
     bv.Void(),
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_update = bb.Route(
     'docs/update',
@@ -3102,9 +3102,9 @@ docs_update = bb.Route(
     PaperDocUpdateArgs_validator,
     PaperDocCreateUpdateResult_validator,
     PaperDocUpdateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'upload'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'upload'},
 )
 docs_users_add = bb.Route(
     'docs/users/add',
@@ -3113,9 +3113,9 @@ docs_users_add = bb.Route(
     AddPaperDocUser_validator,
     bv.List(AddPaperDocUserMemberResult_validator),
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_users_list = bb.Route(
     'docs/users/list',
@@ -3124,9 +3124,9 @@ docs_users_list = bb.Route(
     ListUsersOnPaperDocArgs_validator,
     ListUsersOnPaperDocResponse_validator,
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_users_list_continue = bb.Route(
     'docs/users/list/continue',
@@ -3135,9 +3135,9 @@ docs_users_list_continue = bb.Route(
     ListUsersOnPaperDocContinueArgs_validator,
     ListUsersOnPaperDocResponse_validator,
     ListUsersCursorError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 docs_users_remove = bb.Route(
     'docs/users/remove',
@@ -3146,9 +3146,9 @@ docs_users_remove = bb.Route(
     RemovePaperDocUser_validator,
     bv.Void(),
     DocLookupError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 folders_create = bb.Route(
     'folders/create',
@@ -3157,9 +3157,9 @@ folders_create = bb.Route(
     PaperFolderCreateArg_validator,
     PaperFolderCreateResult_validator,
     PaperFolderCreateError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/sharing.py
+++ b/dropbox/sharing.py
@@ -210,7 +210,7 @@ class AddFileMemberArgs(bb.Struct):
     :ivar sharing.AddFileMemberArgs.custom_message: Message to send to added
         members in their invitation.
     :ivar sharing.AddFileMemberArgs.quiet: Whether added members should be
-        notified via device notifications of their invitation.
+        notified via email and device notifications of their invitation.
     :ivar sharing.AddFileMemberArgs.access_level: AccessLevel union object,
         describing what access level we want to give new members.
     :ivar sharing.AddFileMemberArgs.add_message_as_comment: If the custom
@@ -11018,7 +11018,7 @@ GetSharedLinkFileArg_validator = GetSharedLinkMetadataArg_validator
 GetSharedLinkFileArg = GetSharedLinkMetadataArg
 Id_validator = files.Id_validator
 Path_validator = files.Path_validator
-PathOrId_validator = bv.String(min_length=1, pattern=u'((/|id:).*|nspath:[0-9]+:.*)|ns:[0-9]+(/.*)?')
+PathOrId_validator = bv.String(min_length=1, pattern='((/|id:).*|nspath:[0-9]+:.*)|ns:[0-9]+(/.*)?')
 ReadPath_validator = files.ReadPath_validator
 Rev_validator = files.Rev_validator
 TeamInfo_validator = users.Team_validator
@@ -11283,12 +11283,12 @@ LinkMetadata._fields_ = [
 LinkMetadata._all_fields_ = LinkMetadata._fields_
 
 LinkMetadata._tag_to_subtype_ = {
-    (u'path',): PathLinkMetadata_validator,
-    (u'collection',): CollectionLinkMetadata_validator,
+    ('path',): PathLinkMetadata_validator,
+    ('collection',): CollectionLinkMetadata_validator,
 }
 LinkMetadata._pytype_to_tag_and_subtype_ = {
-    PathLinkMetadata: ((u'path',), PathLinkMetadata_validator),
-    CollectionLinkMetadata: ((u'collection',), CollectionLinkMetadata_validator),
+    PathLinkMetadata: (('path',), PathLinkMetadata_validator),
+    CollectionLinkMetadata: (('collection',), CollectionLinkMetadata_validator),
 }
 LinkMetadata._is_catch_all_ = True
 
@@ -11464,12 +11464,12 @@ SharedLinkMetadata._fields_ = [
 SharedLinkMetadata._all_fields_ = SharedLinkMetadata._fields_
 
 SharedLinkMetadata._tag_to_subtype_ = {
-    (u'file',): FileLinkMetadata_validator,
-    (u'folder',): FolderLinkMetadata_validator,
+    ('file',): FileLinkMetadata_validator,
+    ('folder',): FolderLinkMetadata_validator,
 }
 SharedLinkMetadata._pytype_to_tag_and_subtype_ = {
-    FileLinkMetadata: ((u'file',), FileLinkMetadata_validator),
-    FolderLinkMetadata: ((u'folder',), FolderLinkMetadata_validator),
+    FileLinkMetadata: (('file',), FileLinkMetadata_validator),
+    FolderLinkMetadata: (('folder',), FolderLinkMetadata_validator),
 }
 SharedLinkMetadata._is_catch_all_ = True
 
@@ -13470,9 +13470,9 @@ add_file_member = bb.Route(
     AddFileMemberArgs_validator,
     bv.List(FileMemberActionResult_validator),
     AddFileMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 add_folder_member = bb.Route(
     'add_folder_member',
@@ -13481,9 +13481,9 @@ add_folder_member = bb.Route(
     AddFolderMemberArg_validator,
     bv.Void(),
     AddFolderMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 check_job_status = bb.Route(
     'check_job_status',
@@ -13492,9 +13492,9 @@ check_job_status = bb.Route(
     async_.PollArg_validator,
     JobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 check_remove_member_job_status = bb.Route(
     'check_remove_member_job_status',
@@ -13503,9 +13503,9 @@ check_remove_member_job_status = bb.Route(
     async_.PollArg_validator,
     RemoveMemberJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 check_share_job_status = bb.Route(
     'check_share_job_status',
@@ -13514,9 +13514,9 @@ check_share_job_status = bb.Route(
     async_.PollArg_validator,
     ShareFolderJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_shared_link = bb.Route(
     'create_shared_link',
@@ -13525,9 +13525,9 @@ create_shared_link = bb.Route(
     CreateSharedLinkArg_validator,
     PathLinkMetadata_validator,
     CreateSharedLinkError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 create_shared_link_with_settings = bb.Route(
     'create_shared_link_with_settings',
@@ -13536,9 +13536,9 @@ create_shared_link_with_settings = bb.Route(
     CreateSharedLinkWithSettingsArg_validator,
     SharedLinkMetadata_validator,
     CreateSharedLinkWithSettingsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_file_metadata = bb.Route(
     'get_file_metadata',
@@ -13547,9 +13547,9 @@ get_file_metadata = bb.Route(
     GetFileMetadataArg_validator,
     SharedFileMetadata_validator,
     GetFileMetadataError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_file_metadata_batch = bb.Route(
     'get_file_metadata/batch',
@@ -13558,9 +13558,9 @@ get_file_metadata_batch = bb.Route(
     GetFileMetadataBatchArg_validator,
     bv.List(GetFileMetadataBatchResult_validator),
     SharingUserError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_folder_metadata = bb.Route(
     'get_folder_metadata',
@@ -13569,9 +13569,9 @@ get_folder_metadata = bb.Route(
     GetMetadataArgs_validator,
     SharedFolderMetadata_validator,
     SharedFolderAccessError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_shared_link_file = bb.Route(
     'get_shared_link_file',
@@ -13580,9 +13580,9 @@ get_shared_link_file = bb.Route(
     GetSharedLinkFileArg_validator,
     SharedLinkMetadata_validator,
     GetSharedLinkFileError_validator,
-    {'auth': u'user',
-     'host': u'content',
-     'style': u'download'},
+    {'auth': 'user',
+     'host': 'content',
+     'style': 'download'},
 )
 get_shared_link_metadata = bb.Route(
     'get_shared_link_metadata',
@@ -13591,9 +13591,9 @@ get_shared_link_metadata = bb.Route(
     GetSharedLinkMetadataArg_validator,
     SharedLinkMetadata_validator,
     SharedLinkError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_shared_links = bb.Route(
     'get_shared_links',
@@ -13602,9 +13602,9 @@ get_shared_links = bb.Route(
     GetSharedLinksArg_validator,
     GetSharedLinksResult_validator,
     GetSharedLinksError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_file_members = bb.Route(
     'list_file_members',
@@ -13613,9 +13613,9 @@ list_file_members = bb.Route(
     ListFileMembersArg_validator,
     SharedFileMembers_validator,
     ListFileMembersError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_file_members_batch = bb.Route(
     'list_file_members/batch',
@@ -13624,9 +13624,9 @@ list_file_members_batch = bb.Route(
     ListFileMembersBatchArg_validator,
     bv.List(ListFileMembersBatchResult_validator),
     SharingUserError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_file_members_continue = bb.Route(
     'list_file_members/continue',
@@ -13635,9 +13635,9 @@ list_file_members_continue = bb.Route(
     ListFileMembersContinueArg_validator,
     SharedFileMembers_validator,
     ListFileMembersContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folder_members = bb.Route(
     'list_folder_members',
@@ -13646,9 +13646,9 @@ list_folder_members = bb.Route(
     ListFolderMembersArgs_validator,
     SharedFolderMembers_validator,
     SharedFolderAccessError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folder_members_continue = bb.Route(
     'list_folder_members/continue',
@@ -13657,9 +13657,9 @@ list_folder_members_continue = bb.Route(
     ListFolderMembersContinueArg_validator,
     SharedFolderMembers_validator,
     ListFolderMembersContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folders = bb.Route(
     'list_folders',
@@ -13668,9 +13668,9 @@ list_folders = bb.Route(
     ListFoldersArgs_validator,
     ListFoldersResult_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_folders_continue = bb.Route(
     'list_folders/continue',
@@ -13679,9 +13679,9 @@ list_folders_continue = bb.Route(
     ListFoldersContinueArg_validator,
     ListFoldersResult_validator,
     ListFoldersContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_mountable_folders = bb.Route(
     'list_mountable_folders',
@@ -13690,9 +13690,9 @@ list_mountable_folders = bb.Route(
     ListFoldersArgs_validator,
     ListFoldersResult_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_mountable_folders_continue = bb.Route(
     'list_mountable_folders/continue',
@@ -13701,9 +13701,9 @@ list_mountable_folders_continue = bb.Route(
     ListFoldersContinueArg_validator,
     ListFoldersResult_validator,
     ListFoldersContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_received_files = bb.Route(
     'list_received_files',
@@ -13712,9 +13712,9 @@ list_received_files = bb.Route(
     ListFilesArg_validator,
     ListFilesResult_validator,
     SharingUserError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_received_files_continue = bb.Route(
     'list_received_files/continue',
@@ -13723,9 +13723,9 @@ list_received_files_continue = bb.Route(
     ListFilesContinueArg_validator,
     ListFilesResult_validator,
     ListFilesContinueError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 list_shared_links = bb.Route(
     'list_shared_links',
@@ -13734,9 +13734,9 @@ list_shared_links = bb.Route(
     ListSharedLinksArg_validator,
     ListSharedLinksResult_validator,
     ListSharedLinksError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 modify_shared_link_settings = bb.Route(
     'modify_shared_link_settings',
@@ -13745,9 +13745,9 @@ modify_shared_link_settings = bb.Route(
     ModifySharedLinkSettingsArgs_validator,
     SharedLinkMetadata_validator,
     ModifySharedLinkSettingsError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 mount_folder = bb.Route(
     'mount_folder',
@@ -13756,9 +13756,9 @@ mount_folder = bb.Route(
     MountFolderArg_validator,
     SharedFolderMetadata_validator,
     MountFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 relinquish_file_membership = bb.Route(
     'relinquish_file_membership',
@@ -13767,9 +13767,9 @@ relinquish_file_membership = bb.Route(
     RelinquishFileMembershipArg_validator,
     bv.Void(),
     RelinquishFileMembershipError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 relinquish_folder_membership = bb.Route(
     'relinquish_folder_membership',
@@ -13778,9 +13778,9 @@ relinquish_folder_membership = bb.Route(
     RelinquishFolderMembershipArg_validator,
     async_.LaunchEmptyResult_validator,
     RelinquishFolderMembershipError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 remove_file_member = bb.Route(
     'remove_file_member',
@@ -13789,9 +13789,9 @@ remove_file_member = bb.Route(
     RemoveFileMemberArg_validator,
     FileMemberActionIndividualResult_validator,
     RemoveFileMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 remove_file_member_2 = bb.Route(
     'remove_file_member_2',
@@ -13800,9 +13800,9 @@ remove_file_member_2 = bb.Route(
     RemoveFileMemberArg_validator,
     FileMemberRemoveActionResult_validator,
     RemoveFileMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 remove_folder_member = bb.Route(
     'remove_folder_member',
@@ -13811,9 +13811,9 @@ remove_folder_member = bb.Route(
     RemoveFolderMemberArg_validator,
     async_.LaunchResultBase_validator,
     RemoveFolderMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 revoke_shared_link = bb.Route(
     'revoke_shared_link',
@@ -13822,9 +13822,9 @@ revoke_shared_link = bb.Route(
     RevokeSharedLinkArg_validator,
     bv.Void(),
     RevokeSharedLinkError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 set_access_inheritance = bb.Route(
     'set_access_inheritance',
@@ -13833,9 +13833,9 @@ set_access_inheritance = bb.Route(
     SetAccessInheritanceArg_validator,
     ShareFolderLaunch_validator,
     SetAccessInheritanceError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 share_folder = bb.Route(
     'share_folder',
@@ -13844,9 +13844,9 @@ share_folder = bb.Route(
     ShareFolderArg_validator,
     ShareFolderLaunch_validator,
     ShareFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 transfer_folder = bb.Route(
     'transfer_folder',
@@ -13855,9 +13855,9 @@ transfer_folder = bb.Route(
     TransferFolderArg_validator,
     bv.Void(),
     TransferFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 unmount_folder = bb.Route(
     'unmount_folder',
@@ -13866,9 +13866,9 @@ unmount_folder = bb.Route(
     UnmountFolderArg_validator,
     bv.Void(),
     UnmountFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 unshare_file = bb.Route(
     'unshare_file',
@@ -13877,9 +13877,9 @@ unshare_file = bb.Route(
     UnshareFileArg_validator,
     bv.Void(),
     UnshareFileError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 unshare_folder = bb.Route(
     'unshare_folder',
@@ -13888,9 +13888,9 @@ unshare_folder = bb.Route(
     UnshareFolderArg_validator,
     async_.LaunchEmptyResult_validator,
     UnshareFolderError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 update_file_member = bb.Route(
     'update_file_member',
@@ -13899,9 +13899,9 @@ update_file_member = bb.Route(
     UpdateFileMemberArgs_validator,
     MemberAccessLevelResult_validator,
     FileMemberActionError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 update_folder_member = bb.Route(
     'update_folder_member',
@@ -13910,9 +13910,9 @@ update_folder_member = bb.Route(
     UpdateFolderMemberArg_validator,
     MemberAccessLevelResult_validator,
     UpdateFolderMemberError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 update_folder_policy = bb.Route(
     'update_folder_policy',
@@ -13921,9 +13921,9 @@ update_folder_policy = bb.Route(
     UpdateFolderPolicyArg_validator,
     SharedFolderMetadata_validator,
     UpdateFolderPolicyError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/team.py
+++ b/dropbox/team.py
@@ -13383,7 +13383,7 @@ class UsersSelectorArg(bb.Union):
 UsersSelectorArg_validator = bv.Union(UsersSelectorArg)
 
 GroupsGetInfoResult_validator = bv.List(GroupsGetInfoItem_validator)
-LegalHoldId_validator = bv.String(pattern=u'^pid_dbhid:.+')
+LegalHoldId_validator = bv.String(pattern='^pid_dbhid:.+')
 LegalHoldPolicyDescription_validator = bv.String(max_length=501)
 LegalHoldPolicyName_validator = bv.String(max_length=140)
 LegalHoldsGetPolicyResult_validator = LegalHoldPolicy_validator
@@ -13395,10 +13395,10 @@ LegalHoldsPolicyUpdateResult = LegalHoldPolicy
 ListHeldRevisionCursor_validator = bv.String(min_length=1)
 MembersGetInfoResult_validator = bv.List(MembersGetInfoItem_validator)
 NumberPerDay_validator = bv.List(bv.Nullable(bv.UInt64()))
-Path_validator = bv.String(pattern=u'(/(.|[\\r\\n])*)?')
+Path_validator = bv.String(pattern='(/(.|[\\r\\n])*)?')
 SecondaryEmail_validator = secondary_emails.SecondaryEmail_validator
 SecondaryEmail = secondary_emails.SecondaryEmail
-TeamMemberRoleId_validator = bv.String(max_length=128, pattern=u'pid_dbtmr:.*')
+TeamMemberRoleId_validator = bv.String(max_length=128, pattern='pid_dbtmr:.*')
 UserQuota_validator = bv.UInt32(min_value=15)
 DeviceSession.session_id.validator = bv.String()
 DeviceSession.ip_address.validator = bv.Nullable(bv.String())
@@ -16318,9 +16318,9 @@ devices_list_member_devices = bb.Route(
     ListMemberDevicesArg_validator,
     ListMemberDevicesResult_validator,
     ListMemberDevicesError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 devices_list_members_devices = bb.Route(
     'devices/list_members_devices',
@@ -16329,9 +16329,9 @@ devices_list_members_devices = bb.Route(
     ListMembersDevicesArg_validator,
     ListMembersDevicesResult_validator,
     ListMembersDevicesError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 devices_list_team_devices = bb.Route(
     'devices/list_team_devices',
@@ -16340,9 +16340,9 @@ devices_list_team_devices = bb.Route(
     ListTeamDevicesArg_validator,
     ListTeamDevicesResult_validator,
     ListTeamDevicesError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 devices_revoke_device_session = bb.Route(
     'devices/revoke_device_session',
@@ -16351,9 +16351,9 @@ devices_revoke_device_session = bb.Route(
     RevokeDeviceSessionArg_validator,
     bv.Void(),
     RevokeDeviceSessionError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 devices_revoke_device_session_batch = bb.Route(
     'devices/revoke_device_session_batch',
@@ -16362,9 +16362,9 @@ devices_revoke_device_session_batch = bb.Route(
     RevokeDeviceSessionBatchArg_validator,
     RevokeDeviceSessionBatchResult_validator,
     RevokeDeviceSessionBatchError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 features_get_values = bb.Route(
     'features/get_values',
@@ -16373,9 +16373,9 @@ features_get_values = bb.Route(
     FeaturesGetValuesBatchArg_validator,
     FeaturesGetValuesBatchResult_validator,
     FeaturesGetValuesBatchError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_info = bb.Route(
     'get_info',
@@ -16384,9 +16384,9 @@ get_info = bb.Route(
     bv.Void(),
     TeamGetInfoResult_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_create = bb.Route(
     'groups/create',
@@ -16395,9 +16395,9 @@ groups_create = bb.Route(
     GroupCreateArg_validator,
     GroupFullInfo_validator,
     GroupCreateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_delete = bb.Route(
     'groups/delete',
@@ -16406,9 +16406,9 @@ groups_delete = bb.Route(
     GroupSelector_validator,
     async_.LaunchEmptyResult_validator,
     GroupDeleteError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_get_info = bb.Route(
     'groups/get_info',
@@ -16417,9 +16417,9 @@ groups_get_info = bb.Route(
     GroupsSelector_validator,
     GroupsGetInfoResult_validator,
     GroupsGetInfoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_job_status_get = bb.Route(
     'groups/job_status/get',
@@ -16428,9 +16428,9 @@ groups_job_status_get = bb.Route(
     async_.PollArg_validator,
     async_.PollEmptyResult_validator,
     GroupsPollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_list = bb.Route(
     'groups/list',
@@ -16439,9 +16439,9 @@ groups_list = bb.Route(
     GroupsListArg_validator,
     GroupsListResult_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_list_continue = bb.Route(
     'groups/list/continue',
@@ -16450,9 +16450,9 @@ groups_list_continue = bb.Route(
     GroupsListContinueArg_validator,
     GroupsListResult_validator,
     GroupsListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_members_add = bb.Route(
     'groups/members/add',
@@ -16461,9 +16461,9 @@ groups_members_add = bb.Route(
     GroupMembersAddArg_validator,
     GroupMembersChangeResult_validator,
     GroupMembersAddError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_members_list = bb.Route(
     'groups/members/list',
@@ -16472,9 +16472,9 @@ groups_members_list = bb.Route(
     GroupsMembersListArg_validator,
     GroupsMembersListResult_validator,
     GroupSelectorError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_members_list_continue = bb.Route(
     'groups/members/list/continue',
@@ -16483,9 +16483,9 @@ groups_members_list_continue = bb.Route(
     GroupsMembersListContinueArg_validator,
     GroupsMembersListResult_validator,
     GroupsMembersListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_members_remove = bb.Route(
     'groups/members/remove',
@@ -16494,9 +16494,9 @@ groups_members_remove = bb.Route(
     GroupMembersRemoveArg_validator,
     GroupMembersChangeResult_validator,
     GroupMembersRemoveError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_members_set_access_type = bb.Route(
     'groups/members/set_access_type',
@@ -16505,9 +16505,9 @@ groups_members_set_access_type = bb.Route(
     GroupMembersSetAccessTypeArg_validator,
     GroupsGetInfoResult_validator,
     GroupMemberSetAccessTypeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 groups_update = bb.Route(
     'groups/update',
@@ -16516,9 +16516,9 @@ groups_update = bb.Route(
     GroupUpdateArgs_validator,
     GroupFullInfo_validator,
     GroupUpdateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_create_policy = bb.Route(
     'legal_holds/create_policy',
@@ -16527,9 +16527,9 @@ legal_holds_create_policy = bb.Route(
     LegalHoldsPolicyCreateArg_validator,
     LegalHoldsPolicyCreateResult_validator,
     LegalHoldsPolicyCreateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_get_policy = bb.Route(
     'legal_holds/get_policy',
@@ -16538,9 +16538,9 @@ legal_holds_get_policy = bb.Route(
     LegalHoldsGetPolicyArg_validator,
     LegalHoldsGetPolicyResult_validator,
     LegalHoldsGetPolicyError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_list_held_revisions = bb.Route(
     'legal_holds/list_held_revisions',
@@ -16549,9 +16549,9 @@ legal_holds_list_held_revisions = bb.Route(
     LegalHoldsListHeldRevisionsArg_validator,
     LegalHoldsListHeldRevisionResult_validator,
     LegalHoldsListHeldRevisionsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_list_held_revisions_continue = bb.Route(
     'legal_holds/list_held_revisions_continue',
@@ -16560,9 +16560,9 @@ legal_holds_list_held_revisions_continue = bb.Route(
     LegalHoldsListHeldRevisionsContinueArg_validator,
     LegalHoldsListHeldRevisionResult_validator,
     LegalHoldsListHeldRevisionsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_list_policies = bb.Route(
     'legal_holds/list_policies',
@@ -16571,9 +16571,9 @@ legal_holds_list_policies = bb.Route(
     LegalHoldsListPoliciesArg_validator,
     LegalHoldsListPoliciesResult_validator,
     LegalHoldsListPoliciesError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_release_policy = bb.Route(
     'legal_holds/release_policy',
@@ -16582,9 +16582,9 @@ legal_holds_release_policy = bb.Route(
     LegalHoldsPolicyReleaseArg_validator,
     bv.Void(),
     LegalHoldsPolicyReleaseError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 legal_holds_update_policy = bb.Route(
     'legal_holds/update_policy',
@@ -16593,9 +16593,9 @@ legal_holds_update_policy = bb.Route(
     LegalHoldsPolicyUpdateArg_validator,
     LegalHoldsPolicyUpdateResult_validator,
     LegalHoldsPolicyUpdateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 linked_apps_list_member_linked_apps = bb.Route(
     'linked_apps/list_member_linked_apps',
@@ -16604,9 +16604,9 @@ linked_apps_list_member_linked_apps = bb.Route(
     ListMemberAppsArg_validator,
     ListMemberAppsResult_validator,
     ListMemberAppsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 linked_apps_list_members_linked_apps = bb.Route(
     'linked_apps/list_members_linked_apps',
@@ -16615,9 +16615,9 @@ linked_apps_list_members_linked_apps = bb.Route(
     ListMembersAppsArg_validator,
     ListMembersAppsResult_validator,
     ListMembersAppsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 linked_apps_list_team_linked_apps = bb.Route(
     'linked_apps/list_team_linked_apps',
@@ -16626,9 +16626,9 @@ linked_apps_list_team_linked_apps = bb.Route(
     ListTeamAppsArg_validator,
     ListTeamAppsResult_validator,
     ListTeamAppsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 linked_apps_revoke_linked_app = bb.Route(
     'linked_apps/revoke_linked_app',
@@ -16637,9 +16637,9 @@ linked_apps_revoke_linked_app = bb.Route(
     RevokeLinkedApiAppArg_validator,
     bv.Void(),
     RevokeLinkedAppError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 linked_apps_revoke_linked_app_batch = bb.Route(
     'linked_apps/revoke_linked_app_batch',
@@ -16648,9 +16648,9 @@ linked_apps_revoke_linked_app_batch = bb.Route(
     RevokeLinkedApiAppBatchArg_validator,
     RevokeLinkedAppBatchResult_validator,
     RevokeLinkedAppBatchError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_excluded_users_add = bb.Route(
     'member_space_limits/excluded_users/add',
@@ -16659,9 +16659,9 @@ member_space_limits_excluded_users_add = bb.Route(
     ExcludedUsersUpdateArg_validator,
     ExcludedUsersUpdateResult_validator,
     ExcludedUsersUpdateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_excluded_users_list = bb.Route(
     'member_space_limits/excluded_users/list',
@@ -16670,9 +16670,9 @@ member_space_limits_excluded_users_list = bb.Route(
     ExcludedUsersListArg_validator,
     ExcludedUsersListResult_validator,
     ExcludedUsersListError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_excluded_users_list_continue = bb.Route(
     'member_space_limits/excluded_users/list/continue',
@@ -16681,9 +16681,9 @@ member_space_limits_excluded_users_list_continue = bb.Route(
     ExcludedUsersListContinueArg_validator,
     ExcludedUsersListResult_validator,
     ExcludedUsersListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_excluded_users_remove = bb.Route(
     'member_space_limits/excluded_users/remove',
@@ -16692,9 +16692,9 @@ member_space_limits_excluded_users_remove = bb.Route(
     ExcludedUsersUpdateArg_validator,
     ExcludedUsersUpdateResult_validator,
     ExcludedUsersUpdateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_get_custom_quota = bb.Route(
     'member_space_limits/get_custom_quota',
@@ -16703,9 +16703,9 @@ member_space_limits_get_custom_quota = bb.Route(
     CustomQuotaUsersArg_validator,
     bv.List(CustomQuotaResult_validator),
     CustomQuotaError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_remove_custom_quota = bb.Route(
     'member_space_limits/remove_custom_quota',
@@ -16714,9 +16714,9 @@ member_space_limits_remove_custom_quota = bb.Route(
     CustomQuotaUsersArg_validator,
     bv.List(RemoveCustomQuotaResult_validator),
     CustomQuotaError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 member_space_limits_set_custom_quota = bb.Route(
     'member_space_limits/set_custom_quota',
@@ -16725,9 +16725,9 @@ member_space_limits_set_custom_quota = bb.Route(
     SetCustomQuotaArg_validator,
     bv.List(CustomQuotaResult_validator),
     SetCustomQuotaError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_add_v2 = bb.Route(
     'members/add',
@@ -16736,9 +16736,9 @@ members_add_v2 = bb.Route(
     MembersAddV2Arg_validator,
     MembersAddLaunchV2Result_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_add = bb.Route(
     'members/add',
@@ -16747,9 +16747,9 @@ members_add = bb.Route(
     MembersAddArg_validator,
     MembersAddLaunch_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_add_job_status_get_v2 = bb.Route(
     'members/add/job_status/get',
@@ -16758,9 +16758,9 @@ members_add_job_status_get_v2 = bb.Route(
     async_.PollArg_validator,
     MembersAddJobStatusV2Result_validator,
     async_.PollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_add_job_status_get = bb.Route(
     'members/add/job_status/get',
@@ -16769,9 +16769,9 @@ members_add_job_status_get = bb.Route(
     async_.PollArg_validator,
     MembersAddJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_delete_profile_photo_v2 = bb.Route(
     'members/delete_profile_photo',
@@ -16780,9 +16780,9 @@ members_delete_profile_photo_v2 = bb.Route(
     MembersDeleteProfilePhotoArg_validator,
     TeamMemberInfoV2Result_validator,
     MembersDeleteProfilePhotoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_delete_profile_photo = bb.Route(
     'members/delete_profile_photo',
@@ -16791,9 +16791,9 @@ members_delete_profile_photo = bb.Route(
     MembersDeleteProfilePhotoArg_validator,
     TeamMemberInfo_validator,
     MembersDeleteProfilePhotoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_get_available_team_member_roles = bb.Route(
     'members/get_available_team_member_roles',
@@ -16802,9 +16802,9 @@ members_get_available_team_member_roles = bb.Route(
     bv.Void(),
     MembersGetAvailableTeamMemberRolesResult_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_get_info_v2 = bb.Route(
     'members/get_info',
@@ -16813,9 +16813,9 @@ members_get_info_v2 = bb.Route(
     MembersGetInfoV2Arg_validator,
     MembersGetInfoV2Result_validator,
     MembersGetInfoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_get_info = bb.Route(
     'members/get_info',
@@ -16824,9 +16824,9 @@ members_get_info = bb.Route(
     MembersGetInfoArgs_validator,
     MembersGetInfoResult_validator,
     MembersGetInfoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_list_v2 = bb.Route(
     'members/list',
@@ -16835,9 +16835,9 @@ members_list_v2 = bb.Route(
     MembersListArg_validator,
     MembersListV2Result_validator,
     MembersListError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_list = bb.Route(
     'members/list',
@@ -16846,9 +16846,9 @@ members_list = bb.Route(
     MembersListArg_validator,
     MembersListResult_validator,
     MembersListError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_list_continue_v2 = bb.Route(
     'members/list/continue',
@@ -16857,9 +16857,9 @@ members_list_continue_v2 = bb.Route(
     MembersListContinueArg_validator,
     MembersListV2Result_validator,
     MembersListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_list_continue = bb.Route(
     'members/list/continue',
@@ -16868,9 +16868,9 @@ members_list_continue = bb.Route(
     MembersListContinueArg_validator,
     MembersListResult_validator,
     MembersListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_move_former_member_files = bb.Route(
     'members/move_former_member_files',
@@ -16879,9 +16879,9 @@ members_move_former_member_files = bb.Route(
     MembersDataTransferArg_validator,
     async_.LaunchEmptyResult_validator,
     MembersTransferFormerMembersFilesError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_move_former_member_files_job_status_check = bb.Route(
     'members/move_former_member_files/job_status/check',
@@ -16890,9 +16890,9 @@ members_move_former_member_files_job_status_check = bb.Route(
     async_.PollArg_validator,
     async_.PollEmptyResult_validator,
     async_.PollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_recover = bb.Route(
     'members/recover',
@@ -16901,9 +16901,9 @@ members_recover = bb.Route(
     MembersRecoverArg_validator,
     bv.Void(),
     MembersRecoverError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_remove = bb.Route(
     'members/remove',
@@ -16912,9 +16912,9 @@ members_remove = bb.Route(
     MembersRemoveArg_validator,
     async_.LaunchEmptyResult_validator,
     MembersRemoveError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_remove_job_status_get = bb.Route(
     'members/remove/job_status/get',
@@ -16923,9 +16923,9 @@ members_remove_job_status_get = bb.Route(
     async_.PollArg_validator,
     async_.PollEmptyResult_validator,
     async_.PollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_secondary_emails_add = bb.Route(
     'members/secondary_emails/add',
@@ -16934,9 +16934,9 @@ members_secondary_emails_add = bb.Route(
     AddSecondaryEmailsArg_validator,
     AddSecondaryEmailsResult_validator,
     AddSecondaryEmailsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_secondary_emails_delete = bb.Route(
     'members/secondary_emails/delete',
@@ -16945,9 +16945,9 @@ members_secondary_emails_delete = bb.Route(
     DeleteSecondaryEmailsArg_validator,
     DeleteSecondaryEmailsResult_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_secondary_emails_resend_verification_emails = bb.Route(
     'members/secondary_emails/resend_verification_emails',
@@ -16956,9 +16956,9 @@ members_secondary_emails_resend_verification_emails = bb.Route(
     ResendVerificationEmailArg_validator,
     ResendVerificationEmailResult_validator,
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_send_welcome_email = bb.Route(
     'members/send_welcome_email',
@@ -16967,9 +16967,9 @@ members_send_welcome_email = bb.Route(
     UserSelectorArg_validator,
     bv.Void(),
     MembersSendWelcomeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_admin_permissions_v2 = bb.Route(
     'members/set_admin_permissions',
@@ -16978,9 +16978,9 @@ members_set_admin_permissions_v2 = bb.Route(
     MembersSetPermissions2Arg_validator,
     MembersSetPermissions2Result_validator,
     MembersSetPermissions2Error_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_admin_permissions = bb.Route(
     'members/set_admin_permissions',
@@ -16989,9 +16989,9 @@ members_set_admin_permissions = bb.Route(
     MembersSetPermissionsArg_validator,
     MembersSetPermissionsResult_validator,
     MembersSetPermissionsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_profile_v2 = bb.Route(
     'members/set_profile',
@@ -17000,9 +17000,9 @@ members_set_profile_v2 = bb.Route(
     MembersSetProfileArg_validator,
     TeamMemberInfoV2Result_validator,
     MembersSetProfileError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_profile = bb.Route(
     'members/set_profile',
@@ -17011,9 +17011,9 @@ members_set_profile = bb.Route(
     MembersSetProfileArg_validator,
     TeamMemberInfo_validator,
     MembersSetProfileError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_profile_photo_v2 = bb.Route(
     'members/set_profile_photo',
@@ -17022,9 +17022,9 @@ members_set_profile_photo_v2 = bb.Route(
     MembersSetProfilePhotoArg_validator,
     TeamMemberInfoV2Result_validator,
     MembersSetProfilePhotoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_set_profile_photo = bb.Route(
     'members/set_profile_photo',
@@ -17033,9 +17033,9 @@ members_set_profile_photo = bb.Route(
     MembersSetProfilePhotoArg_validator,
     TeamMemberInfo_validator,
     MembersSetProfilePhotoError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_suspend = bb.Route(
     'members/suspend',
@@ -17044,9 +17044,9 @@ members_suspend = bb.Route(
     MembersDeactivateArg_validator,
     bv.Void(),
     MembersSuspendError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 members_unsuspend = bb.Route(
     'members/unsuspend',
@@ -17055,9 +17055,9 @@ members_unsuspend = bb.Route(
     MembersUnsuspendArg_validator,
     bv.Void(),
     MembersUnsuspendError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 namespaces_list = bb.Route(
     'namespaces/list',
@@ -17066,9 +17066,9 @@ namespaces_list = bb.Route(
     TeamNamespacesListArg_validator,
     TeamNamespacesListResult_validator,
     TeamNamespacesListError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 namespaces_list_continue = bb.Route(
     'namespaces/list/continue',
@@ -17077,9 +17077,9 @@ namespaces_list_continue = bb.Route(
     TeamNamespacesListContinueArg_validator,
     TeamNamespacesListResult_validator,
     TeamNamespacesListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_add = bb.Route(
     'properties/template/add',
@@ -17088,9 +17088,9 @@ properties_template_add = bb.Route(
     file_properties.AddTemplateArg_validator,
     file_properties.AddTemplateResult_validator,
     file_properties.ModifyTemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_get = bb.Route(
     'properties/template/get',
@@ -17099,9 +17099,9 @@ properties_template_get = bb.Route(
     file_properties.GetTemplateArg_validator,
     file_properties.GetTemplateResult_validator,
     file_properties.TemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_list = bb.Route(
     'properties/template/list',
@@ -17110,9 +17110,9 @@ properties_template_list = bb.Route(
     bv.Void(),
     file_properties.ListTemplateResult_validator,
     file_properties.TemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 properties_template_update = bb.Route(
     'properties/template/update',
@@ -17121,9 +17121,9 @@ properties_template_update = bb.Route(
     file_properties.UpdateTemplateArg_validator,
     file_properties.UpdateTemplateResult_validator,
     file_properties.ModifyTemplateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 reports_get_activity = bb.Route(
     'reports/get_activity',
@@ -17132,9 +17132,9 @@ reports_get_activity = bb.Route(
     DateRange_validator,
     GetActivityReport_validator,
     DateRangeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 reports_get_devices = bb.Route(
     'reports/get_devices',
@@ -17143,9 +17143,9 @@ reports_get_devices = bb.Route(
     DateRange_validator,
     GetDevicesReport_validator,
     DateRangeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 reports_get_membership = bb.Route(
     'reports/get_membership',
@@ -17154,9 +17154,9 @@ reports_get_membership = bb.Route(
     DateRange_validator,
     GetMembershipReport_validator,
     DateRangeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 reports_get_storage = bb.Route(
     'reports/get_storage',
@@ -17165,9 +17165,9 @@ reports_get_storage = bb.Route(
     DateRange_validator,
     GetStorageReport_validator,
     DateRangeError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_activate = bb.Route(
     'team_folder/activate',
@@ -17176,9 +17176,9 @@ team_folder_activate = bb.Route(
     TeamFolderIdArg_validator,
     TeamFolderMetadata_validator,
     TeamFolderActivateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_archive = bb.Route(
     'team_folder/archive',
@@ -17187,9 +17187,9 @@ team_folder_archive = bb.Route(
     TeamFolderArchiveArg_validator,
     TeamFolderArchiveLaunch_validator,
     TeamFolderArchiveError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_archive_check = bb.Route(
     'team_folder/archive/check',
@@ -17198,9 +17198,9 @@ team_folder_archive_check = bb.Route(
     async_.PollArg_validator,
     TeamFolderArchiveJobStatus_validator,
     async_.PollError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_create = bb.Route(
     'team_folder/create',
@@ -17209,9 +17209,9 @@ team_folder_create = bb.Route(
     TeamFolderCreateArg_validator,
     TeamFolderMetadata_validator,
     TeamFolderCreateError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_get_info = bb.Route(
     'team_folder/get_info',
@@ -17220,9 +17220,9 @@ team_folder_get_info = bb.Route(
     TeamFolderIdListArg_validator,
     bv.List(TeamFolderGetInfoItem_validator),
     bv.Void(),
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_list = bb.Route(
     'team_folder/list',
@@ -17231,9 +17231,9 @@ team_folder_list = bb.Route(
     TeamFolderListArg_validator,
     TeamFolderListResult_validator,
     TeamFolderListError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_list_continue = bb.Route(
     'team_folder/list/continue',
@@ -17242,9 +17242,9 @@ team_folder_list_continue = bb.Route(
     TeamFolderListContinueArg_validator,
     TeamFolderListResult_validator,
     TeamFolderListContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_permanently_delete = bb.Route(
     'team_folder/permanently_delete',
@@ -17253,9 +17253,9 @@ team_folder_permanently_delete = bb.Route(
     TeamFolderIdArg_validator,
     bv.Void(),
     TeamFolderPermanentlyDeleteError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_rename = bb.Route(
     'team_folder/rename',
@@ -17264,9 +17264,9 @@ team_folder_rename = bb.Route(
     TeamFolderRenameArg_validator,
     TeamFolderMetadata_validator,
     TeamFolderRenameError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 team_folder_update_sync_settings = bb.Route(
     'team_folder/update_sync_settings',
@@ -17275,9 +17275,9 @@ team_folder_update_sync_settings = bb.Route(
     TeamFolderUpdateSyncSettingsArg_validator,
     TeamFolderMetadata_validator,
     TeamFolderUpdateSyncSettingsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 token_get_authenticated_admin = bb.Route(
     'token/get_authenticated_admin',
@@ -17286,9 +17286,9 @@ token_get_authenticated_admin = bb.Route(
     bv.Void(),
     TokenGetAuthenticatedAdminResult_validator,
     TokenGetAuthenticatedAdminError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/team_log.py
+++ b/dropbox/team_log.py
@@ -4804,6 +4804,86 @@ class DataPlacementRestrictionSatisfyPolicyType(bb.Struct):
 
 DataPlacementRestrictionSatisfyPolicyType_validator = bv.Struct(DataPlacementRestrictionSatisfyPolicyType)
 
+class DataResidencyMigrationRequestSuccessfulDetails(bb.Struct):
+    """
+    Requested data residency migration for team data.
+    """
+
+    __slots__ = [
+    ]
+
+    _has_required_fields = False
+
+    def __init__(self):
+        pass
+
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
+        super(DataResidencyMigrationRequestSuccessfulDetails, self)._process_custom_annotations(annotation_type, field_path, processor)
+
+DataResidencyMigrationRequestSuccessfulDetails_validator = bv.Struct(DataResidencyMigrationRequestSuccessfulDetails)
+
+class DataResidencyMigrationRequestSuccessfulType(bb.Struct):
+
+    __slots__ = [
+        '_description_value',
+    ]
+
+    _has_required_fields = True
+
+    def __init__(self,
+                 description=None):
+        self._description_value = bb.NOT_SET
+        if description is not None:
+            self.description = description
+
+    # Instance attribute type: str (validator is set below)
+    description = bb.Attribute("description")
+
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
+        super(DataResidencyMigrationRequestSuccessfulType, self)._process_custom_annotations(annotation_type, field_path, processor)
+
+DataResidencyMigrationRequestSuccessfulType_validator = bv.Struct(DataResidencyMigrationRequestSuccessfulType)
+
+class DataResidencyMigrationRequestUnsuccessfulDetails(bb.Struct):
+    """
+    Request for data residency migration for team data has failed.
+    """
+
+    __slots__ = [
+    ]
+
+    _has_required_fields = False
+
+    def __init__(self):
+        pass
+
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
+        super(DataResidencyMigrationRequestUnsuccessfulDetails, self)._process_custom_annotations(annotation_type, field_path, processor)
+
+DataResidencyMigrationRequestUnsuccessfulDetails_validator = bv.Struct(DataResidencyMigrationRequestUnsuccessfulDetails)
+
+class DataResidencyMigrationRequestUnsuccessfulType(bb.Struct):
+
+    __slots__ = [
+        '_description_value',
+    ]
+
+    _has_required_fields = True
+
+    def __init__(self,
+                 description=None):
+        self._description_value = bb.NOT_SET
+        if description is not None:
+            self.description = description
+
+    # Instance attribute type: str (validator is set below)
+    description = bb.Attribute("description")
+
+    def _process_custom_annotations(self, annotation_type, field_path, processor):
+        super(DataResidencyMigrationRequestUnsuccessfulType, self)._process_custom_annotations(annotation_type, field_path, processor)
+
+DataResidencyMigrationRequestUnsuccessfulType_validator = bv.Struct(DataResidencyMigrationRequestUnsuccessfulType)
+
 class DefaultLinkExpirationDaysPolicy(bb.Union):
     """
     Policy for the default number of days until an externally shared link
@@ -12886,6 +12966,30 @@ class EventDetails(bb.Union):
         return cls('web_sessions_change_idle_length_policy_details', val)
 
     @classmethod
+    def data_residency_migration_request_successful_details(cls, val):
+        """
+        Create an instance of this class set to the
+        ``data_residency_migration_request_successful_details`` tag with value
+        ``val``.
+
+        :param DataResidencyMigrationRequestSuccessfulDetails val:
+        :rtype: EventDetails
+        """
+        return cls('data_residency_migration_request_successful_details', val)
+
+    @classmethod
+    def data_residency_migration_request_unsuccessful_details(cls, val):
+        """
+        Create an instance of this class set to the
+        ``data_residency_migration_request_unsuccessful_details`` tag with value
+        ``val``.
+
+        :param DataResidencyMigrationRequestUnsuccessfulDetails val:
+        :rtype: EventDetails
+        """
+        return cls('data_residency_migration_request_unsuccessful_details', val)
+
+    @classmethod
     def team_merge_from_details(cls, val):
         """
         Create an instance of this class set to the ``team_merge_from_details``
@@ -16843,6 +16947,22 @@ class EventDetails(bb.Union):
         :rtype: bool
         """
         return self._tag == 'web_sessions_change_idle_length_policy_details'
+
+    def is_data_residency_migration_request_successful_details(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_successful_details``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_successful_details'
+
+    def is_data_residency_migration_request_unsuccessful_details(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_unsuccessful_details``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_unsuccessful_details'
 
     def is_team_merge_from_details(self):
         """
@@ -21536,6 +21656,26 @@ class EventDetails(bb.Union):
             raise AttributeError("tag 'web_sessions_change_idle_length_policy_details' not set")
         return self._value
 
+    def get_data_residency_migration_request_successful_details(self):
+        """
+        Only call this if :meth:`is_data_residency_migration_request_successful_details` is true.
+
+        :rtype: DataResidencyMigrationRequestSuccessfulDetails
+        """
+        if not self.is_data_residency_migration_request_successful_details():
+            raise AttributeError("tag 'data_residency_migration_request_successful_details' not set")
+        return self._value
+
+    def get_data_residency_migration_request_unsuccessful_details(self):
+        """
+        Only call this if :meth:`is_data_residency_migration_request_unsuccessful_details` is true.
+
+        :rtype: DataResidencyMigrationRequestUnsuccessfulDetails
+        """
+        if not self.is_data_residency_migration_request_unsuccessful_details():
+            raise AttributeError("tag 'data_residency_migration_request_unsuccessful_details' not set")
+        return self._value
+
     def get_team_merge_from_details(self):
         """
         Only call this if :meth:`is_team_merge_from_details` is true.
@@ -23022,6 +23162,12 @@ class EventType(bb.Union):
     :ivar WebSessionsChangeIdleLengthPolicyType
         EventType.web_sessions_change_idle_length_policy: (team_policies)
         Changed how long team members can be idle while signed in to Dropbox.com
+    :ivar DataResidencyMigrationRequestSuccessfulType
+        EventType.data_residency_migration_request_successful: (team_profile)
+        Requested data residency migration for team data
+    :ivar DataResidencyMigrationRequestUnsuccessfulType
+        EventType.data_residency_migration_request_unsuccessful: (team_profile)
+        Request for data residency migration for team data has failed
     :ivar TeamMergeFromType EventType.team_merge_from: (team_profile) Merged
         another team into this team
     :ivar TeamMergeToType EventType.team_merge_to: (team_profile) Merged this
@@ -27925,6 +28071,29 @@ class EventType(bb.Union):
         return cls('web_sessions_change_idle_length_policy', val)
 
     @classmethod
+    def data_residency_migration_request_successful(cls, val):
+        """
+        Create an instance of this class set to the
+        ``data_residency_migration_request_successful`` tag with value ``val``.
+
+        :param DataResidencyMigrationRequestSuccessfulType val:
+        :rtype: EventType
+        """
+        return cls('data_residency_migration_request_successful', val)
+
+    @classmethod
+    def data_residency_migration_request_unsuccessful(cls, val):
+        """
+        Create an instance of this class set to the
+        ``data_residency_migration_request_unsuccessful`` tag with value
+        ``val``.
+
+        :param DataResidencyMigrationRequestUnsuccessfulType val:
+        :rtype: EventType
+        """
+        return cls('data_residency_migration_request_unsuccessful', val)
+
+    @classmethod
     def team_merge_from(cls, val):
         """
         Create an instance of this class set to the ``team_merge_from`` tag with
@@ -31869,6 +32038,22 @@ class EventType(bb.Union):
         :rtype: bool
         """
         return self._tag == 'web_sessions_change_idle_length_policy'
+
+    def is_data_residency_migration_request_successful(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_successful``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_successful'
+
+    def is_data_residency_migration_request_unsuccessful(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_unsuccessful``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_unsuccessful'
 
     def is_team_merge_from(self):
         """
@@ -37494,6 +37679,31 @@ class EventType(bb.Union):
             raise AttributeError("tag 'web_sessions_change_idle_length_policy' not set")
         return self._value
 
+    def get_data_residency_migration_request_successful(self):
+        """
+        (team_profile) Requested data residency migration for team data
+
+        Only call this if :meth:`is_data_residency_migration_request_successful` is true.
+
+        :rtype: DataResidencyMigrationRequestSuccessfulType
+        """
+        if not self.is_data_residency_migration_request_successful():
+            raise AttributeError("tag 'data_residency_migration_request_successful' not set")
+        return self._value
+
+    def get_data_residency_migration_request_unsuccessful(self):
+        """
+        (team_profile) Request for data residency migration for team data has
+        failed
+
+        Only call this if :meth:`is_data_residency_migration_request_unsuccessful` is true.
+
+        :rtype: DataResidencyMigrationRequestUnsuccessfulType
+        """
+        if not self.is_data_residency_migration_request_unsuccessful():
+            raise AttributeError("tag 'data_residency_migration_request_unsuccessful' not set")
+        return self._value
+
     def get_team_merge_from(self):
         """
         (team_profile) Merged another team into this team
@@ -38901,6 +39111,11 @@ class EventTypeArg(bb.Union):
     :ivar team_log.EventTypeArg.web_sessions_change_idle_length_policy:
         (team_policies) Changed how long team members can be idle while signed
         in to Dropbox.com
+    :ivar team_log.EventTypeArg.data_residency_migration_request_successful:
+        (team_profile) Requested data residency migration for team data
+    :ivar team_log.EventTypeArg.data_residency_migration_request_unsuccessful:
+        (team_profile) Request for data residency migration for team data has
+        failed
     :ivar team_log.EventTypeArg.team_merge_from: (team_profile) Merged another
         team into this team
     :ivar team_log.EventTypeArg.team_merge_to: (team_profile) Merged this team
@@ -39877,6 +40092,10 @@ class EventTypeArg(bb.Union):
     web_sessions_change_fixed_length_policy = None
     # Attribute is overwritten below the class definition
     web_sessions_change_idle_length_policy = None
+    # Attribute is overwritten below the class definition
+    data_residency_migration_request_successful = None
+    # Attribute is overwritten below the class definition
+    data_residency_migration_request_unsuccessful = None
     # Attribute is overwritten below the class definition
     team_merge_from = None
     # Attribute is overwritten below the class definition
@@ -43436,6 +43655,22 @@ class EventTypeArg(bb.Union):
         """
         return self._tag == 'web_sessions_change_idle_length_policy'
 
+    def is_data_residency_migration_request_successful(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_successful``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_successful'
+
+    def is_data_residency_migration_request_unsuccessful(self):
+        """
+        Check if the union tag is ``data_residency_migration_request_unsuccessful``.
+
+        :rtype: bool
+        """
+        return self._tag == 'data_residency_migration_request_unsuccessful'
+
     def is_team_merge_from(self):
         """
         Check if the union tag is ``team_merge_from``.
@@ -44011,11 +44246,21 @@ class ExternalDriveBackupPolicy(bb.Union):
 
     _catch_all = 'other'
     # Attribute is overwritten below the class definition
+    default = None
+    # Attribute is overwritten below the class definition
     disabled = None
     # Attribute is overwritten below the class definition
     enabled = None
     # Attribute is overwritten below the class definition
     other = None
+
+    def is_default(self):
+        """
+        Check if the union tag is ``default``.
+
+        :rtype: bool
+        """
+        return self._tag == 'default'
 
     def is_disabled(self):
         """
@@ -72533,14 +72778,14 @@ AppLogInfo._fields_ = [
 AppLogInfo._all_fields_ = AppLogInfo._fields_
 
 AppLogInfo._tag_to_subtype_ = {
-    (u'user_or_team_linked_app',): UserOrTeamLinkedAppLogInfo_validator,
-    (u'user_linked_app',): UserLinkedAppLogInfo_validator,
-    (u'team_linked_app',): TeamLinkedAppLogInfo_validator,
+    ('user_or_team_linked_app',): UserOrTeamLinkedAppLogInfo_validator,
+    ('user_linked_app',): UserLinkedAppLogInfo_validator,
+    ('team_linked_app',): TeamLinkedAppLogInfo_validator,
 }
 AppLogInfo._pytype_to_tag_and_subtype_ = {
-    UserOrTeamLinkedAppLogInfo: ((u'user_or_team_linked_app',), UserOrTeamLinkedAppLogInfo_validator),
-    UserLinkedAppLogInfo: ((u'user_linked_app',), UserLinkedAppLogInfo_validator),
-    TeamLinkedAppLogInfo: ((u'team_linked_app',), TeamLinkedAppLogInfo_validator),
+    UserOrTeamLinkedAppLogInfo: (('user_or_team_linked_app',), UserOrTeamLinkedAppLogInfo_validator),
+    UserLinkedAppLogInfo: (('user_linked_app',), UserLinkedAppLogInfo_validator),
+    TeamLinkedAppLogInfo: (('team_linked_app',), TeamLinkedAppLogInfo_validator),
 }
 AppLogInfo._is_catch_all_ = True
 
@@ -73107,6 +73352,20 @@ DataPlacementRestrictionSatisfyPolicyType.description.validator = bv.String()
 DataPlacementRestrictionSatisfyPolicyType._all_field_names_ = set(['description'])
 DataPlacementRestrictionSatisfyPolicyType._all_fields_ = [('description', DataPlacementRestrictionSatisfyPolicyType.description.validator)]
 
+DataResidencyMigrationRequestSuccessfulDetails._all_field_names_ = set([])
+DataResidencyMigrationRequestSuccessfulDetails._all_fields_ = []
+
+DataResidencyMigrationRequestSuccessfulType.description.validator = bv.String()
+DataResidencyMigrationRequestSuccessfulType._all_field_names_ = set(['description'])
+DataResidencyMigrationRequestSuccessfulType._all_fields_ = [('description', DataResidencyMigrationRequestSuccessfulType.description.validator)]
+
+DataResidencyMigrationRequestUnsuccessfulDetails._all_field_names_ = set([])
+DataResidencyMigrationRequestUnsuccessfulDetails._all_fields_ = []
+
+DataResidencyMigrationRequestUnsuccessfulType.description.validator = bv.String()
+DataResidencyMigrationRequestUnsuccessfulType._all_field_names_ = set(['description'])
+DataResidencyMigrationRequestUnsuccessfulType._all_fields_ = [('description', DataResidencyMigrationRequestUnsuccessfulType.description.validator)]
+
 DefaultLinkExpirationDaysPolicy._day_1_validator = bv.Void()
 DefaultLinkExpirationDaysPolicy._day_180_validator = bv.Void()
 DefaultLinkExpirationDaysPolicy._day_3_validator = bv.Void()
@@ -73163,16 +73422,16 @@ DeviceSessionLogInfo._fields_ = [
 DeviceSessionLogInfo._all_fields_ = DeviceSessionLogInfo._fields_
 
 DeviceSessionLogInfo._tag_to_subtype_ = {
-    (u'desktop_device_session',): DesktopDeviceSessionLogInfo_validator,
-    (u'mobile_device_session',): MobileDeviceSessionLogInfo_validator,
-    (u'web_device_session',): WebDeviceSessionLogInfo_validator,
-    (u'legacy_device_session',): LegacyDeviceSessionLogInfo_validator,
+    ('desktop_device_session',): DesktopDeviceSessionLogInfo_validator,
+    ('mobile_device_session',): MobileDeviceSessionLogInfo_validator,
+    ('web_device_session',): WebDeviceSessionLogInfo_validator,
+    ('legacy_device_session',): LegacyDeviceSessionLogInfo_validator,
 }
 DeviceSessionLogInfo._pytype_to_tag_and_subtype_ = {
-    DesktopDeviceSessionLogInfo: ((u'desktop_device_session',), DesktopDeviceSessionLogInfo_validator),
-    MobileDeviceSessionLogInfo: ((u'mobile_device_session',), MobileDeviceSessionLogInfo_validator),
-    WebDeviceSessionLogInfo: ((u'web_device_session',), WebDeviceSessionLogInfo_validator),
-    LegacyDeviceSessionLogInfo: ((u'legacy_device_session',), LegacyDeviceSessionLogInfo_validator),
+    DesktopDeviceSessionLogInfo: (('desktop_device_session',), DesktopDeviceSessionLogInfo_validator),
+    MobileDeviceSessionLogInfo: (('mobile_device_session',), MobileDeviceSessionLogInfo_validator),
+    WebDeviceSessionLogInfo: (('web_device_session',), WebDeviceSessionLogInfo_validator),
+    LegacyDeviceSessionLogInfo: (('legacy_device_session',), LegacyDeviceSessionLogInfo_validator),
 }
 DeviceSessionLogInfo._is_catch_all_ = True
 
@@ -73208,14 +73467,14 @@ SessionLogInfo._fields_ = [('session_id', SessionLogInfo.session_id.validator)]
 SessionLogInfo._all_fields_ = SessionLogInfo._fields_
 
 SessionLogInfo._tag_to_subtype_ = {
-    (u'web',): WebSessionLogInfo_validator,
-    (u'desktop',): DesktopSessionLogInfo_validator,
-    (u'mobile',): MobileSessionLogInfo_validator,
+    ('web',): WebSessionLogInfo_validator,
+    ('desktop',): DesktopSessionLogInfo_validator,
+    ('mobile',): MobileSessionLogInfo_validator,
 }
 SessionLogInfo._pytype_to_tag_and_subtype_ = {
-    WebSessionLogInfo: ((u'web',), WebSessionLogInfo_validator),
-    DesktopSessionLogInfo: ((u'desktop',), DesktopSessionLogInfo_validator),
-    MobileSessionLogInfo: ((u'mobile',), MobileSessionLogInfo_validator),
+    WebSessionLogInfo: (('web',), WebSessionLogInfo_validator),
+    DesktopSessionLogInfo: (('desktop',), DesktopSessionLogInfo_validator),
+    MobileSessionLogInfo: (('mobile',), MobileSessionLogInfo_validator),
 }
 SessionLogInfo._is_catch_all_ = True
 
@@ -74309,6 +74568,8 @@ EventDetails._watermarking_policy_changed_details_validator = WatermarkingPolicy
 EventDetails._web_sessions_change_active_session_limit_details_validator = WebSessionsChangeActiveSessionLimitDetails_validator
 EventDetails._web_sessions_change_fixed_length_policy_details_validator = WebSessionsChangeFixedLengthPolicyDetails_validator
 EventDetails._web_sessions_change_idle_length_policy_details_validator = WebSessionsChangeIdleLengthPolicyDetails_validator
+EventDetails._data_residency_migration_request_successful_details_validator = DataResidencyMigrationRequestSuccessfulDetails_validator
+EventDetails._data_residency_migration_request_unsuccessful_details_validator = DataResidencyMigrationRequestUnsuccessfulDetails_validator
 EventDetails._team_merge_from_details_validator = TeamMergeFromDetails_validator
 EventDetails._team_merge_to_details_validator = TeamMergeToDetails_validator
 EventDetails._team_profile_add_background_details_validator = TeamProfileAddBackgroundDetails_validator
@@ -74788,6 +75049,8 @@ EventDetails._tagmap = {
     'web_sessions_change_active_session_limit_details': EventDetails._web_sessions_change_active_session_limit_details_validator,
     'web_sessions_change_fixed_length_policy_details': EventDetails._web_sessions_change_fixed_length_policy_details_validator,
     'web_sessions_change_idle_length_policy_details': EventDetails._web_sessions_change_idle_length_policy_details_validator,
+    'data_residency_migration_request_successful_details': EventDetails._data_residency_migration_request_successful_details_validator,
+    'data_residency_migration_request_unsuccessful_details': EventDetails._data_residency_migration_request_unsuccessful_details_validator,
     'team_merge_from_details': EventDetails._team_merge_from_details_validator,
     'team_merge_to_details': EventDetails._team_merge_to_details_validator,
     'team_profile_add_background_details': EventDetails._team_profile_add_background_details_validator,
@@ -75270,6 +75533,8 @@ EventType._watermarking_policy_changed_validator = WatermarkingPolicyChangedType
 EventType._web_sessions_change_active_session_limit_validator = WebSessionsChangeActiveSessionLimitType_validator
 EventType._web_sessions_change_fixed_length_policy_validator = WebSessionsChangeFixedLengthPolicyType_validator
 EventType._web_sessions_change_idle_length_policy_validator = WebSessionsChangeIdleLengthPolicyType_validator
+EventType._data_residency_migration_request_successful_validator = DataResidencyMigrationRequestSuccessfulType_validator
+EventType._data_residency_migration_request_unsuccessful_validator = DataResidencyMigrationRequestUnsuccessfulType_validator
 EventType._team_merge_from_validator = TeamMergeFromType_validator
 EventType._team_merge_to_validator = TeamMergeToType_validator
 EventType._team_profile_add_background_validator = TeamProfileAddBackgroundType_validator
@@ -75748,6 +76013,8 @@ EventType._tagmap = {
     'web_sessions_change_active_session_limit': EventType._web_sessions_change_active_session_limit_validator,
     'web_sessions_change_fixed_length_policy': EventType._web_sessions_change_fixed_length_policy_validator,
     'web_sessions_change_idle_length_policy': EventType._web_sessions_change_idle_length_policy_validator,
+    'data_residency_migration_request_successful': EventType._data_residency_migration_request_successful_validator,
+    'data_residency_migration_request_unsuccessful': EventType._data_residency_migration_request_unsuccessful_validator,
     'team_merge_from': EventType._team_merge_from_validator,
     'team_merge_to': EventType._team_merge_to_validator,
     'team_profile_add_background': EventType._team_profile_add_background_validator,
@@ -76229,6 +76496,8 @@ EventTypeArg._watermarking_policy_changed_validator = bv.Void()
 EventTypeArg._web_sessions_change_active_session_limit_validator = bv.Void()
 EventTypeArg._web_sessions_change_fixed_length_policy_validator = bv.Void()
 EventTypeArg._web_sessions_change_idle_length_policy_validator = bv.Void()
+EventTypeArg._data_residency_migration_request_successful_validator = bv.Void()
+EventTypeArg._data_residency_migration_request_unsuccessful_validator = bv.Void()
 EventTypeArg._team_merge_from_validator = bv.Void()
 EventTypeArg._team_merge_to_validator = bv.Void()
 EventTypeArg._team_profile_add_background_validator = bv.Void()
@@ -76707,6 +76976,8 @@ EventTypeArg._tagmap = {
     'web_sessions_change_active_session_limit': EventTypeArg._web_sessions_change_active_session_limit_validator,
     'web_sessions_change_fixed_length_policy': EventTypeArg._web_sessions_change_fixed_length_policy_validator,
     'web_sessions_change_idle_length_policy': EventTypeArg._web_sessions_change_idle_length_policy_validator,
+    'data_residency_migration_request_successful': EventTypeArg._data_residency_migration_request_successful_validator,
+    'data_residency_migration_request_unsuccessful': EventTypeArg._data_residency_migration_request_unsuccessful_validator,
     'team_merge_from': EventTypeArg._team_merge_from_validator,
     'team_merge_to': EventTypeArg._team_merge_to_validator,
     'team_profile_add_background': EventTypeArg._team_profile_add_background_validator,
@@ -77186,6 +77457,8 @@ EventTypeArg.watermarking_policy_changed = EventTypeArg('watermarking_policy_cha
 EventTypeArg.web_sessions_change_active_session_limit = EventTypeArg('web_sessions_change_active_session_limit')
 EventTypeArg.web_sessions_change_fixed_length_policy = EventTypeArg('web_sessions_change_fixed_length_policy')
 EventTypeArg.web_sessions_change_idle_length_policy = EventTypeArg('web_sessions_change_idle_length_policy')
+EventTypeArg.data_residency_migration_request_successful = EventTypeArg('data_residency_migration_request_successful')
+EventTypeArg.data_residency_migration_request_unsuccessful = EventTypeArg('data_residency_migration_request_unsuccessful')
 EventTypeArg.team_merge_from = EventTypeArg('team_merge_from')
 EventTypeArg.team_merge_to = EventTypeArg('team_merge_to')
 EventTypeArg.team_profile_add_background = EventTypeArg('team_profile_add_background')
@@ -77279,15 +77552,18 @@ ExtendedVersionHistoryPolicy.implicitly_limited = ExtendedVersionHistoryPolicy('
 ExtendedVersionHistoryPolicy.implicitly_unlimited = ExtendedVersionHistoryPolicy('implicitly_unlimited')
 ExtendedVersionHistoryPolicy.other = ExtendedVersionHistoryPolicy('other')
 
+ExternalDriveBackupPolicy._default_validator = bv.Void()
 ExternalDriveBackupPolicy._disabled_validator = bv.Void()
 ExternalDriveBackupPolicy._enabled_validator = bv.Void()
 ExternalDriveBackupPolicy._other_validator = bv.Void()
 ExternalDriveBackupPolicy._tagmap = {
+    'default': ExternalDriveBackupPolicy._default_validator,
     'disabled': ExternalDriveBackupPolicy._disabled_validator,
     'enabled': ExternalDriveBackupPolicy._enabled_validator,
     'other': ExternalDriveBackupPolicy._other_validator,
 }
 
+ExternalDriveBackupPolicy.default = ExternalDriveBackupPolicy('default')
 ExternalDriveBackupPolicy.disabled = ExternalDriveBackupPolicy('disabled')
 ExternalDriveBackupPolicy.enabled = ExternalDriveBackupPolicy('enabled')
 ExternalDriveBackupPolicy.other = ExternalDriveBackupPolicy('other')
@@ -79643,14 +79919,14 @@ UserLogInfo._fields_ = [
 UserLogInfo._all_fields_ = UserLogInfo._fields_
 
 UserLogInfo._tag_to_subtype_ = {
-    (u'team_member',): TeamMemberLogInfo_validator,
-    (u'trusted_non_team_member',): TrustedNonTeamMemberLogInfo_validator,
-    (u'non_team_member',): NonTeamMemberLogInfo_validator,
+    ('team_member',): TeamMemberLogInfo_validator,
+    ('trusted_non_team_member',): TrustedNonTeamMemberLogInfo_validator,
+    ('non_team_member',): NonTeamMemberLogInfo_validator,
 }
 UserLogInfo._pytype_to_tag_and_subtype_ = {
-    TeamMemberLogInfo: ((u'team_member',), TeamMemberLogInfo_validator),
-    TrustedNonTeamMemberLogInfo: ((u'trusted_non_team_member',), TrustedNonTeamMemberLogInfo_validator),
-    NonTeamMemberLogInfo: ((u'non_team_member',), NonTeamMemberLogInfo_validator),
+    TeamMemberLogInfo: (('team_member',), TeamMemberLogInfo_validator),
+    TrustedNonTeamMemberLogInfo: (('trusted_non_team_member',), TrustedNonTeamMemberLogInfo_validator),
+    NonTeamMemberLogInfo: (('non_team_member',), NonTeamMemberLogInfo_validator),
 }
 UserLogInfo._is_catch_all_ = True
 
@@ -83601,9 +83877,9 @@ get_events = bb.Route(
     GetTeamEventsArg_validator,
     GetTeamEventsResult_validator,
     GetTeamEventsError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_events_continue = bb.Route(
     'get_events/continue',
@@ -83612,9 +83888,9 @@ get_events_continue = bb.Route(
     GetTeamEventsContinueArg_validator,
     GetTeamEventsResult_validator,
     GetTeamEventsContinueError_validator,
-    {'auth': u'team',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'team',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {

--- a/dropbox/team_policies.py
+++ b/dropbox/team_policies.py
@@ -185,6 +185,8 @@ class ExternalDriveBackupPolicyState(bb.Union):
         Backup feature is disabled.
     :ivar team_policies.ExternalDriveBackupPolicyState.enabled: External Drive
         Backup feature is enabled.
+    :ivar team_policies.ExternalDriveBackupPolicyState.default: External Drive
+        Backup default value based on team tier.
     """
 
     _catch_all = 'other'
@@ -192,6 +194,8 @@ class ExternalDriveBackupPolicyState(bb.Union):
     disabled = None
     # Attribute is overwritten below the class definition
     enabled = None
+    # Attribute is overwritten below the class definition
+    default = None
     # Attribute is overwritten below the class definition
     other = None
 
@@ -210,6 +214,14 @@ class ExternalDriveBackupPolicyState(bb.Union):
         :rtype: bool
         """
         return self._tag == 'enabled'
+
+    def is_default(self):
+        """
+        Check if the union tag is ``default``.
+
+        :rtype: bool
+        """
+        return self._tag == 'default'
 
     def is_other(self):
         """
@@ -1527,15 +1539,18 @@ EmmState.other = EmmState('other')
 
 ExternalDriveBackupPolicyState._disabled_validator = bv.Void()
 ExternalDriveBackupPolicyState._enabled_validator = bv.Void()
+ExternalDriveBackupPolicyState._default_validator = bv.Void()
 ExternalDriveBackupPolicyState._other_validator = bv.Void()
 ExternalDriveBackupPolicyState._tagmap = {
     'disabled': ExternalDriveBackupPolicyState._disabled_validator,
     'enabled': ExternalDriveBackupPolicyState._enabled_validator,
+    'default': ExternalDriveBackupPolicyState._default_validator,
     'other': ExternalDriveBackupPolicyState._other_validator,
 }
 
 ExternalDriveBackupPolicyState.disabled = ExternalDriveBackupPolicyState('disabled')
 ExternalDriveBackupPolicyState.enabled = ExternalDriveBackupPolicyState('enabled')
+ExternalDriveBackupPolicyState.default = ExternalDriveBackupPolicyState('default')
 ExternalDriveBackupPolicyState.other = ExternalDriveBackupPolicyState('other')
 
 FileLockingPolicyState._disabled_validator = bv.Void()

--- a/dropbox/users.py
+++ b/dropbox/users.py
@@ -1371,9 +1371,9 @@ features_get_values = bb.Route(
     UserFeaturesGetValuesBatchArg_validator,
     UserFeaturesGetValuesBatchResult_validator,
     UserFeaturesGetValuesBatchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_account = bb.Route(
     'get_account',
@@ -1382,9 +1382,9 @@ get_account = bb.Route(
     GetAccountArg_validator,
     BasicAccount_validator,
     GetAccountError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_account_batch = bb.Route(
     'get_account_batch',
@@ -1393,9 +1393,9 @@ get_account_batch = bb.Route(
     GetAccountBatchArg_validator,
     GetAccountBatchResult_validator,
     GetAccountBatchError_validator,
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_current_account = bb.Route(
     'get_current_account',
@@ -1404,9 +1404,9 @@ get_current_account = bb.Route(
     bv.Void(),
     FullAccount_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 get_space_usage = bb.Route(
     'get_space_usage',
@@ -1415,9 +1415,9 @@ get_space_usage = bb.Route(
     bv.Void(),
     SpaceUsage_validator,
     bv.Void(),
-    {'auth': u'user',
-     'host': u'api',
-     'style': u'rpc'},
+    {'auth': 'user',
+     'host': 'api',
+     'style': 'rpc'},
 )
 
 ROUTES = {


### PR DESCRIPTION
Automated Spec Update 
 13bbef7298d235257ee5576025b5938f748de526 

 Change Notes:

files Namespace
- Add MoveIntoFamilyError unions
- Add payload_too_large and cant_move_into_family errors

sharing_files Namespace
- doc update

team_log_generated Namespace
- Add DataResidencyMigrationRequestSuccessfulDetails, DataResidencyMigrationRequestUnsuccessfulDetails, DataResidencyMigrationRequestSuccessfulType, DataResidencyMigrationRequestUnsuccessfulType structs

Co-authored-by: Scott Erickson <serickson@dropbox.com>

 4c1da4778bc4bd3dbc6b55e11788a40aa896b3dc 

 Change Notes:

Team Log Generated Namespace:

- Update ExtendedVersionHistoryPolicy union to include default
- Update Examples

Team Policies Namespace:

- Update ExternalDriveBackupPolicyState union to include default