### PR TITLE
Drop six dependency and require Python 3.11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,13 @@ on:
 
 jobs:
   CI:
-    continue-on-error: true
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5
@@ -62,7 +61,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.11"
           cache: "pip"
 
       - name: Install build and doc tooling
@@ -101,7 +100,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [macos-15-intel, macos-latest, windows-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Setup virtual environment
         run: |
           python -m venv venv
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v3.1.4
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Setup virtual environment
         run: |
           python -m venv venv

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Python environment
         uses: actions/setup-python@v3.1.4
         with:
-          python-version: 3.9
+          python-version: '3.11'
       - name: Get current time
         uses: 1466587594/get-current-time@v2
         id: current-time

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.7"
+    python: "3.11"
 
 python:
   install:

--- a/README.rst
+++ b/README.rst
@@ -19,10 +19,9 @@ Documentation can be found on `Read The Docs`_.
 Requirements
 ============
 
-This SDK requires **Python 3.11 or newer**. Support for Python 2.7 and Python 3.4
-through 3.10 has been dropped, as those versions have reached end of life and are no
-longer maintained upstream. This release also updates the ``stone`` dependency to
-``>=3.4.0`` and removes the ``six`` dependency.
+This SDK requires **Python 3.11 or newer**. Earlier versions of Python, including
+Python 2.7 and Python 3.4 through 3.10, are not supported, as they have reached end
+of life and are no longer maintained upstream.
 
 Installation
 ============

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,14 @@ The official Dropbox SDK for Python.
 
 Documentation can be found on `Read The Docs`_.
 
+Requirements
+============
+
+This SDK requires **Python 3.11 or newer**. Support for Python 2.7 and Python 3.4
+through 3.10 has been dropped, as those versions have reached end of life and are no
+longer maintained upstream. This release also updates the ``stone`` dependency to
+``>=3.4.0`` and removes the ``six`` dependency.
+
 Installation
 ============
 

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -16,7 +16,6 @@ import random
 import time
 
 import requests
-import six
 
 from datetime import datetime, timedelta
 from dropbox.auth import (
@@ -75,7 +74,7 @@ class RouteResult(object):
         :param requests.models.Response http_resp: A raw HTTP response. It will
             be used to stream the binary-body payload of the response.
         """
-        assert isinstance(obj_result, six.string_types), \
+        assert isinstance(obj_result, str), \
             'obj_result: expected string, got %r' % type(obj_result)
         if http_resp is not None:
             assert isinstance(http_resp, requests.models.Response), \
@@ -530,7 +529,7 @@ class _DropboxTransport(object):
         if host not in self._host_map:
             raise ValueError('Unknown value for host: %r' % host)
 
-        if not isinstance(request_binary, (six.binary_type, type(None))):
+        if not isinstance(request_binary, (bytes, type(None))):
             # Disallow streams and file-like objects even though the underlying
             # requests library supports them. This is to prevent incorrect
             # behavior when a non-rewindable stream is read from, but the

--- a/dropbox/oauth.py
+++ b/dropbox/oauth.py
@@ -14,7 +14,6 @@ __all__ = [
 
 import base64
 import os
-import six
 import urllib
 import re
 from datetime import datetime, timedelta
@@ -26,12 +25,8 @@ from .session import (
     DEFAULT_TIMEOUT,
 )
 
-if six.PY3:
-    url_path_quote = urllib.parse.quote  # pylint: disable=no-member,useless-suppression
-    url_encode = urllib.parse.urlencode  # pylint: disable=no-member,useless-suppression
-else:
-    url_path_quote = urllib.quote  # pylint: disable=no-member,useless-suppression
-    url_encode = urllib.urlencode  # pylint: disable=no-member,useless-suppression
+url_path_quote = urllib.parse.quote
+url_encode = urllib.parse.urlencode
 
 TOKEN_ACCESS_TYPES = ['offline', 'online', 'legacy']
 INCLUDE_GRANTED_SCOPES_TYPES = ['user', 'team']
@@ -233,9 +228,6 @@ class DropboxOAuth2FlowBase(object):
         :return: The path and parameters components of an API URL.
         :rtype: str
         """
-        if six.PY2 and isinstance(target, six.text_type):
-            target = target.encode('utf8')
-
         target_path = url_path_quote(target)
 
         params = params or {}
@@ -610,15 +602,15 @@ def _params_to_urlencoded(params):
     unicode objects which are utf8-encoded.
     """
     def encode(o):
-        if isinstance(o, six.binary_type):
+        if isinstance(o, bytes):
             return o
         else:
-            if isinstance(o, six.text_type):
+            if isinstance(o, str):
                 return o.encode('utf-8')
             else:
                 return str(o).encode('utf-8')
 
-    utf8_params = {encode(k): encode(v) for k, v in six.iteritems(params)}
+    utf8_params = {encode(k): encode(v) for k, v in params.items()}
     return url_encode(utf8_params)
 
 def _generate_pkce_code_verifier():

--- a/example/updown.py
+++ b/example/updown.py
@@ -3,13 +3,10 @@
 This is an example app for API v2.
 """
 
-from __future__ import print_function
-
 import argparse
 import contextlib
 import datetime
 import os
-import six
 import sys
 import time
 import unicodedata
@@ -74,7 +71,7 @@ def main():
         # First do all the files.
         for name in files:
             fullname = os.path.join(dn, name)
-            if not isinstance(name, six.text_type):
+            if not isinstance(name, str):
                 name = name.decode('utf-8')
             nname = unicodedata.normalize('NFC', name)
             if name.startswith('.'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # Dependencies required for installation (keep in sync with setup.py)
 requests>=2.16.2
-six >= 1.12.0
-stone>=2,<=3.3.9
+stone>=3.4.0,<4
 # Other dependencies for development
 ply
 pytest

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-# Don't import unicode_literals because of a bug in py2 setuptools
-# where package_data is expected to be str and not unicode.
-from __future__ import absolute_import, division, print_function
-
 import codecs
 import os
 
@@ -16,8 +12,7 @@ version = eval(line.split('=', 1)[1].strip())  # pylint: disable=eval-used
 
 install_reqs = [
     'requests>=2.16.2',
-    'six >= 1.12.0',
-    'stone>=2,<=3.3.9',
+    'stone>=3.4.0,<4',
 ]
 
 with codecs.open('README.rst', encoding='utf-8') as f:
@@ -45,15 +40,13 @@ dist = setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    python_requires='>=3.11',
 )

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,4 +2,4 @@ pytest
 mock
 pytest-mock
 coverage
-stone>=2,<=3.3.9
+stone>=3.4.0,<4

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 
-envlist = py{27,36,37,38,39-dev,py,py3},check,lint,docs,test_unit,coverage
+envlist = py{311,312,313,py3},check,lint,docs,test_unit,coverage
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
## Summary

Removes the `six` dependency and drops support for now-EOL Python versions.

- Replace `six` shims with native Python 3 equivalents in `dropbox/oauth.py`, `dropbox/dropbox_client.py`, and `example/updown.py` (`text_type`→`str`, `binary_type`→`bytes`, `string_types`→`str`, `iteritems`→`.items()`, and dropping dead `PY2`/`PY3` branches).
- Bump `stone` to `>=3.4.0,<4`, which itself no longer depends on `six` — so `six` is fully removed from the dependency graph (verified: `import dropbox` works with `six` uninstalled).
- `stone` 3.4.0 requires Python 3.11+, so drop the now-EOL Python 2.7 and 3.4–3.10: set `python_requires>=3.11`, refresh classifiers, `tox` envlist, and CI/coverage/spec_update/readthedocs Python versions.
- Document the new requirement in the README.

## Validation

- **35/35 unit tests pass** against a real `stone` 3.4.0 install on Python 3.11.
- `six` confirmed absent from the dependency graph; `dropbox` imports and OAuth flows work without it.
- `flake8` clean; wheel builds and `twine check` passes (metadata: `Requires-Python: >=3.11`, deps `requests` + `stone>=3.4.0,<4`).
- README renders cleanly.