### PR TITLE
Restore CI, including Python 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           pytest -v test/unit/test_dropbox_unit.py
   Docs:
-    runs-on: macos-13
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           flake8 setup.py dropbox example test
       - name: Run Unit Tests
         run: |
-          pytest test/unit/test_dropbox_unit.py
+          pytest -v test/unit/test_dropbox_unit.py
   Docs:
     runs-on: macos-13
     steps:
@@ -121,4 +121,4 @@ jobs:
           SCOPED_TEAM_REFRESH_TOKEN: ${{ secrets.SCOPED_TEAM_REFRESH_TOKEN }}
           DROPBOX_SHARED_LINK: ${{ secrets.DROPBOX_SHARED_LINK }}
         run: |
-          pytest test/integration/test_dropbox.py
+          pytest -v test/integration/test_dropbox.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python get-pip.py
       - if: ${{ matrix.python-version != '2.7' }}
         name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: '3.7'
       - name: Install Requirements
@@ -93,7 +93,7 @@ jobs:
           python get-pip.py
       - if: ${{ matrix.python-version != '2.7' }}
         name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,26 @@ jobs:
     # https://github.com/actions/python-versions/blob/main/versions-manifest.json
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy-2.7, pypy-3.7]
+        os: [macos-13, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
         exclude:
           - os: windows-latest
             python-version: 3.6
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: 3.7
+          - os: ubuntu-20.04
+            python-version: 2.7
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python environment
+      - if: ${{ matrix.python-version == '2.7' }}
+        name: Setup Python environment (2.7)
+        run: |
+          sudo apt-get install python-is-python2
+          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+          python get-pip.py
+      - if: ${{ matrix.python-version != '2.7' }}
+        name: Setup Python environment
         uses: actions/setup-python@v2.2.2
         with:
           python-version: ${{ matrix.python-version }}
@@ -38,7 +47,7 @@ jobs:
         run: |
           pytest test/unit/test_dropbox_unit.py
   Docs:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
@@ -64,17 +73,26 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          os: [macos-latest, windows-latest]
-          python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy-2.7, pypy-3.7]
+          os: [macos-13, windows-latest]
+          python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
           exclude:
             - os: windows-latest
               python-version: 3.6
           include:
-            - os: ubuntu-latest
+            - os: ubuntu-20.04
               python-version: 3.7
+            - os: ubuntu-20.04
+              python-version: 2.7
     steps: 
       - uses: actions/checkout@v2.3.4
-      - name: Setup Python environment
+      - if: ${{ matrix.python-version == '2.7' }}
+        name: Setup Python environment (2.7)
+        run: |
+          sudo apt-get install python-is-python2
+          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+          python get-pip.py
+      - if: ${{ matrix.python-version != '2.7' }}
+        name: Setup Python environment
         uses: actions/setup-python@v2.2.2
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,6 @@ jobs:
           pip install flake8 pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
-          pip install setuptools wheel twine # XXX
-          python setup.py bdist_wheel  # XXX
           python setup.py install --user
       - name: Run Integration Tests
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           pip install flake8 pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
-          python setup.py install
+          python setup.py install --user
       - name: Run Linter
         run: |
           flake8 setup.py dropbox example test
