### PR TITLE
Automated Spec Update

### DIFF
--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -1465,7 +1465,8 @@ class DropboxBase(object):
         must be less than 20 GB in size and any single file within must be less
         than 4 GB in size. The resulting zip must have fewer than 10,000 total
         file and folder entries, including the top level folder. The input
-        cannot be a single file.
+        cannot be a single file. Note: this endpoint does not support HTTP range
+        requests.
 
         Route attributes:
             scope: files.content.read
@@ -1501,7 +1502,8 @@ class DropboxBase(object):
         must be less than 20 GB in size and any single file within must be less
         than 4 GB in size. The resulting zip must have fewer than 10,000 total
         file and folder entries, including the top level folder. The input
-        cannot be a single file.
+        cannot be a single file. Note: this endpoint does not support HTTP range
+        requests.
 
         Route attributes:
             scope: files.content.read

--- a/dropbox/base_team.py
+++ b/dropbox/base_team.py
@@ -810,7 +810,7 @@ class DropboxTeamBase(object):
         all teams have the feature. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str name: Policy name.
         :param Nullable[str] description: A description of the legal hold
@@ -845,7 +845,7 @@ class DropboxTeamBase(object):
         teams have the feature. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str id: The legal hold Id.
         :rtype: :class:`dropbox.team.LegalHoldPolicy`
@@ -871,7 +871,7 @@ class DropboxTeamBase(object):
         file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str id: The legal hold Id.
         :rtype: :class:`dropbox.team.LegalHoldsListHeldRevisionResult`
@@ -898,7 +898,7 @@ class DropboxTeamBase(object):
         Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str id: The legal hold Id.
         :param Nullable[str] cursor: The cursor idicates where to continue
@@ -927,7 +927,7 @@ class DropboxTeamBase(object):
         teams have the feature. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param bool include_released: Whether to return holds that were
             released.
@@ -953,7 +953,7 @@ class DropboxTeamBase(object):
         teams have the feature. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str id: The legal hold Id.
         :rtype: None
@@ -981,7 +981,7 @@ class DropboxTeamBase(object):
         have the feature. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.member
+            scope: team_data.governance.write
 
         :param str id: The legal hold Id.
         :param Nullable[str] name: Policy new name.
@@ -2565,7 +2565,7 @@ class DropboxTeamBase(object):
         member file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param str team_folder_id: The ID of the team folder.
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
@@ -2588,7 +2588,7 @@ class DropboxTeamBase(object):
         shared team space. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param bool force_async_off: Whether to force the archive to happen
             synchronously.
@@ -2611,7 +2611,7 @@ class DropboxTeamBase(object):
         Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param str async_job_id: Id of the asynchronous job. This is the value
             of a response returned from the method that launched the job.
@@ -2639,7 +2639,7 @@ class DropboxTeamBase(object):
         Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param str name: Name for the new team folder.
         :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: The
@@ -2668,7 +2668,7 @@ class DropboxTeamBase(object):
         access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.read
 
         :param List[str] team_folder_ids: The list of team folder IDs.
         :rtype: List[:class:`dropbox.team.TeamFolderGetInfoItem`]
@@ -2688,7 +2688,7 @@ class DropboxTeamBase(object):
         Lists all team folders. Permission : Team member file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.read
 
         :param int limit: The maximum number of results to return per request.
         :rtype: :class:`dropbox.team.TeamFolderListResult`
@@ -2714,7 +2714,7 @@ class DropboxTeamBase(object):
         access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.read
 
         :param str cursor: Indicates from what point to get the next set of team
             folders.
@@ -2741,7 +2741,7 @@ class DropboxTeamBase(object):
         file access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param str team_folder_id: The ID of the team folder.
         :rtype: None
@@ -2763,7 +2763,7 @@ class DropboxTeamBase(object):
         access.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param str name: New team folder name.
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
@@ -2791,7 +2791,7 @@ class DropboxTeamBase(object):
         endpoint requires that the team has team selective sync enabled.
 
         Route attributes:
