### PR TITLE
Fix abstract method signature and other bugs

### DIFF
--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -32,7 +32,8 @@ class DropboxBase(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def request(self, route, namespace, arg, arg_binary=None):
+    def request(self, route, namespace, request_arg, request_binary,
+                timeout=None):
         pass
 
     # ------------------------------------------

--- a/dropbox/base_team.py
+++ b/dropbox/base_team.py
@@ -32,7 +32,8 @@ class DropboxTeamBase(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def request(self, route, namespace, arg, arg_binary=None):
+    def request(self, route, namespace, request_arg, request_binary,
+                timeout=None):
         pass
 
     # ------------------------------------------

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -196,7 +196,7 @@ class _DropboxTransport(object):
         if oauth2_refresh_token and not app_key:
             raise BadInputException("app_key is required to refresh tokens")
 
-        if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
+        if scope is not None and (not isinstance(scope, list) or len(scope) == 0):
             raise BadInputException("Scope list must be of type list")
 
         self._oauth2_access_token = oauth2_access_token
@@ -262,7 +262,7 @@ class _DropboxTransport(object):
             oauth2_access_token or self._oauth2_access_token,
             max_retries_on_error or self._max_retries_on_error,
             max_retries_on_rate_limit or self._max_retries_on_rate_limit,
-            user_agent or self._user_agent,
+            user_agent or self._raw_user_agent,
             session or self._session,
             headers or self._headers,
             timeout or self._timeout,
@@ -379,7 +379,7 @@ class _DropboxTransport(object):
         :param scope: list of permission scopes for access token
         :return:
         """
-        if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
+        if scope is not None and (not isinstance(scope, list) or len(scope) == 0):
             raise BadInputException("Scope list must be of type list")
 
         if not (self._oauth2_refresh_token and self._app_key):

--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -121,7 +121,7 @@ class DropboxOAuth2FlowBase(object):
     def __init__(self, consumer_key, consumer_secret=None, locale=None, token_access_type=None,
                  scope=None, include_granted_scopes=None, use_pkce=False, timeout=DEFAULT_TIMEOUT,
                  ca_certs=None):
-        if scope is not None and (len(scope) == 0 or not isinstance(scope, list)):
+        if scope is not None and (not isinstance(scope, list) or len(scope) == 0):
             raise BadInputException("Scope list must be of type list")
         if token_access_type is not None and token_access_type not in TOKEN_ACCESS_TYPES:
             raise BadInputException("Token access type must be from the following enum: {}".format(


### PR DESCRIPTION
This PR fixes several bugs in the dropbox-sdk-python:

## 1. Fix #511 - Abstract method signature mismatch

The abstract \equest()\ method in \DropboxBase\ and \DropboxTeamBase\ had different signatures from the concrete implementation in \_DropboxTransport\. This violated LSP and caused type-checking errors when generating stubs.

- Renamed \rg\ to \equest_arg\
- Renamed \rg_binary\ to \equest_binary\, removed default None
- Added \	imeout=None\ parameter

## 2. Fix clone() double-appending user-agent suffix

\clone()\ passed \self._user_agent\ (which already contains the '/OfficialDropboxPythonSDKv2/<version>' suffix) to the constructor, which appended it again. Changed to use \self._raw_user_agent\ which stores the original user agent without the SDK suffix.

## 3. Fix unsafe scope validation order

In three locations, \len(scope) == 0\ was checked before \
ot isinstance(scope, list)\, which could cause a \TypeError\ if scope is a non-iterable type. Reordered to check \isinstance\ first.