### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ dist = setup(
     license='MIT License',
     long_description=README,
     url='http://www.dropbox.com/developers',
+    project_urls={
+        'Source': 'https://github.com/dropbox/dropbox-sdk-python',
+    },
     # From <https://pypi.python.org/pypi?%3Aaction=list_classifiers>
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does `tox` pass?
- [ ] Do the tests pass?

Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)