### PR TITLE
Modernize GitHub Actions in coverage and spec_update workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,9 +11,9 @@ jobs:
   Coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup Python environment
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Setup virtual environment
@@ -33,7 +33,7 @@ jobs:
           coverage run --rcfile=.coveragerc -m pytest test/unit/test_dropbox_unit.py
           coverage xml
       - name: Publish Coverage
-        uses: codecov/codecov-action@v3.1.6
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
@@ -41,9 +41,9 @@ jobs:
   IntegrationCoverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: Setup Python environment
-        uses: actions/setup-python@v3.1.4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Setup virtual environment
@@ -77,7 +77,7 @@ jobs:
           coverage run --rcfile=.coveragerc -m pytest test/integration/test_dropbox.py
           coverage xml
       - name: Publish Coverage
-        uses: codecov/codecov-action@v3.1.6
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: integration

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -8,9 +8,9 @@ jobs:
   Update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Setup Python environment
-        uses: actions/setup-python@v3.1.4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
       - name: Get current time
@@ -51,7 +51,7 @@ jobs:
           pip install -r requirements.txt
           python generate_base_client.py
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5.0.0
+        uses: peter-evans/create-pull-request@v7
         if: steps.git-diff-num.outputs.num-diff != 0
         with:
           token: ${{ secrets.SPEC_UPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps the GitHub Action versions in `coverage.yml` and `spec_update.yml`, which had fallen behind the rest of the workflows. `ci.yml` and `pypiupload.yml` already use `actions/checkout@v5` and `actions/setup-python@v6`; this brings the other two in line and updates the remaining actions to current majors:

- `actions/checkout`: v2 / v3 → **v5**
- `actions/setup-python`: v3.1.4 / v4 → **v6**
- `codecov/codecov-action`: v3.1.6 → **v5**
- `peter-evans/create-pull-request`: v5.0.0 → **v7**

After this change, all four workflow files use consistent action versions, and the Node 20 deprecation warnings from the older actions go away.

## Supersedes

This replaces the following stale dependabot PRs, which targeted long-outdated versions and no longer merge cleanly:

- #422 — Bump actions/checkout from 2 to 3
- #471 — Bump codecov/codecov-action from 1.3.2 to 3.1.4
- #473 — Bump actions/setup-python from 2.2.2 to 4.6.1
- #478 — Bump peter-evans/create-pull-request from 5.0.0 to 5.0.2

## Verification

- Both workflow files validated as well-formed YAML.
- Confirmed all `checkout` / `setup-python` versions are now consistent across every workflow.