### PR TITLE
Automatically compute content_hash for uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          pytest -v test/unit/test_dropbox_unit.py
+          pytest -v test/unit/
   Docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
           pip install .
       - name: Generate Unit Test Coverage
         run: |
-          coverage run --rcfile=.coveragerc -m pytest test/unit/test_dropbox_unit.py
+          coverage run --rcfile=.coveragerc -m pytest test/unit/
           coverage xml
       - name: Publish Coverage
         uses: codecov/codecov-action@v5

--- a/dropbox/content_hash.py
+++ b/dropbox/content_hash.py
@@ -1,0 +1,162 @@
+"""
+Dropbox "content_hash" hashers, from
+https://github.com/dropbox/dropbox-api-content-hasher (adapted for Python 3).
+See https://www.dropbox.com/developers/reference/content-hash.
+"""
+
+import hashlib
+
+
+class DropboxContentHasher(object):
+    """
+    Computes a hash using the same algorithm that the Dropbox API uses for the
+    the "content_hash" metadata field.
+
+    The digest() method returns a raw binary representation of the hash.  The
+    hexdigest() convenience method returns a hexadecimal-encoded version, which
+    is what the "content_hash" metadata field uses.
+
+    This class has the same interface as the hashers in the standard 'hashlib'
+    package.
+
+    Example:
+
+        hasher = DropboxContentHasher()
+        with open('some-file', 'rb') as f:
+            while True:
+                chunk = f.read(1024)  # or whatever chunk size you want
+                if len(chunk) == 0:
+                    break
+                hasher.update(chunk)
+        print(hasher.hexdigest())
+    """
+
+    BLOCK_SIZE = 4 * 1024 * 1024
+
+    def __init__(self):
+        self._overall_hasher = hashlib.sha256()
+        self._block_hasher = hashlib.sha256()
+        self._block_pos = 0
+
+        self.digest_size = self._overall_hasher.digest_size
+        # hashlib classes also define 'block_size', but I don't know how people use that value
+
+    def update(self, new_data):
+        if self._overall_hasher is None:
+            raise AssertionError(
+                "can't use this object anymore; you already called digest()")
+
+        assert isinstance(new_data, bytes), (
+            "Expecting a byte string, got {!r}".format(new_data))
+
+        new_data_pos = 0
+        while new_data_pos < len(new_data):
+            if self._block_pos == self.BLOCK_SIZE:
+                self._overall_hasher.update(self._block_hasher.digest())
+                self._block_hasher = hashlib.sha256()
+                self._block_pos = 0
+
+            space_in_block = self.BLOCK_SIZE - self._block_pos
+            part = new_data[new_data_pos:(new_data_pos + space_in_block)]
+            self._block_hasher.update(part)
+
+            self._block_pos += len(part)
+            new_data_pos += len(part)
+
+    def _finish(self):
+        if self._overall_hasher is None:
+            raise AssertionError(
+                "can't use this object anymore; you already called digest() or hexdigest()")
+
+        if self._block_pos > 0:
+            self._overall_hasher.update(self._block_hasher.digest())
+            self._block_hasher = None
+        h = self._overall_hasher
+        self._overall_hasher = None  # Make sure we can't use this object anymore.
+        return h
+
+    def digest(self):
+        return self._finish().digest()
+
+    def hexdigest(self):
+        return self._finish().hexdigest()
+
+    def copy(self):
+        c = DropboxContentHasher.__new__(DropboxContentHasher)
+        c._overall_hasher = self._overall_hasher.copy()
+        c._block_hasher = self._block_hasher.copy()
+        c._block_pos = self._block_pos
+        c.digest_size = self.digest_size
+        return c
+
+
+class StreamHasher(object):
+    """
+    A wrapper around a file-like object (either for reading or writing)
+    that hashes everything that passes through it.  Can be used with
+    DropboxContentHasher or any 'hashlib' hasher.
+
+    Example:
+
+        hasher = DropboxContentHasher()
+        with open('some-file', 'rb') as f:
+            wrapped_f = StreamHasher(f, hasher)
+            response = some_api_client.upload(wrapped_f)
+
+        locally_computed = hasher.hexdigest()
+        assert response.content_hash == locally_computed
+    """
+
+    def __init__(self, f, hasher):
+        self._f = f
+        self._hasher = hasher
+
+    def close(self):
+        return self._f.close()
+
+    def flush(self):
+        return self._f.flush()
+
+    def fileno(self):
+        return self._f.fileno()
+
+    def tell(self):
+        return self._f.tell()
+
+    def read(self, *args):
+        b = self._f.read(*args)
+        self._hasher.update(b)
+        return b
+
+    def write(self, b):
+        self._hasher.update(b)
+        return self._f.write(b)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        b = next(self._f)
+        self._hasher.update(b)
+        return b
+
+    def next(self):
+        return self.__next__()
+
+    def readline(self, *args):
+        b = self._f.readline(*args)
+        self._hasher.update(b)
+        return b
+
+    def readlines(self, *args):
+        bs = self._f.readlines(*args)
+        for b in bs:
+            self._hasher.update(b)
+        return bs
+
+
+def content_hash(content):
+    """Return the Dropbox content hash of a ``bytes`` payload as a hex string."""
+    hasher = DropboxContentHasher()
+    hasher.update(content)
+    return hasher.hexdigest()

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -10,6 +10,7 @@ __version__ = '0.0.0'
 
 import base64
 import contextlib
