### PR TITLE
Remove CI for Python 3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
+        python-version: [3.6, 3.7, 3.8, pypy-3.7]
         exclude:
           - os: windows-latest
             python-version: 3.6
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy-3.7]
+        python-version: [3.6, 3.7, 3.8, pypy-3.7]
         exclude:
           - os: windows-latest
             python-version: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py{27,34,35,36,37,38,39-dev,py,py3},check,lint,docs,test_unit,coverage
+envlist = py{27,36,37,38,39-dev,py,py3},check,lint,docs,test_unit,coverage
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
This is currently broken, seemingly due to the built version having a version of `pip` (or a dependency) so old it can't securely connect to PyPI anymore. 