### PR TITLE
Fix potential KeyError in raise_dropbox_error_for_resp and replace eval()

### DIFF
--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -620,14 +620,15 @@ class _DropboxTransport(object):
             raise InternalServerError(request_id, res.status_code, res.text)
         elif res.status_code == 400:
             try:
-                if res.json()['error'] == 'invalid_grant':
+                error_val = res.json().get('error')
+                if error_val == 'invalid_grant':
                     request_id = res.headers.get('x-dropbox-request-id')
                     err = stone_serializers.json_compat_obj_decode(
                         AuthError_validator, 'invalid_access_token')
                     raise AuthError(request_id, err)
                 else:
                     raise BadInputError(request_id, res.text)
-            except ValueError:
+            except (ValueError, AttributeError):
                 raise BadInputError(request_id, res.text)
         elif res.status_code == 401:
             assert res.headers.get('content-type') == 'application/json', (

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ line = '= "UNKNOWN"'
 for line in open(dbx_mod_path):
     if line.startswith('__version__'):
         break
-version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
+version = line.split('=', 1)[1].strip().strip('\'"')
 
 install_reqs = [
     'requests>=2.16.2',


### PR DESCRIPTION
## 1. Fix potential KeyError in raise_dropbox_error_for_resp()

If the server returns a 400 with valid JSON that doesn't contain the 'error' key, accessing es.json()['error'] raises an unhandled KeyError. Changed to use .get('error') to safely access the key.

Also widened the except clause to catch AttributeError alongside ValueError.

## 2. Replace eval() with safe string parsing

Using eval() to parse a version string from a file is unnecessary and fragile. Replaced with simple string stripping.