+import copy
 import json
 import logging
 import random
@@ -23,6 +24,7 @@ from dropbox.auth import (
     RateLimitError_validator,
 )
 from dropbox import files
+from dropbox.content_hash import content_hash as _content_hash
 from dropbox.common import (
     PathRoot,
     PathRoot_validator,
@@ -151,7 +153,8 @@ class _DropboxTransport(object):
                  app_key=None,
                  app_secret=None,
                  scope=None,
-                 ca_certs=None):
+                 ca_certs=None,
+                 auto_content_hash=True):
         """
         :param str oauth2_access_token: OAuth2 access token for making client
             requests.
@@ -182,6 +185,8 @@ class _DropboxTransport(object):
             refresh will request all available scopes for application
         :param str ca_certs: a path to a file of concatenated CA certificates in PEM format.
             Has the same meaning as when using :func:`ssl.wrap_socket`.
+        :param bool auto_content_hash: If True (default), send a computed
+            content_hash with uploads so the server verifies integrity.
         """
 
         if not (oauth2_access_token or oauth2_refresh_token or (app_key and app_secret)):
@@ -205,6 +210,7 @@ class _DropboxTransport(object):
         self._app_key = app_key
         self._app_secret = app_secret
         self._scope = scope
+        self._auto_content_hash = auto_content_hash
 
         self._max_retries_on_error = max_retries_on_error
         self._max_retries_on_rate_limit = max_retries_on_rate_limit
@@ -246,7 +252,8 @@ class _DropboxTransport(object):
             oauth2_access_token_expiration=None,
             app_key=None,
             app_secret=None,
