### PR TITLE
Fix incorrect pin of `requests`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies required for installation (keep in sync with setup.py)
-requests<2.30
+requests>=2.27.1
 urllib3<2
 six >= 1.12.0
 stone>=2,<3.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies required for installation (keep in sync with setup.py)
-requests>=2.27.1
+requests>=2.16.2
 urllib3<2
 six >= 1.12.0
 stone>=2,<3.3.3

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ for line in open(dbx_mod_path):
 version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
-    'requests>=2.27.1',
+    'requests>=2.16.2',
     'urllib3<2',
     'six >= 1.12.0',
     'stone>=2,<3.3.3',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ for line in open(dbx_mod_path):
 version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
-    'requests<2.30',
+    'requests>=2.27.1',
     'urllib3<2',
     'six >= 1.12.0',
     'stone>=2,<3.3.3',


### PR DESCRIPTION
The change in #492 aimed to restore Python 2.7 support in CI. This included an attempt to avoid automatically pulling in `urllib3>=2` as that introduces potential breaking changes. The change both (incorrectly) introduced a maximum version requirement for `requests` and (correctly) added a requirement to pin `urllib3<2` (as suggested in the docs for [requests](https://github.com/psf/requests/blob/main/HISTORY.md#2300-2023-05-03) and [urllib3](https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html)). It should only have done the latter. 

This reverts the version requirement for `requests` to what it was prior to #492. Fixes #504. 