### PR TITLE
Remove redundant transitive dependency 'ply' from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 requests>=2.16.2
 stone>=3.4.0,<4
 # Other dependencies for development
-ply
 pytest
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
## Summary

Removes the explicit `ply` entry from `requirements.txt`. `ply` is a transitive dependency of `stone` and is not imported directly anywhere in this repo, so listing it explicitly in the dev requirements is redundant — `stone` pulls it in as needed.

This redoes #517 (by @vtalos) on top of current `main`, where the surrounding dependencies have since changed (`six` removed, `stone` bumped to `>=3.4.0,<4`).

## Verification

- Confirmed nothing in `dropbox/`, `generate_base_client.py`, `scripts/`, or `test/` imports `ply`/`yacc` directly.
- Confirmed `ply` remains installed transitively via `stone` after removal.

## Note

This is a cleanup only — it does **not** resolve CVE-2025-56005 in `ply`, since `ply` is still installed transitively through `stone`. The vulnerable `ply.yacc(picklefile=...)` code path is not reachable from the SDK.