### PR TITLE
Remove transitive dependency 'ply' from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ requests>=2.16.2
 six >= 1.12.0
 stone>=2,<3.3.3
 # Other dependencies for development
-ply
 pytest
 pytest-runner==5.2.0
 sphinx


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `ply`, which is required by `stone`, is specified as a requirement in the `requirements.txt` file, even though it is not used directly and does not need to be listed explicitly, as it will be automatically handled by pip during installation.

This PR removes it from `requirements.txt` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

## **Checklist**

**General Contributing**
- [x] Have you read the Code of Conduct and signed the [CLA](https://opensource.dropbox.com/cla/)?

**Is This a Code Change?**
- [x] Non-code related change (markdown/git settings etc)
- [ ] SDK Code Change
- [ ] Example/Test Code Change

**Validation**
- [x] Does `tox` pass?
- [x] Do the tests pass?