### PR TITLE
Publish to PyPI via AWS Secrets Manager (OIDC)

### DIFF
--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -6,13 +6,33 @@ name: Publish to PyPi
 on:
   release:
     types: [created]
+  workflow_dispatch:  # Allow manual trigger for testing
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:  # required for OIDC authentication
+      id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v5
+
+    # NOTE: The IAM role and Secrets Manager secret below must be provisioned
+    # for the dropbox-sdk-python repo. The stone repo's role/secret ARNs will
+    # NOT work here -- the role's trust policy is scoped to a single repo.
+    - name: Configure AWS credentials (OIDC)
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-sdk-python-repo
+        aws-region: us-west-2
+    - name: Get PyPI token from AWS Secrets Manager
+      id: get-secret
+      uses: aws-actions/aws-secretsmanager-get-secrets@v2
+      with:
+        secret-ids: |
+          PYPI_SECRET,arn:aws:secretsmanager:us-west-2:082972943155:secret:pypi-api-token-dropbox-sdk-python
+        parse-json-secrets: false
     - name: Setup Python environment
       uses: actions/setup-python@v6
       with:
@@ -26,7 +46,7 @@ jobs:
     - name: Publish
       env:
         TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.pypi_secret }}
+        TWINE_PASSWORD: ${{ env.PYPI_SECRET }}
       run: |
         twine check dist/*
         twine upload dist/*

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -18,20 +18,19 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
-    # NOTE: The IAM role and Secrets Manager secret below must be provisioned
-    # for the dropbox-sdk-python repo. The stone repo's role/secret ARNs will
-    # NOT work here -- the role's trust policy is scoped to a single repo.
     - name: Configure AWS credentials (OIDC)
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-sdk-python-repo
+        role-to-assume: arn:aws:iam::082972943155:role/oidc-github-dropbox-dropbox-sdk-python-repo
         aws-region: us-west-2
     - name: Get PyPI token from AWS Secrets Manager
       id: get-secret
       uses: aws-actions/aws-secretsmanager-get-secrets@v2
       with:
+        # Referenced by friendly name; Secrets Manager appends a random suffix to
+        # the full ARN, so the name is the stable identifier.
         secret-ids: |
-          PYPI_SECRET,arn:aws:secretsmanager:us-west-2:082972943155:secret:pypi-api-token-dropbox-sdk-python
+          PYPI_SECRET,pypi-api-token-dropbox-sdk-python
         parse-json-secrets: false
     - name: Setup Python environment
       uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary

The **v12.1.0** publish (release #530 → tag `v12.1.0`) built and `twine check`ed cleanly but **failed at upload with `403 Forbidden`**: `secrets.pypi_secret` is no longer configured on this repo, so `TWINE_PASSWORD` was empty.

`dropbox/stone` already migrated its publishing off GitHub secrets to a **PyPI token fetched from AWS Secrets Manager via GitHub OIDC**. This PR mirrors that approach so `dropbox-sdk-python` publishes the same way.

## Changes

`.github/workflows/pypiupload.yml`:
- Add `permissions: id-token: write` for OIDC.
- Assume an AWS IAM role via `aws-actions/configure-aws-credentials`, then fetch the PyPI token with `aws-actions/aws-secretsmanager-get-secrets`.
- Use that token for `twine upload` (replaces the empty `secrets.pypi_secret`).
- Add `workflow_dispatch` so a maintainer can re-trigger publishing without cutting a new release.

## ⚠️ Requires infra provisioning before it works

The `role-to-assume` and `secret-ids` ARNs are **placeholders scoped to this repo** and must be provisioned for `dropbox-sdk-python`:

- `arn:aws:iam::082972943155:role/oidc-github-dropbox-sdk-python-repo` — IAM role with a trust policy allowing this repo's OIDC subject (stone's role won't work; its trust policy is repo-scoped).
- `arn:aws:secretsmanager:us-west-2:082972943155:secret:pypi-api-token-dropbox-sdk-python` — Secrets Manager secret holding a PyPI API token scoped to the `dropbox` project.

Please confirm/adjust these ARNs to match what's provisioned.

## Publishing v12.1.0 after merge

Tag `v12.1.0` and its GitHub Release already exist; only the upload failed. Once this is merged and the AWS resources exist, publish via **Actions → Publish to PyPi → Run workflow** (`workflow_dispatch`), or re-run the failed release run.

Refs #528