### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-**Important: Make sure you're using v12.0.2 or newer of this SDK by January 2026 for continued compatibility with the Dropbox API servers. Please refer to this blog post for more information: https://dropbox.tech/developers/api-server-certificate-changes**
+**Important: Use v12.0.2 or newer of this SDK for compatibility with the Dropbox API servers. Older versions stopped working in January 2026. Please refer to this blog post for more information: https://dropbox.tech/developers/api-server-certificate-changes**
 
 .. image:: https://cfl.dropboxstatic.com/static/images/sdk/python_banner.png
     :target: https://github.com/dropbox/dropbox-sdk-python
@@ -12,7 +12,7 @@
 .. image:: https://codecov.io/gh/dropbox/dropbox-sdk-python/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/dropbox/dropbox-sdk-python
 
-The offical Dropbox SDK for Python.
+The official Dropbox SDK for Python.
 
 Documentation can be found on `Read The Docs`_.
 


### PR DESCRIPTION
* Reword the v12.0.2 requirement to past tense now that the January 2026 certificate-migration deadline has passed.
* Fix the 'offical' -> 'official' typo.