@@ -73,17 +73,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-          os: [macos-13, windows-latest]
-          python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
-          exclude:
-            - os: windows-latest
-              python-version: 3.6
-          include:
-            - os: ubuntu-20.04
-              python-version: 3.7
-            - os: ubuntu-20.04
-              python-version: 2.7
-    steps: 
+        os: [macos-13, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
+        exclude:
+          - os: windows-latest
+            python-version: 3.6
+        include:
+          - os: ubuntu-20.04
+            python-version: 3.7
+          - os: ubuntu-20.04
+            python-version: 2.7
+    steps:
       - uses: actions/checkout@v2.3.4
       - if: ${{ matrix.python-version == '2.7' }}
         name: Setup Python environment (2.7)
@@ -102,7 +102,9 @@ jobs:
           pip install flake8 pytest
           pip install -r requirements.txt
           pip install -r test/requirements.txt
-          python setup.py install
+          pip install setuptools wheel twine # XXX
+          python setup.py bdist_wheel  # XXX
+          python setup.py install --user
       - name: Run Integration Tests
         env:
           LEGACY_USER_DROPBOX_TOKEN: ${{ secrets.LEGACY_USER_DROPBOX_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Publish Coverage
         uses: codecov/codecov-action@v3.1.6
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
           fail_ci_if_error: true
   IntegrationCoverage:
@@ -68,5 +69,6 @@ jobs:
       - name: Publish Coverage
         uses: codecov/codecov-action@v3.1.6
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
           coverage run --rcfile=.coveragerc -m pytest test/unit/test_dropbox_unit.py
           coverage xml
       - name: Publish Coverage
-        uses: codecov/codecov-action@v1.3.2
+        uses: codecov/codecov-action@v3.1.6
         with:
           flags: unit
           fail_ci_if_error: true
@@ -66,7 +66,7 @@ jobs:
           coverage run --rcfile=.coveragerc -m pytest test/integration/test_dropbox.py
           coverage xml
       - name: Publish Coverage
-        uses: codecov/codecov-action@v1.3.2
+        uses: codecov/codecov-action@v3.1.6
         with:
           flags: integration
           fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: '3.7'
       - name: Install Requirements
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: '3.7'
       - name: Install Requirements

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -24,7 +24,7 @@ jobs:
         python get-pip.py
     - if: ${{ matrix.python-version != '2.7' }}
       name: Setup Python environment
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v3.1.4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -9,14 +9,21 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [2.7, 3.x]
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Python
+    - if: ${{ matrix.python-version == '2.7' }}
+      name: Setup Python environment (2.7)
+      run: |
+        sudo apt-get install python-is-python2
+        curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+        python get-pip.py
+    - if: ${{ matrix.python-version != '2.7' }}
+      name: Setup Python environment
       uses: actions/setup-python@v2.2.2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [2.7, 3.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.4
     - if: ${{ matrix.python-version == '2.7' }}
       name: Setup Python environment (2.7)
       run: |

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python environment
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@v3.1.4
         with:
           python-version: 3.7
       - name: Get current time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies required for installation (keep in sync with setup.py)
-requests>=2.27
+requests<2.30
 urllib3<2
 six >= 1.12.0
 stone>=2,<3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
 # Dependencies required for installation (keep in sync with setup.py)
-requests >= 2.16.2
+requests>=2.27
+urllib3<2
 six >= 1.12.0
-stone >= 2
+stone>=2,<3.3.3
 # Other dependencies for development
 ply
 pytest
-pytest-runner
+pytest-runner==5.2.0
 sphinx
 twine
 wheel

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ for line in open(dbx_mod_path):
 version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
-    'requests>=2.27',
+    'requests<2.30',
     'urllib3<2',
     'six >= 1.12.0',
     'stone>=2,<3.3.3',

--- a/setup.py
+++ b/setup.py
@@ -25,15 +25,16 @@ for line in open(dbx_mod_path):
 version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
-    'requests >= 2.16.2',
+    'requests>=2.27',
+    'urllib3<2',
     'six >= 1.12.0',
-    'stone >= 2',
+    'stone>=2,<3.3.3',
 ]
 
 setup_requires = [
     # Pin pytest-runner to 5.2.0, since 5.3.0 uses `find_namespaces` directive, not supported in
     # Python 2.7
-    'pytest-runner == 5.2.0',
+    'pytest-runner==5.2.0',
 ]
 
 # WARNING: This imposes limitations on test/requirements.txt such that the

--- a/test/integration/test_dropbox.py
+++ b/test/integration/test_dropbox.py
@@ -26,7 +26,7 @@ from dropbox.dropbox_client import PATH_ROOT_HEADER, SELECT_USER_HEADER
 from dropbox.exceptions import (
     ApiError,
     AuthError,
-    BadInputError,
+    # BadInputError,
     PathRootError,
 )
 from dropbox.files import (
@@ -153,9 +153,12 @@ class TestDropbox:
     def test_bad_auth(self):
         # Test malformed token
         malformed_token_dbx = Dropbox(MALFORMED_TOKEN)
-        with pytest.raises(BadInputError,) as cm:
+        # TODO: backend is no longer returning `BadInputError`
+        # with pytest.raises(BadInputError,) as cm:
+        #     malformed_token_dbx.files_list_folder('')
+        # assert 'token is malformed' in cm.value.message
+        with pytest.raises(AuthError,):
             malformed_token_dbx.files_list_folder('')
-        assert 'token is malformed' in cm.value.message
 
         # Test reasonable-looking invalid token
         invalid_token_dbx = Dropbox(INVALID_TOKEN)

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,4 +2,4 @@ pytest
 mock
 pytest-mock
 coverage
-stone>=2
+stone>=2,<3.3.3


### PR DESCRIPTION
* Restores CI to a green state to aid in landing other changes.
* Python 2.7 is still covered, but only on Ubuntu and excluding PyPy. Changes are made to `requirements.txt` et al to ensure this works.
* Fixes an integration test breaking due to backend changes, to be investigated separately. 
