### PR TITLE
Refresh support matrix for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
     # https://github.com/actions/python-versions/blob/main/versions-manifest.json
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy-2.7, pypy-3.7]
-        exclude:
-          - os: windows-latest
-            python-version: 3.6
+        os: [macos-13, windows-2022]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
         include:
-          - os: ubuntu-latest
-            python-version: 3.7
+          - os: ubuntu-22.04
+            python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
+        include:
+          - os: macos-14
+            python-version: [3.10, 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
@@ -38,13 +38,13 @@ jobs:
         run: |
           pytest test/unit/test_dropbox_unit.py
   Docs:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip
@@ -64,18 +64,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          os: [macos-latest, windows-latest]
-          python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy-2.7, pypy-3.7]
-          exclude:
-            - os: windows-latest
-              python-version: 3.6
-          include:
-            - os: ubuntu-latest
-              python-version: 3.7
+        os: [macos-13, windows-2022]
+        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        include:
+          - os: ubuntu-22.04
+            python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
+        include:
+          - os: macos-14
+            python-version: [3.10, 3.11, 3.12]
     steps: 
       - uses: actions/checkout@v2.3.4
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         include:
           - os: ubuntu-22.04
-            python-version: 2.7
-          - os: ubuntu-22.04
-            python-version: pypy-2.7
-          - os: ubuntu-22.04
             python-version: pypy-3.9
           - os: ubuntu-22.04
             python-version: pypy-3.10
@@ -72,10 +68,6 @@ jobs:
         os: [macos-13, windows-2022, ubuntu-22.04]
         python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         include:
-          - os: ubuntu-22.04
-            python-version: 2.7
-          - os: ubuntu-22.04
-            python-version: pypy-2.7
           - os: ubuntu-22.04
             python-version: pypy-3.9
           - os: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         include:
           - os: ubuntu-22.04
             python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
-        include:
           - os: macos-14
             python-version: [3.10, 3.11, 3.12]
     steps:
@@ -69,10 +68,9 @@ jobs:
         include:
           - os: ubuntu-22.04
             python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
-        include:
           - os: macos-14
             python-version: [3.10, 3.11, 3.12]
-    steps: 
+    steps:
       - uses: actions/checkout@v2.3.4
       - name: Setup Python environment
         uses: actions/setup-python@v2.3.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,8 @@ jobs:
             python-version: pypy-3.9
           - os: ubuntu-22.04
             python-version: pypy-3.10
-          - os: macos-14
-            python-version: 3.10
-          - os: macos-14
-            python-version: 3.11
-          - os: macos-14
-            python-version: 3.12
+          - os: macos-14  # apple silicon
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
@@ -84,12 +80,8 @@ jobs:
             python-version: pypy-3.9
           - os: ubuntu-22.04
             python-version: pypy-3.10
-          - os: macos-14
-            python-version: 3.10
-          - os: macos-14
-            python-version: 3.11
-          - os: macos-14
-            python-version: 3.12
+          - os: macos-14  # apple silicon
+            python-version: "3.10"
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Setup Python environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,23 @@ jobs:
     # https://github.com/actions/python-versions/blob/main/versions-manifest.json
     strategy:
       matrix:
-        os: [macos-13, windows-2022]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        os: [macos-13, windows-2022, ubuntu-22.04]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         include:
           - os: ubuntu-22.04
-            python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
+            python-version: 2.7
+          - os: ubuntu-22.04
+            python-version: pypy-2.7
+          - os: ubuntu-22.04
+            python-version: pypy-3.9
+          - os: ubuntu-22.04
+            python-version: pypy-3.10
           - os: macos-14
-            python-version: [3.10, 3.11, 3.12]
+            python-version: 3.10
+          - os: macos-14
+            python-version: 3.11
+          - os: macos-14
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
@@ -63,13 +73,23 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, windows-2022]
-        python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
+        os: [macos-13, windows-2022, ubuntu-22.04]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         include:
           - os: ubuntu-22.04
-            python-version: [2.7, 3.8, 3.9, 3.10, 3.11, 3.12, pypy-2.7, pypy-3.9, pypy-3.10]
+            python-version: 2.7
+          - os: ubuntu-22.04
+            python-version: pypy-2.7
+          - os: ubuntu-22.04
+            python-version: pypy-3.9
+          - os: ubuntu-22.04
+            python-version: pypy-3.10
           - os: macos-14
-            python-version: [3.10, 3.11, 3.12]
+            python-version: 3.10
+          - os: macos-14
+            python-version: 3.11
+          - os: macos-14
+            python-version: 3.12
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Setup Python environment

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   Coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip
@@ -33,13 +33,13 @@ jobs:
           flags: unit
           fail_ci_if_error: true
   IntegrationCoverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
       - name: Install Requirements
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.x]
+        python-version: [3.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2.3.4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   Update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v2.3.4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ stone >= 2
 # Other dependencies for development
 ply
 pytest
-pytest-runner
+pytest-runner == 5.3.2
 sphinx
 twine
 setuptools; python_version>="3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pytest
 pytest-runner
 sphinx
 twine
+setuptools; python_version>="3.12"
 wheel

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ dist = setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',  # untested
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,6 @@ install_reqs = [
     'setuptools',
 ]
 
-setup_requires = [
-    # Pin pytest-runner to 5.2.0, since 5.3.0 uses `find_namespaces` directive, not supported in
-    # Python 2.7
-    'pytest-runner == 5.2.0',
-]
-
 # WARNING: This imposes limitations on test/requirements.txt such that the
 # full Pip syntax is not supported. See also
 # <http://stackoverflow.com/questions/14399534/>.
@@ -51,7 +45,6 @@ dist = setup(
     name='dropbox',
     version=version,
     install_requires=install_reqs,
-    setup_requires=setup_requires,
     tests_require=test_reqs,
     packages=['dropbox'],
     package_data={'dropbox': ['trusted-certs.crt']},
@@ -72,7 +65,7 @@ dist = setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 2.7',  # untested
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ install_reqs = [
     'requests >= 2.16.2',
     'six >= 1.12.0',
     'stone >= 2',
+    'setuptools',
 ]
 
 setup_requires = [
@@ -72,11 +73,11 @@ dist = setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py{27,38,39,310,311,312,py,py3},check,lint,docs,test_unit,coverage
+envlist = py{38,39,310,311,312,py,py3},check,lint,docs,test_unit,coverage
 skip_missing_interpreters = true
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py{27,34,35,36,37,38,39-dev,py,py3},check,lint,docs,test_unit,coverage
+envlist = py{27,38,39,310,311,312,py,py3},check,lint,docs,test_unit,coverage
 skip_missing_interpreters = true
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands =
 
 deps =
     twine
+    wheel
 
 usedevelop = true
 


### PR DESCRIPTION
* CI now tests Python 3.9, 3.10, 3.11, 3.12, we no longer test 3.5, 3.6, 3.7. 
* We no longer advertise support for Python 2.7. This is inevitable as GitHub action runners no longer support Python 2.7, so we can no longer run CI for this version.
* We refer to runners with an explicit version (e.g. `macos-13` , no more `*-latest`). This previously broke most test configurations when macOS defaulted to 14, which is Apple Silicon.
* Add `setuptools` to `install_requires`, since on Python 3.12+ this is no longer built-in. The library depends on this at runtime (`pkg_resources`). 

Supersedes #481 and #484. These changes will require a major version bump. 