### PR TITLE
Fix doc generation and PyPI uploads by pinning to Python 3.7

### DIFF
--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.x]
+        python-version: [2.7, 3.7]
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -34,9 +34,9 @@ jobs:
     - name: Build
       run: |
         python setup.py bdist_wheel
-    - name: Build Sources (3.x)
+    - name: Build Sources (Python 3)
       run: python setup.py sdist
-      if: matrix.python-version == '3.x'
+      if: ${{ matrix.python-version != '2.7' }}
     - name: Publish
       env:
         TWINE_USERNAME: __token__

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,16 @@
-# .readthedocs.yml
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Don't build any extra formats
-# https://docs.readthedocs.io/en/latest/yaml-config.html#formats
-formats: []
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.7"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,15 +2,12 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
   os: ubuntu-20.04
   tools:
     python: "3.7"
 
-# Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Dropbox for Python'
-copyright = u'2015-2019, Dropbox, Inc.'
+copyright = u'2015-2024, Dropbox, Inc.'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
* Per the [docs](https://blog.readthedocs.com/migrate-configuration-v2/), ReadTheDocs now requires a `version 2` config file. In it, we pin the version used to generate the docs to Python 3.7, which matches what is currently tested (and green) in CI.
* PyPI uploads were still configured to run on the latest version of Python (currently 3.12). We pin this back to Python 3.7, which make it less likely to break in mysterious ways.