### PR TITLE
Update Read the Docs build OS

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.11"
 


### PR DESCRIPTION
## Summary

Update the Read the Docs build image from `ubuntu-20.04` to `ubuntu-24.04`.

## Why

Read the Docs no longer accepts `ubuntu-20.04`, causing [build 33520151](https://app.readthedocs.org/projects/dropbox-sdk-python/builds/33520151/) to fail during config validation before dependencies or Sphinx run.

## Impact

Documentation builds can proceed on a supported LTS image.

## Validation

- YAML parses successfully.
- `git diff --check` passes.
