### PR TITLE
Further fixes to doc generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,5 +9,11 @@ build:
   tools:
     python: "3.7"
 
+python:
+  install:
+    - requirements: requirements.txt
+    - method: setuptools
+      path: .
+
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ import dropbox
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
+    'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -108,7 +109,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@ Dropbox for Python Documentation
    tutorial
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    api/async
    api/auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ ply
 pytest
 pytest-runner==5.2.0
 sphinx
+sphinx_rtd_theme
 twine
 wheel


### PR DESCRIPTION
Fully fixes the ReadTheDocs integration. This PR's docs are generated here: https://dropbox-sdk-python--503.org.readthedocs.build/en/503/index.html. 