### PR TITLE
Fix spec update action

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v2.2.2
         with:
-          python-version: 2.7
+          python-version: 3.7
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -1,5 +1,5 @@
 name: Spec Update
-on: 
+on:
   workflow_dispatch:
   repository_dispatch:
     types: [spec_update]
@@ -19,9 +19,6 @@ jobs:
         with:
           format: YYYY_MM_DD
           utcOffset: "-08:00"
-      - name: Install SDK
-        run: |
-          npm install
       - name: Update Modules
         run: |
           git submodule init

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
Not exactly sure how this worked before. But the last couple runs have been blocked by running on python 2, and running an `npm install` command that doesn't seem to do anything. This fixes the action, which [successfully ran](https://github.com/dropbox/dropbox-sdk-python/actions/runs/1786587640) and was merged in #412.

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does `tox` pass?
- [ ] Do the tests pass?