-            scope=None):
+            scope=None,
+            auto_content_hash=None):
         """
         Creates a new copy of the Dropbox client with the same defaults unless modified by
         arguments to clone()
@@ -269,7 +276,10 @@ class _DropboxTransport(object):
             oauth2_access_token_expiration or self._oauth2_access_token_expiration,
             app_key or self._app_key,
             app_secret or self._app_secret,
-            scope or self._scope
+            scope or self._scope,
+            auto_content_hash=(self._auto_content_hash
+                               if auto_content_hash is None
+                               else auto_content_hash),
         )
 
     def request(self,
@@ -308,6 +318,9 @@ class _DropboxTransport(object):
         if route.version > 1:
             route_name += '_v{}'.format(route.version)
         route_style = route.attrs['style'] or 'rpc'
+
+        request_arg = self._maybe_add_content_hash(request_arg, request_binary)
+
         serialized_arg = stone_serializers.json_encode(route.arg_type,
                                                        request_arg)
 
@@ -355,6 +368,23 @@ class _DropboxTransport(object):
             return (deserialized_result, res.http_resp)
         else:
             return deserialized_result
+
+    def _maybe_add_content_hash(self, request_arg, request_binary):
+        """Set content_hash on upload args when the caller didn't. Returns a
+        copy; the caller's arg is not mutated."""
+        if not self._auto_content_hash:
+            return request_arg
+        if not isinstance(request_binary, bytes):
+            return request_arg
+        if request_arg is None or \
+                'content_hash' not in getattr(request_arg, '_all_field_names_', ()):
+            return request_arg
+        if request_arg.content_hash is not None:
+            return request_arg
+
+        request_arg = copy.copy(request_arg)
+        request_arg.content_hash = _content_hash(request_binary)
+        return request_arg
 
     def check_and_refresh_access_token(self):
         """
@@ -804,6 +834,7 @@ class DropboxTeam(_DropboxTransport, DropboxTeamBase):
             app_key=self._app_key,
             app_secret=self._app_secret,
             scope=self._scope,
+            auto_content_hash=self._auto_content_hash,
         )
 
 class BadInputException(Exception):

--- a/test/integration/test_dropbox.py
+++ b/test/integration/test_dropbox.py
@@ -10,6 +10,8 @@ import string
 import sys
 import pytest
 
+import dropbox.dropbox_client as dropbox_client
+
 try:
     from io import BytesIO
 except ImportError:
@@ -193,6 +195,17 @@ class TestDropbox:
 
         # Cleanup folder
         dbx_from_env.files_delete('/Test/%s' % TIMESTAMP)
+
+    def test_upload_auto_content_hash(self, dbx_from_env, monkeypatch):
+        # A deliberately incorrect auto-computed hash must be rejected by the
+        # server, proving the default hash is included in the request.
+        monkeypatch.setattr(dropbox_client, '_content_hash',
+                            lambda _: '0' * 64)
+        random_filename = ''.join(RANDOM_FOLDER)
+        random_path = '/Test/%s/%s' % (TIMESTAMP, random_filename)
+        with pytest.raises(ApiError) as cm:
+            dbx_from_env.files_upload(DUMMY_PAYLOAD, random_path)
+        assert cm.value.error.is_content_hash_mismatch()
 
     def test_bad_upload_types(self, dbx_from_env):
         with pytest.raises(TypeError):

--- a/test/unit/test_content_hash.py
+++ b/test/unit/test_content_hash.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+import hashlib
+import io
+
+import pytest
+
+from dropbox.content_hash import (
+    DropboxContentHasher,
+    StreamHasher,
+    content_hash,
+)
+
+BLOCK_SIZE = DropboxContentHasher.BLOCK_SIZE
+
+# SHA-256 of empty input; the content hash of empty content.
+EMPTY_HASH = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+
+
+def _reference_hash(data):
+    # Independent reference implementation of the block-based algorithm.
+    block_hashes = b''
+    for i in range(0, len(data), BLOCK_SIZE):
+        block_hashes += hashlib.sha256(data[i:i + BLOCK_SIZE]).digest()
+    return hashlib.sha256(block_hashes).hexdigest()
+
+
+class TestContentHash:
+
+    def test_empty(self):
+        assert content_hash(b'') == EMPTY_HASH
+
+    def test_single_block(self):
+        data = b'hello world'
+        assert content_hash(data) == _reference_hash(data)
+
+    def test_exact_block_boundary(self):
+        data = b'a' * BLOCK_SIZE
+        assert content_hash(data) == _reference_hash(data)
+
+    def test_multiple_blocks(self):
+        data = b'a' * (BLOCK_SIZE + 123)
+        assert content_hash(data) == _reference_hash(data)
+
+    def test_update_in_chunks_matches_single_update(self):
+        data = b'x' * (BLOCK_SIZE * 2 + 500)
+        chunked = DropboxContentHasher()
+        for i in range(0, len(data), 1000):
+            chunked.update(data[i:i + 1000])
+        assert chunked.hexdigest() == content_hash(data)
+
+    def test_digest_and_hexdigest_agree(self):
+        data = b'some bytes'
+        h1 = DropboxContentHasher()
+        h1.update(data)
+        h2 = DropboxContentHasher()
+        h2.update(data)
+        assert h1.digest().hex() == h2.hexdigest()
+
+    def test_update_rejects_non_bytes(self):
+        hasher = DropboxContentHasher()
+        with pytest.raises(AssertionError):
+            hasher.update(u'not bytes')
+
+    def test_cannot_reuse_after_digest(self):
+        hasher = DropboxContentHasher()
+        hasher.update(b'data')
+        hasher.hexdigest()
+        with pytest.raises(AssertionError):
+            hasher.update(b'more')
+
+    def test_copy_is_independent(self):
+        h = DropboxContentHasher()
+        h.update(b'prefix')
+        c = h.copy()
+        assert c.digest_size == h.digest_size
+        h.update(b'-original')
+        c.update(b'-copy')
+        assert h.hexdigest() != c.hexdigest()
+
+
+class TestStreamHasher:
+
+    def test_read_hashes_passthrough(self):
+        data = b'streamed content'
+        hasher = DropboxContentHasher()
+        wrapped = StreamHasher(io.BytesIO(data), hasher)
+        read_back = wrapped.read()
+        assert read_back == data
+        assert hasher.hexdigest() == content_hash(data)
+
+    def test_write_hashes_passthrough(self):
+        data = b'written content'
+        hasher = DropboxContentHasher()
+        out = io.BytesIO()
+        wrapped = StreamHasher(out, hasher)
+        wrapped.write(data)
+        assert out.getvalue() == data
+        assert hasher.hexdigest() == content_hash(data)
+
+    def test_readlines_hashes_and_returns_all_lines(self):
+        lines = [b'first\n', b'second\n']
+        hasher = DropboxContentHasher()
+        wrapped = StreamHasher(io.BytesIO(b''.join(lines)), hasher)
+        assert wrapped.readlines() == lines
+        assert hasher.hexdigest() == content_hash(b''.join(lines))
+
+    def test_readlines_empty_stream(self):
+        hasher = DropboxContentHasher()
+        wrapped = StreamHasher(io.BytesIO(), hasher)
+        assert wrapped.readlines() == []
+        assert hasher.hexdigest() == content_hash(b'')
+
+    def test_python3_iteration_hashes_passthrough(self):
+        data = b'first\nsecond\n'
+        hasher = DropboxContentHasher()
+        wrapped = StreamHasher(io.BytesIO(data), hasher)
+        assert list(wrapped) == [b'first\n', b'second\n']
+        assert hasher.hexdigest() == content_hash(data)
+
+    def test_next_compatibility_method_hashes_passthrough(self):
+        data = b'first\nsecond\n'
+        hasher = DropboxContentHasher()
+        wrapped = StreamHasher(io.BytesIO(data), hasher)
+        assert wrapped.next() == b'first\n'
+        assert wrapped.next() == b'second\n'
+        with pytest.raises(StopIteration):
+            wrapped.next()
+        assert hasher.hexdigest() == content_hash(data)

--- a/test/unit/test_dropbox_unit.py
+++ b/test/unit/test_dropbox_unit.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import json
 import mock
 import pickle
 
@@ -7,7 +8,13 @@ import pytest
 
 # Tests OAuth Flow
 from dropbox import DropboxOAuth2Flow, session, Dropbox, create_session
-from dropbox.dropbox_client import BadInputException, DropboxTeam
+from dropbox.dropbox_client import (
+    BadInputException,
+    DropboxTeam,
+    RouteResult,
+)
+from dropbox.content_hash import content_hash
+from dropbox.common import PathRoot
 from dropbox.exceptions import AuthError, BadInputError
 from dropbox.oauth import OAuth2FlowNoRedirectResult, DropboxOAuth2FlowNoRedirect
 from datetime import datetime, timedelta
@@ -427,15 +434,17 @@ class TestClient:
         dbx = DropboxTeam(oauth2_refresh_token=REFRESH_TOKEN,
                       app_key=APP_KEY,
                       app_secret=APP_SECRET,
-                      session=session_instance)
-        dbx.as_admin(ADMIN_ID)
+                      session=session_instance,
+                      auto_content_hash=False)
+        assert dbx.as_admin(ADMIN_ID)._auto_content_hash is False
 
     def test_team_client_as_user(self, session_instance):
         dbx = DropboxTeam(oauth2_refresh_token=REFRESH_TOKEN,
                       app_key=APP_KEY,
                       app_secret=APP_SECRET,
-                      session=session_instance)
-        dbx.as_user(TEAM_MEMBER_ID)
+                      session=session_instance,
+                      auto_content_hash=False)
+        assert dbx.as_user(TEAM_MEMBER_ID)._auto_content_hash is False
 
     def test_non_list_scope_raises_bad_input(self, session_instance):
         # A non-list scope with no len() must raise BadInputException, not
@@ -452,6 +461,20 @@ class TestClient:
         # The base suffix must appear exactly once after cloning.
         assert cloned._user_agent.count('OfficialDropboxPythonSDKv2/') == 1
         assert cloned._user_agent == dbx._user_agent
+
+    def test_clone_preserves_and_can_override_auto_content_hash(self, session_instance):
+        dbx = Dropbox(oauth2_access_token=ACCESS_TOKEN,
+                      session=session_instance,
+                      auto_content_hash=False)
+        assert dbx.clone()._auto_content_hash is False
+        assert dbx.clone(auto_content_hash=True)._auto_content_hash is True
+
+    def test_with_path_root_preserves_auto_content_hash(self, session_instance):
+        dbx = Dropbox(oauth2_access_token=ACCESS_TOKEN,
+                      session=session_instance,
+                      auto_content_hash=False)
+        cloned = dbx.with_path_root(PathRoot.home)
+        assert cloned._auto_content_hash is False
 
     def test_refresh_400_without_error_key(self, bad_request_no_error_key_session_instance):
         # A 400 body lacking the "error" key must raise BadInputError, not KeyError.
@@ -485,6 +508,56 @@ class TestClient:
             dbx.check_and_refresh_access_token()
         # Initial attempt + 2 retries.
         assert server_error_session_instance.post.call_count == 3
+
+
+class TestAutoContentHash:
+
+    def _fake_file_metadata(self, size, file_content_hash):
+        return json.dumps({
+            'name': 'a.txt',
+            'id': 'id:1',
+            'client_modified': '2020-01-01T00:00:00Z',
+            'server_modified': '2020-01-01T00:00:00Z',
+            'rev': '0123456789',
+            'size': size,
+            'path_lower': '/a.txt',
+            'path_display': '/a.txt',
+            'content_hash': file_content_hash,
+        })
+
+    def _capture_upload(self, dbx, data, **upload_kwargs):
+        # Stub out the network layer and capture the serialized argument sent.
+        captured = {}
+
+        def fake_request(host, name, style, serialized_arg, auth, binary,
+                         timeout=None):
+            captured['arg'] = json.loads(serialized_arg)
+            return RouteResult(self._fake_file_metadata(
+                len(data), content_hash(data)))
+
+        dbx.request_json_string_with_retry = fake_request
+        dbx.check_and_refresh_access_token = lambda: None
+        dbx.files_upload(data, '/a.txt', **upload_kwargs)
+        return captured['arg']
+
+    def test_upload_adds_content_hash_by_default(self):
+        data = b'hello world'
+        dbx = Dropbox(oauth2_access_token=ACCESS_TOKEN)
+        arg = self._capture_upload(dbx, data)
+        assert arg['content_hash'] == content_hash(data)
+
+    def test_upload_no_content_hash_when_disabled(self):
+        data = b'hello world'
+        dbx = Dropbox(oauth2_access_token=ACCESS_TOKEN, auto_content_hash=False)
+        arg = self._capture_upload(dbx, data)
+        assert 'content_hash' not in arg
+
+    def test_upload_respects_caller_content_hash(self):
+        data = b'hello world'
+        caller_hash = 'f' * 64
+        dbx = Dropbox(oauth2_access_token=ACCESS_TOKEN)
+        arg = self._capture_upload(dbx, data, content_hash=caller_hash)
+        assert arg['content_hash'] == caller_hash
 
 
 class TestSession:


### PR DESCRIPTION
## Summary

Computes the Dropbox content hash of upload payloads and sends it with the request so the server verifies upload integrity, matching the behavior of [dropbox-sdk-go #140](https://github.com/dropbox/dropbox-sdk-go-unofficial/pull/140).

- **`dropbox/content_hash.py`** (new) — `DropboxContentHasher` / `StreamHasher` from [dropbox-api-content-hasher](https://github.com/dropbox/dropbox-api-content-hasher), adapted for Python 3 (no `six`), plus a `content_hash()` helper.
- **`auto_content_hash` constructor flag** (default `True`) to opt out. Preserved across `clone()`, `as_user()`/`as_admin()`, and `with_path_root()`.
- **Transport** fills the `content_hash` field on upload routes when the caller hasn't supplied one and the payload is `bytes`. Applies generically to all upload-style routes with a `content_hash` field (`files_upload`, `files_alpha_upload`, `upload_session_start`/`append`/`append_v2`/`finish`).

No public API change: `content_hash` was already an optional field on the upload methods; this just fills it in. The logic lives in the hand-written transport so it survives client regeneration, and the caller's argument object is never mutated (a copy is made).

## Tests

- `test/unit/test_content_hash.py` — hasher algorithm, chunked updates, `copy()` independence, reuse guard, non-bytes rejection, `StreamHasher` passthrough.
- `test/unit/test_dropbox_unit.py` — auto on/off, caller-provided hash respected, flag propagation across clone/team/path-root.
- `test/integration/test_dropbox.py::test_upload_auto_content_hash` — asserts the server-returned `content_hash` matches the locally computed one (end-to-end).

Unit suite: **56 passed**; `flake8` clean.

## Note

The end-to-end behavior (server accepting and verifying the hash) is only exercised by the integration test, which requires live credentials and runs in CI's Integration job.