### PR TITLE
Release 12.1.0: fix sdist install under setuptools >= 82

### DIFF
--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -1,4 +1,4 @@
-# This workflows will upload a Python Package using Twine when a release is created
+# This workflow will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish to PyPi
@@ -10,33 +10,19 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [2.7, 3.x]
 
     steps:
-    - uses: actions/checkout@v2.3.4
-    - if: ${{ matrix.python-version == '2.7' }}
-      name: Setup Python environment (2.7)
-      run: |
-        sudo apt-get install python-is-python2
-        curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-        python get-pip.py
-    - if: ${{ matrix.python-version != '2.7' }}
-      name: Setup Python environment
-      uses: actions/setup-python@vv3.1.4
+    - uses: actions/checkout@v5
+    - name: Setup Python environment
+      uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.x"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Build
-      run: |
-        python setup.py bdist_wheel
-    - name: Build Sources (Python 3)
-      run: python setup.py sdist
-      if: ${{ matrix.python-version != '2.7' }}
+        python -m pip install build twine
+    - name: Build sdist and wheel
+      run: python -m build
     - name: Publish
       env:
         TWINE_USERNAME: __token__


### PR DESCRIPTION
## Summary

Cuts release **12.1.0** to fix the source-install failure reported in #528.

Released **v12.0.2** ships a `setup.py` with an `ez_setup` / `use_setuptools()` bootstrap that transitively imports `pkg_resources`. setuptools **82.0.0** removed `pkg_resources`, so `pip install --no-binary :all: dropbox` now fails with `ModuleNotFoundError: No module named 'pkg_resources'`. This affects source-only consumers: distro packaging, `--no-binary` lockfile rebuilds, and platforms with no matching wheel.

The offending bootstrap was already removed from `setup.py` on `main` but was never published. This PR simply ships it.

## Changes

- **`dropbox/dropbox_client.py`** — bump `__version__` `0.0.0` → `12.1.0`.
- **`.github/workflows/pypiupload.yml`** — repair the release workflow so it can actually publish:
  - Drop the Python 2.7 matrix + get-pip.py bootstrap.
  - Fix the `actions/setup-python@vv3.1.4` typo → `@v6`; `checkout@v2.3.4` → `@v5`.
  - Use `python-version: "3.x"` (matches dropbox/stone's publish workflow).
  - Replace deprecated `python setup.py bdist_wheel`/`sdist` with `python -m build`.

`setup.py` itself is unchanged — the fix (removing `ez_setup`/`pkg_resources`) was already on `main`.

## Verification

- `python -m build` produces `dropbox-12.1.0` sdist + wheel; `twine check` passes.
- Reproduced the ticket scenario: `pip install --no-binary :all: dropbox-12.1.0.tar.gz` under **setuptools 83.0.0** on Python 3.14 now **succeeds**, and `import dropbox` reports `12.1.0`.

Fixes #528
