### PR TITLE
Return token content when refreshing token

### DIFF
--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -377,7 +377,7 @@ class _DropboxTransport(object):
 
         :param host: host to hit token endpoint with
         :param scope: list of permission scopes for access token
-        :return:
+        :return: token content
         """
         if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
             raise BadInputException("Scope list must be of type list")
@@ -409,6 +409,7 @@ class _DropboxTransport(object):
         self._oauth2_access_token = token_content["access_token"]
         self._oauth2_access_token_expiration = datetime.utcnow() + \
             timedelta(seconds=int(token_content["expires_in"]))
+        return token_content
 
     def request_json_object(self,
                             host,


### PR DESCRIPTION
When refreshing token, I would like to actually get the token contents so I can store it for offline usage.  To this end, I added return statement to `refresh_access_token` method.  

## **Checklist**
<!-- For completed items, change [ ] to [x]. -->

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [ ] Non-code related change (markdown/git settings etc)
- [x] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [ ] Does `tox` pass?
- [ ] Do the tests pass?