### PR TITLE
Added _ca_certs property to _SSLAdapter to properly support pickling (broke in SDK v11.33)

### DIFF
--- a/dropbox/session.py
+++ b/dropbox/session.py
@@ -41,6 +41,7 @@ except NotImplementedError:  # Package is used inside python archive
 # TODO(kelkabany): We probably only want to instantiate this once so that even
 # if multiple Dropbox objects are instantiated, they all share the same pool.
 class _SSLAdapter(HTTPAdapter):
+    _ca_certs = None
 
     def __init__(self, *args, **kwargs):
         self._ca_certs = kwargs.pop("ca_certs", None) or _TRUSTED_CERT_FILE

--- a/test/unit/test_dropbox_unit.py
+++ b/test/unit/test_dropbox_unit.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import mock
+import pickle
 
 import pytest
 
@@ -404,3 +405,10 @@ class TestClient:
                       app_secret=APP_SECRET,
                       session=session_instance)
         dbx.as_user(TEAM_MEMBER_ID)
+
+
+class TestSession:
+    def test_pickle_session(self):
+        session_obj = create_session()
+        pickled_session = pickle.dumps(session_obj)
+        pickle.loads(pickled_session)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->
In Dropbox SDK v11.33 PR #385 added a new `_ca_certs` property to `_SSLAdapter`. 

However, the property is dynamically specified, which **breaks** *unpickling* it using `pickle.loads()`:
```
  AttributeError: '_SSLAdapter' object has no attribute '_ca_certs'
```

The fix is simple: **Define** the property instead of _dynamically_ defining it.


## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [ ] Have you read the Code of Conduct ? -> Broken! ❌
- [x] Have you read signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] ~~Non-code related change (markdown/git settings etc)~~
- [x] SDK Code Change
- [ ] ~~Example/Test Code Change~~

**Validation**
- [x] Does `tox` pass?
- [ ] Do the tests pass?