-            scope: team_data.team_space
+            scope: team_data.content.write
 
         :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: Sync
             setting to apply to the team folder itself. Only meaningful if the

--- a/dropbox/sharing.py
+++ b/dropbox/sharing.py
@@ -13606,7 +13606,7 @@ get_shared_link_metadata = bb.Route(
     GetSharedLinkMetadataArg_validator,
     SharedLinkMetadata_validator,
     SharedLinkError_validator,
-    {'auth': 'user',
+    {'auth': 'app, user',
      'host': 'api',
      'style': 'rpc'},
 )

--- a/dropbox/team_log.py
+++ b/dropbox/team_log.py
@@ -1327,12 +1327,17 @@ class AdminAlertingAlertConfiguration(bb.Struct):
         Sensitivity level.
     :ivar team_log.AdminAlertingAlertConfiguration.recipients_settings:
         Recipient settings.
+    :ivar team_log.AdminAlertingAlertConfiguration.text: Text.
+    :ivar team_log.AdminAlertingAlertConfiguration.excluded_file_extensions:
+        Excluded file extensions.
     """
 
     __slots__ = [
         '_alert_state_value',
         '_sensitivity_level_value',
         '_recipients_settings_value',
+        '_text_value',
+        '_excluded_file_extensions_value',
     ]
 
     _has_required_fields = False
@@ -1340,16 +1345,24 @@ class AdminAlertingAlertConfiguration(bb.Struct):
     def __init__(self,
                  alert_state=None,
                  sensitivity_level=None,
-                 recipients_settings=None):
+                 recipients_settings=None,
+                 text=None,
+                 excluded_file_extensions=None):
         self._alert_state_value = bb.NOT_SET
         self._sensitivity_level_value = bb.NOT_SET
         self._recipients_settings_value = bb.NOT_SET
+        self._text_value = bb.NOT_SET
+        self._excluded_file_extensions_value = bb.NOT_SET
         if alert_state is not None:
             self.alert_state = alert_state
         if sensitivity_level is not None:
             self.sensitivity_level = sensitivity_level
         if recipients_settings is not None:
             self.recipients_settings = recipients_settings
+        if text is not None:
+            self.text = text
+        if excluded_file_extensions is not None:
+            self.excluded_file_extensions = excluded_file_extensions
 
     # Instance attribute type: AdminAlertingAlertStatePolicy (validator is set below)
     alert_state = bb.Attribute("alert_state", nullable=True, user_defined=True)
@@ -1359,6 +1372,12 @@ class AdminAlertingAlertConfiguration(bb.Struct):
 
     # Instance attribute type: RecipientsConfiguration (validator is set below)
     recipients_settings = bb.Attribute("recipients_settings", nullable=True, user_defined=True)
+
+    # Instance attribute type: str (validator is set below)
+    text = bb.Attribute("text", nullable=True)
+
+    # Instance attribute type: str (validator is set below)
+    excluded_file_extensions = bb.Attribute("excluded_file_extensions", nullable=True)
 
     def _process_custom_annotations(self, annotation_type, field_path, processor):
         super(AdminAlertingAlertConfiguration, self)._process_custom_annotations(annotation_type, field_path, processor)
@@ -59209,6 +59228,8 @@ class PlacementRestriction(bb.Union):
     # Attribute is overwritten below the class definition
     uk_only = None
     # Attribute is overwritten below the class definition
+    us_s3_only = None
+    # Attribute is overwritten below the class definition
     other = None
 
     def is_australia_only(self):
@@ -59250,6 +59271,14 @@ class PlacementRestriction(bb.Union):
         :rtype: bool
         """
         return self._tag == 'uk_only'
+
+    def is_us_s3_only(self):
+        """
+        Check if the union tag is ``us_s3_only``.
+
+        :rtype: bool
+        """
+        return self._tag == 'us_s3_only'
 
     def is_other(self):
         """
@@ -73139,15 +73168,21 @@ AdminAlertSeverityEnum.other = AdminAlertSeverityEnum('other')
 AdminAlertingAlertConfiguration.alert_state.validator = bv.Nullable(AdminAlertingAlertStatePolicy_validator)
 AdminAlertingAlertConfiguration.sensitivity_level.validator = bv.Nullable(AdminAlertingAlertSensitivity_validator)
 AdminAlertingAlertConfiguration.recipients_settings.validator = bv.Nullable(RecipientsConfiguration_validator)
+AdminAlertingAlertConfiguration.text.validator = bv.Nullable(bv.String())
+AdminAlertingAlertConfiguration.excluded_file_extensions.validator = bv.Nullable(bv.String())
 AdminAlertingAlertConfiguration._all_field_names_ = set([
     'alert_state',
     'sensitivity_level',
     'recipients_settings',
+    'text',
+    'excluded_file_extensions',
 ])
 AdminAlertingAlertConfiguration._all_fields_ = [
     ('alert_state', AdminAlertingAlertConfiguration.alert_state.validator),
     ('sensitivity_level', AdminAlertingAlertConfiguration.sensitivity_level.validator),
     ('recipients_settings', AdminAlertingAlertConfiguration.recipients_settings.validator),
+    ('text', AdminAlertingAlertConfiguration.text.validator),
+    ('excluded_file_extensions', AdminAlertingAlertConfiguration.excluded_file_extensions.validator),
 ]
 
 AdminAlertingAlertSensitivity._high_validator = bv.Void()
@@ -81549,6 +81584,7 @@ PlacementRestriction._europe_only_validator = bv.Void()
 PlacementRestriction._japan_only_validator = bv.Void()
 PlacementRestriction._none_validator = bv.Void()
 PlacementRestriction._uk_only_validator = bv.Void()
+PlacementRestriction._us_s3_only_validator = bv.Void()
 PlacementRestriction._other_validator = bv.Void()
 PlacementRestriction._tagmap = {
     'australia_only': PlacementRestriction._australia_only_validator,
@@ -81556,6 +81592,7 @@ PlacementRestriction._tagmap = {
     'japan_only': PlacementRestriction._japan_only_validator,
     'none': PlacementRestriction._none_validator,
     'uk_only': PlacementRestriction._uk_only_validator,
+    'us_s3_only': PlacementRestriction._us_s3_only_validator,
     'other': PlacementRestriction._other_validator,
 }
 
@@ -81564,6 +81601,7 @@ PlacementRestriction.europe_only = PlacementRestriction('europe_only')
 PlacementRestriction.japan_only = PlacementRestriction('japan_only')
 PlacementRestriction.none = PlacementRestriction('none')
 PlacementRestriction.uk_only = PlacementRestriction('uk_only')
+PlacementRestriction.us_s3_only = PlacementRestriction('us_s3_only')
 PlacementRestriction.other = PlacementRestriction('other')
 
 PolicyType._disposition_validator = bv.Void()


### PR DESCRIPTION
Automated Spec Update 
 69f7bb2ea7702db5564f12549efb23956c5d6329 

 Change Notes:

files Namespace
- Update examples

shared_links Namespace
- Update get_shared_link_metadata route to include app and user auth

team_folders Namespace
- Update team_folder/create, team_folder/rename, team_folder/list, team_folder/list/continue, team_folder/get_info, team_folder/activate, team_folder/archive, team_folder/archive/check, team_folder/permanently_delete, team_folder/update_sync_settings routes to include updated scopes

team_legal_holds Namespace
- Update legal_holds/create_policy, legal_holds/get_policy, legal_holds/list_policies, legal_holds/list_held_revisions, legal_holds/list_held_revisions_continue, legal_holds/update_policy, legal_holds/release_policy routes to include updated scopes
team_log_generated Namespace
- Update AdminAlertingAlertConfiguration to include text and excluded_file_extensions
- Update PlacementRestriction to include us_s3_only
- Update examples

Co-authored-by: Brent Bumann <bbumann@dropbox.com>