### PR TITLE
Fix invalid specifier in `stone` requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies required for installation (keep in sync with setup.py)
 requests >= 2.16.2
 six >= 1.12.0
-stone >= 2.*
+stone >= 2
 # Other dependencies for development
 ply
 pytest

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 install_reqs = [
     'requests >= 2.16.2',
     'six >= 1.12.0',
-    'stone >= 2.*',
+    'stone >= 2',
 ]
 
 setup_requires = [

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,4 +2,4 @@ pytest
 mock
 pytest-mock
 coverage
-stone>=2.*
+stone>=2


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description below.
-->

As mentioned in https://github.com/pypa/pip-audit/issues/445#issuecomment-1363101453:

> [PEP 440](https://peps.python.org/pep-0440/) doesn't say it directly, but the language implies that the .* is only valid on exact comparison operators (e.g. == and !=), nor ordered comparisons (e.g. >=).
> 
> In particular, a comparison like >=3.5.* is redundant: it has the exact same meaning as >=3.5.

This is causing `pip-audit` to fail, like so:
https://github.com/frappe/frappe/actions/runs/3811860090/jobs/6484759800#step:4:183

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `tox` pass?
- [x] Do the tests pass?