### PR TITLE
Bump stone to 3.5.2 and regenerate client

### DIFF
--- a/dropbox/account.py
+++ b/dropbox/account.py
@@ -9,14 +9,14 @@ from stone.backends.python_rsrc import stone_validators as bv
 
 class AccountPhotoGetArg(bb.Struct):
     """
-    :ivar account.AccountPhotoGetArg.dbx_account_id: Encoded ID of the user.
-        Must start either with 'dbid:' or 'dbaphid:'.
-    :ivar account.AccountPhotoGetArg.size: A string representing the size of the
-        photo.
-    :ivar account.AccountPhotoGetArg.circle_crop: True if the photo should be
-        cropped and false otherwise.
-    :ivar account.AccountPhotoGetArg.expect_account_photo: True if we expect
-        account photo to exist.
+    :ivar AccountPhotoGetArg.dbx_account_id:
+        Encoded ID of the user. Must start either with 'dbid:' or 'dbaphid:'.
+    :ivar AccountPhotoGetArg.size:
+        A string representing the size of the photo.
+    :ivar AccountPhotoGetArg.circle_crop:
+        True if the photo should be cropped and false otherwise.
+    :ivar AccountPhotoGetArg.expect_account_photo:
+        True if we expect account photo to exist.
     """
 
     __slots__ = [
@@ -69,12 +69,13 @@ class AccountPhotoGetError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar ThumbnailError AccountPhotoGetError.thumbnail_error: Indicates
-        infrastructural failure.
-    :ivar account.AccountPhotoGetError.account_photo_missing: Account photo is
-        missing (but we did not expect it to exist).
-    :ivar account.AccountPhotoGetError.expected_account_photo_missing: Account
-        photo was expected to exist, but it's missing.
+    :ivar AccountPhotoGetError.thumbnail_error:
+        Indicates infrastructural failure.
+    :vartype AccountPhotoGetError.thumbnail_error: ThumbnailError
+    :ivar AccountPhotoGetError.account_photo_missing:
+        Account photo is missing (but we did not expect it to exist).
+    :ivar AccountPhotoGetError.expected_account_photo_missing:
+        Account photo was expected to exist, but it's missing.
     """
 
     _catch_all = 'other'
@@ -147,8 +148,8 @@ AccountPhotoGetError_validator = bv.Union(AccountPhotoGetError)
 
 class AccountPhotoGetResult(bb.Struct):
     """
-    :ivar account.AccountPhotoGetResult.content_type: The data returned by
-        get_photo.
+    :ivar AccountPhotoGetResult.content_type:
+        The data returned by get_photo.
     """
 
     __slots__ = [
@@ -242,8 +243,9 @@ class PhotoSourceArg(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str account.PhotoSourceArg.base64_data: Image data in base64-encoded
-        bytes.
+    :ivar PhotoSourceArg.base64_data:
+        Image data in base64-encoded bytes.
+    :vartype PhotoSourceArg.base64_data: str
     """
 
     _catch_all = 'other'
@@ -296,8 +298,8 @@ PhotoSourceArg_validator = bv.Union(PhotoSourceArg)
 
 class SetProfilePhotoArg(bb.Struct):
     """
-    :ivar account.SetProfilePhotoArg.photo: Image to set as the user's new
-        profile photo.
+    :ivar SetProfilePhotoArg.photo:
+        Image to set as the user's new profile photo.
     """
 
     __slots__ = [
@@ -326,16 +328,16 @@ class SetProfilePhotoError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar account.SetProfilePhotoError.file_type_error: File cannot be set as
-        profile photo.
-    :ivar account.SetProfilePhotoError.file_size_error: File cannot exceed 10
-        MB.
-    :ivar account.SetProfilePhotoError.dimension_error: Image must be larger
-        than 128 x 128.
-    :ivar account.SetProfilePhotoError.thumbnail_error: Image could not be
-        thumbnailed.
-    :ivar account.SetProfilePhotoError.transient_error: Temporary infrastructure
-        failure, please retry.
+    :ivar SetProfilePhotoError.file_type_error:
+        File cannot be set as profile photo.
+    :ivar SetProfilePhotoError.file_size_error:
+        File cannot exceed 10 MB.
+    :ivar SetProfilePhotoError.dimension_error:
+        Image must be larger than 128 x 128.
+    :ivar SetProfilePhotoError.thumbnail_error:
+        Image could not be thumbnailed.
+    :ivar SetProfilePhotoError.transient_error:
+        Temporary infrastructure failure, please retry.
     """
 
     _catch_all = 'other'
@@ -407,8 +409,8 @@ SetProfilePhotoError_validator = bv.Union(SetProfilePhotoError)
 
 class SetProfilePhotoResult(bb.Struct):
     """
-    :ivar account.SetProfilePhotoResult.profile_photo_url: URL for the photo
-        representing the user, if one is set.
+    :ivar SetProfilePhotoResult.profile_photo_url:
+        URL for the photo representing the user, if one is set.
     """
 
     __slots__ = [
@@ -437,10 +439,10 @@ class ThumbnailError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar account.ThumbnailError.permanent_failure: Indicates permanent
-        infrastructural failure.
-    :ivar account.ThumbnailError.temporary_failure: Indicates temporary
-        infrastructural failure.
+    :ivar ThumbnailError.permanent_failure:
+        Indicates permanent infrastructural failure.
+    :ivar ThumbnailError.temporary_failure:
+        Indicates temporary infrastructural failure.
     """
 
     _catch_all = 'other'

--- a/dropbox/async_.py
+++ b/dropbox/async_.py
@@ -19,9 +19,10 @@ class LaunchResultBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str async.LaunchResultBase.async_job_id: This response indicates that
-        the processing is asynchronous. The string is an id that can be used to
-        obtain the status of the asynchronous job.
+    :ivar LaunchResultBase.async_job_id:
+        This response indicates that the processing is asynchronous. The string
+        is an id that can be used to obtain the status of the asynchronous job.
+    :vartype LaunchResultBase.async_job_id: str
     """
 
     _catch_all = None
@@ -73,8 +74,8 @@ class LaunchEmptyResult(LaunchResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar async.LaunchEmptyResult.complete: The job finished synchronously and
-        successfully.
+    :ivar LaunchEmptyResult.complete:
+        The job finished synchronously and successfully.
     """
 
     # Attribute is overwritten below the class definition
@@ -97,8 +98,9 @@ class PollArg(bb.Struct):
     """
     Arguments for methods that poll the status of an asynchronous job.
 
-    :ivar async.PollArg.async_job_id: Id of the asynchronous job. This is the
-        value of a response returned from the method that launched the job.
+    :ivar PollArg.async_job_id:
+        Id of the asynchronous job. This is the value of a response returned
+        from the method that launched the job.
     """
 
     __slots__ = [
@@ -132,8 +134,8 @@ class PollResultBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar async.PollResultBase.in_progress: The asynchronous job is still in
-        progress.
+    :ivar PollResultBase.in_progress:
+        The asynchronous job is still in progress.
     """
 
     _catch_all = None
@@ -162,8 +164,8 @@ class PollEmptyResult(PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar async.PollEmptyResult.complete: The asynchronous job has completed
-        successfully.
+    :ivar PollEmptyResult.complete:
+        The asynchronous job has completed successfully.
     """
 
     # Attribute is overwritten below the class definition
@@ -190,10 +192,12 @@ class PollError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar async.PollError.invalid_async_job_id: The job ID is invalid.
-    :ivar async.PollError.internal_error: Something went wrong with the job on
-        Dropbox's end. You'll need to verify that the action you were taking
-        succeeded, and if not, try again. This should happen very rarely.
+    :ivar PollError.invalid_async_job_id:
+        The job ID is invalid.
+    :ivar PollError.internal_error:
+        Something went wrong with the job on Dropbox's end. You'll need to
+        verify that the action you were taking succeeded, and if not, try again.
+        This should happen very rarely.
     """
 
     _catch_all = 'other'

--- a/dropbox/auth.py
+++ b/dropbox/auth.py
@@ -16,14 +16,17 @@ class AccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar InvalidAccountTypeError AccessError.invalid_account_type: Current
-        account type cannot access the resource.
-    :ivar PaperAccessError AccessError.paper_access_denied: Current account
-        cannot access Paper.
-    :ivar auth.AccessError.team_access_denied: Team doesn't have permission to
-        access.
-    :ivar NoPermissionError AccessError.no_permission: Caller does not have
-        permission to access the resource.
+    :ivar AccessError.invalid_account_type:
+        Current account type cannot access the resource.
+    :vartype AccessError.invalid_account_type: InvalidAccountTypeError
+    :ivar AccessError.paper_access_denied:
+        Current account cannot access Paper.
+    :vartype AccessError.paper_access_denied: PaperAccessError
+    :ivar AccessError.team_access_denied:
+        Team doesn't have permission to access.
+    :ivar AccessError.no_permission:
+        Caller does not have permission to access the resource.
+    :vartype AccessError.no_permission: NoPermissionError
     """
 
     _catch_all = 'other'
@@ -154,17 +157,23 @@ class AuthError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar auth.AuthError.invalid_access_token: The access token is invalid.
-    :ivar auth.AuthError.invalid_select_user: The user specified in
-        'Dropbox-API-Select-User' is no longer on the team.
-    :ivar auth.AuthError.invalid_select_admin: The user specified in
-        'Dropbox-API-Select-Admin' is not a Dropbox Business team admin.
-    :ivar auth.AuthError.user_suspended: The user has been suspended.
-    :ivar auth.AuthError.expired_access_token: The access token has expired.
-    :ivar TokenScopeError AuthError.missing_scope: The access token does not
-        have the required scope to access the route.
-    :ivar auth.AuthError.route_access_denied: The route is not available to
-        public.
+    :ivar AuthError.invalid_access_token:
+        The access token is invalid.
+    :ivar AuthError.invalid_select_user:
+        The user specified in 'Dropbox-API-Select-User' is no longer on the
+        team.
+    :ivar AuthError.invalid_select_admin:
+        The user specified in 'Dropbox-API-Select-Admin' is not a Dropbox
+        Business team admin.
+    :ivar AuthError.user_suspended:
+        The user has been suspended.
+    :ivar AuthError.expired_access_token:
+        The access token has expired.
+    :ivar AuthError.missing_scope:
+        The access token does not have the required scope to access the route.
+    :vartype AuthError.missing_scope: TokenScopeError
+    :ivar AuthError.route_access_denied:
+        The route is not available to public.
     """
 
     _catch_all = 'other'
@@ -281,10 +290,11 @@ class InvalidAccountTypeError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar auth.InvalidAccountTypeError.endpoint: Current account type doesn't
-        have permission to access this route endpoint.
-    :ivar auth.InvalidAccountTypeError.feature: Current account type doesn't
-        have permission to access this feature.
+    :ivar InvalidAccountTypeError.endpoint:
+        Current account type doesn't have permission to access this route
+        endpoint.
+    :ivar InvalidAccountTypeError.feature:
+        Current account type doesn't have permission to access this feature.
     """
 
     _catch_all = 'other'
@@ -330,10 +340,10 @@ class NoPermissionError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UnauthorizedAccountIdUsageError
-        NoPermissionError.unauthorized_account_id_usage: Current caller does not
-        have permission to access the account information for one or more of the
-        specified account IDs.
+    :ivar NoPermissionError.unauthorized_account_id_usage:
+        Current caller does not have permission to access the account
+        information for one or more of the specified account IDs.
+    :vartype NoPermissionError.unauthorized_account_id_usage: UnauthorizedAccountIdUsageError
     """
 
     _catch_all = 'other'
@@ -391,9 +401,10 @@ class PaperAccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar auth.PaperAccessError.paper_disabled: Paper is disabled.
-    :ivar auth.PaperAccessError.not_paper_user: The provided user has not used
-        Paper yet.
+    :ivar PaperAccessError.paper_disabled:
+        Paper is disabled.
+    :ivar PaperAccessError.not_paper_user:
+        The provided user has not used Paper yet.
     """
 
     _catch_all = 'other'
@@ -437,10 +448,11 @@ class RateLimitError(bb.Struct):
     """
     Error occurred because the app is being rate limited.
 
-    :ivar auth.RateLimitError.reason: The reason why the app is being rate
-        limited.
-    :ivar auth.RateLimitError.retry_after: The number of seconds that the app
-        should wait before making another request.
+    :ivar RateLimitError.reason:
+        The reason why the app is being rate limited.
+    :ivar RateLimitError.retry_after:
+        The number of seconds that the app should wait before making another
+        request.
     """
 
     __slots__ = [
@@ -477,10 +489,11 @@ class RateLimitReason(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar auth.RateLimitReason.too_many_requests: You are making too many
-        requests in the past few minutes.
-    :ivar auth.RateLimitReason.too_many_write_operations: There are currently
-        too many write operations happening in the user's Dropbox.
+    :ivar RateLimitReason.too_many_requests:
+        You are making too many requests in the past few minutes.
+    :ivar RateLimitReason.too_many_write_operations:
+        There are currently too many write operations happening in the user's
+        Dropbox.
     """
 
     _catch_all = 'other'
@@ -522,10 +535,10 @@ RateLimitReason_validator = bv.Union(RateLimitReason)
 
 class TokenFromOAuth1Arg(bb.Struct):
     """
-    :ivar auth.TokenFromOAuth1Arg.oauth1_token: The supplied OAuth 1.0 access
-        token.
-    :ivar auth.TokenFromOAuth1Arg.oauth1_token_secret: The token secret
-        associated with the supplied access token.
+    :ivar TokenFromOAuth1Arg.oauth1_token:
+        The supplied OAuth 1.0 access token.
+    :ivar TokenFromOAuth1Arg.oauth1_token_secret:
+        The token secret associated with the supplied access token.
     """
 
     __slots__ = [
@@ -562,10 +575,11 @@ class TokenFromOAuth1Error(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar auth.TokenFromOAuth1Error.invalid_oauth1_token_info: Part or all of
-        the OAuth 1.0 access token info is invalid.
-    :ivar auth.TokenFromOAuth1Error.app_id_mismatch: The authorized app does not
-        match the app associated with the supplied access token.
+    :ivar TokenFromOAuth1Error.invalid_oauth1_token_info:
+        Part or all of the OAuth 1.0 access token info is invalid.
+    :ivar TokenFromOAuth1Error.app_id_mismatch:
+        The authorized app does not match the app associated with the supplied
+        access token.
     """
 
     _catch_all = 'other'
@@ -607,8 +621,8 @@ TokenFromOAuth1Error_validator = bv.Union(TokenFromOAuth1Error)
 
 class TokenFromOAuth1Result(bb.Struct):
     """
-    :ivar auth.TokenFromOAuth1Result.oauth2_token: The OAuth 2.0 token generated
-        from the supplied OAuth 1.0 token.
+    :ivar TokenFromOAuth1Result.oauth2_token:
+        The OAuth 2.0 token generated from the supplied OAuth 1.0 token.
     """
 
     __slots__ = [
@@ -633,8 +647,8 @@ TokenFromOAuth1Result_validator = bv.Struct(TokenFromOAuth1Result)
 
 class TokenScopeError(bb.Struct):
     """
-    :ivar auth.TokenScopeError.required_scope: The required scope to access the
-        route.
+    :ivar TokenScopeError.required_scope:
+        The required scope to access the route.
     """
 
     __slots__ = [
@@ -659,8 +673,8 @@ TokenScopeError_validator = bv.Struct(TokenScopeError)
 
 class UnauthorizedAccountIdUsageError(bb.Struct):
     """
-    :ivar auth.UnauthorizedAccountIdUsageError.unauthorized_account_ids: The
-        account IDs that the caller does not have permission to use.
+    :ivar UnauthorizedAccountIdUsageError.unauthorized_account_ids:
+        The account IDs that the caller does not have permission to use.
     """
 
     __slots__ = [

--- a/dropbox/base.py
+++ b/dropbox/base.py
@@ -72,13 +72,16 @@ class DropboxBase(object):
         Route attributes:
             scope: account_info.read
 
-        :param str dbx_account_id: Encoded ID of the user. Must start either
-            with 'dbid:' or 'dbaphid:'.
-        :param str size: A string representing the size of the photo.
-        :param bool circle_crop: True if the photo should be cropped and false
+        :param dbx_account_id: Encoded ID of the user. Must start either with
+            'dbid:' or 'dbaphid:'.
+        :type dbx_account_id: str
+        :param size: A string representing the size of the photo.
+        :type size: str
+        :param circle_crop: True if the photo should be cropped and false
             otherwise.
-        :param bool expect_account_photo: True if we expect account photo to
-            exist.
+        :type circle_crop: bool
+        :param expect_account_photo: True if we expect account photo to exist.
+        :type expect_account_photo: bool
         :rtype: (:class:`dropbox.account.AccountPhotoGetResult`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -117,13 +120,16 @@ class DropboxBase(object):
             scope: account_info.read
 
         :param str download_path: Path on local machine to save file.
-        :param str dbx_account_id: Encoded ID of the user. Must start either
-            with 'dbid:' or 'dbaphid:'.
-        :param str size: A string representing the size of the photo.
-        :param bool circle_crop: True if the photo should be cropped and false
+        :param dbx_account_id: Encoded ID of the user. Must start either with
+            'dbid:' or 'dbaphid:'.
+        :type dbx_account_id: str
+        :param size: A string representing the size of the photo.
+        :type size: str
+        :param circle_crop: True if the photo should be cropped and false
             otherwise.
-        :param bool expect_account_photo: True if we expect account photo to
-            exist.
+        :type circle_crop: bool
+        :param expect_account_photo: True if we expect account photo to exist.
+        :type expect_account_photo: bool
         :rtype: :class:`dropbox.account.AccountPhotoGetResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -178,9 +184,11 @@ class DropboxBase(object):
         Creates an OAuth 2.0 access token from the supplied OAuth 1.0 access
         token.
 
-        :param str oauth1_token: The supplied OAuth 1.0 access token.
-        :param str oauth1_token_secret: The token secret associated with the
+        :param oauth1_token: The supplied OAuth 1.0 access token.
+        :type oauth1_token: str
+        :param oauth1_token_secret: The token secret associated with the
             supplied access token.
+        :type oauth1_token_secret: str
         :rtype: :class:`dropbox.auth.TokenFromOAuth1Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -232,7 +240,8 @@ class DropboxBase(object):
         at least part of the Dropbox API infrastructure is working and that the
         app key and secret valid.
 
-        :param str query: The string that you'd like to be echoed back to you.
+        :param query: The string that you'd like to be echoed back to you.
+        :type query: str
         :rtype: :class:`dropbox.check.EchoResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -261,7 +270,8 @@ class DropboxBase(object):
         Route attributes:
             scope: account_info.read
 
-        :param str query: The string that you'd like to be echoed back to you.
+        :param query: The string that you'd like to be echoed back to you.
+        :type query: str
         :rtype: :class:`dropbox.check.EchoResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -308,8 +318,8 @@ class DropboxBase(object):
         Route attributes:
             scope: contacts.write
 
-        :param List[str] email_addresses: List of manually added contacts to be
-            deleted.
+        :param email_addresses: List of manually added contacts to be deleted.
+        :type email_addresses: List[str]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -339,11 +349,12 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.file_properties.PropertyGroup`]
-            property_groups: The property groups which are to be added to a
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param property_groups: The property groups which are to be added to a
             Dropbox file. No two groups in the input should refer to the same
             template.
+        :type property_groups: List[:class:`dropbox.file_properties.PropertyGroup`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -374,10 +385,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.file_properties.PropertyGroup`]
-            property_groups: The property groups "snapshot" updates to force
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param property_groups: The property groups "snapshot" updates to force
             apply. No two groups in the input should refer to the same template.
+        :type property_groups: List[:class:`dropbox.file_properties.PropertyGroup`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -409,10 +421,12 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[str] property_template_ids: A list of identifiers for a
-            template created by :meth:`file_properties_templates_add_for_user`
-            or :meth:`file_properties_templates_add_for_team`.
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param property_template_ids: A list of identifiers for a template
+            created by :meth:`file_properties_templates_add_for_user` or
+            :meth:`file_properties_templates_add_for_team`.
+        :type property_template_ids: List[str]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -438,8 +452,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param List[:class:`dropbox.file_properties.PropertiesSearchQuery`]
-            queries: Queries to search.
+        :param queries: Queries to search.
+        :type queries: List[:class:`dropbox.file_properties.PropertiesSearchQuery`]
         :param template_filter: Filter results to contain only properties
             associated with these template IDs.
         :type template_filter: :class:`dropbox.file_properties.TemplateFilter`
@@ -469,9 +483,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str cursor: The cursor returned by your last call to
+        :param cursor: The cursor returned by your last call to
             :meth:`file_properties_properties_search` or
             :meth:`file_properties_properties_search_continue`.
+        :type cursor: str
         :rtype: :class:`dropbox.file_properties.PropertiesSearchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -502,10 +517,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.file_properties.PropertyGroupUpdate`]
-            update_property_groups: The property groups "delta" updates to
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param update_property_groups: The property groups "delta" updates to
             apply.
+        :type update_property_groups: List[:class:`dropbox.file_properties.PropertyGroupUpdate`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -560,9 +576,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str template_id: An identifier for template added by route  See
+        :param template_id: An identifier for template added by route  See
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
+        :type template_id: str
         :rtype: :class:`dropbox.file_properties.GetTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -613,9 +630,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str template_id: An identifier for a template created by
+        :param template_id: An identifier for a template created by
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
+        :type template_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -645,17 +663,19 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str template_id: An identifier for template added by  See
+        :param template_id: An identifier for template added by  See
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
-        :param Nullable[str] name: A display name for the template. template
-            names can be up to 256 bytes.
-        :param Nullable[str] description: Description for the new template.
-            Template descriptions can be up to 1024 bytes.
-        :param
-            Nullable[List[:class:`dropbox.file_properties.PropertyFieldTemplate`]]
-            add_fields: Property field templates to be added to the group
+        :type template_id: str
+        :param name: A display name for the template. template names can be up
+            to 256 bytes.
+        :type name: Nullable[str]
+        :param description: Description for the new template. Template
+            descriptions can be up to 1024 bytes.
+        :type description: Nullable[str]
+        :param add_fields: Property field templates to be added to the group
             template. There can be up to 32 properties in a single template.
+        :type add_fields: Nullable[List[:class:`dropbox.file_properties.PropertyFieldTemplate`]]
         :rtype: :class:`dropbox.file_properties.UpdateTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -709,19 +729,24 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.write
 
-        :param str title: The title of the file request. Must not be empty.
-        :param str destination: The path of the folder in the Dropbox where
-            uploaded files will be sent. For apps with the app folder
-            permission, this will be relative to the app folder.
-        :param Nullable[:class:`dropbox.file_requests.FileRequestDeadline`]
-            deadline: The deadline for the file request. Deadlines can only be
-            set by Professional and Business accounts.
-        :param bool open: Whether or not the file request should be open. If the
-            file request is closed, it will not accept any file submissions, but
-            it can be opened later.
-        :param Nullable[str] description: A description of the file request.
-        :param Nullable[str] video_project_id: If this request was created from
-            video project, its id.
+        :param title: The title of the file request. Must not be empty.
+        :type title: str
+        :param destination: The path of the folder in the Dropbox where uploaded
+            files will be sent. For apps with the app folder permission, this
+            will be relative to the app folder.
+        :type destination: str
+        :param deadline: The deadline for the file request. Deadlines can only
+            be set by Professional and Business accounts.
+        :type deadline: Nullable[:class:`dropbox.file_requests.FileRequestDeadline`]
+        :param open: Whether or not the file request should be open. If the file
+            request is closed, it will not accept any file submissions, but it
+            can be opened later.
+        :type open: bool
+        :param description: A description of the file request.
+        :type description: Nullable[str]
+        :param video_project_id: If this request was created from video project,
+            its id.
+        :type video_project_id: Nullable[str]
         :rtype: :class:`dropbox.file_requests.FileRequest`
         :raises: :class:`.exceptions.ApiError`
 
@@ -750,7 +775,8 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.write
 
-        :param List[str] ids: List IDs of the file requests to delete.
+        :param ids: List IDs of the file requests to delete.
+        :type ids: List[str]
         :rtype: :class:`dropbox.file_requests.DeleteFileRequestsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -792,7 +818,8 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.read
 
-        :param str id: The ID of the file request to retrieve.
+        :param id: The ID of the file request to retrieve.
+        :type id: str
         :rtype: :class:`dropbox.file_requests.FileRequest`
         """
         arg = file_requests.GetFileRequestArgs(id)
@@ -834,8 +861,9 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.read
 
-        :param int limit: The maximum number of file requests that should be
+        :param limit: The maximum number of file requests that should be
             returned per request.
+        :type limit: int
         :rtype: :class:`dropbox.file_requests.ListFileRequestsV2Result`
         """
         arg = file_requests.ListFileRequestsArg(limit)
@@ -858,8 +886,9 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.read
 
-        :param str cursor: The cursor returned by the previous API call
-            specified in the endpoint description.
+        :param cursor: The cursor returned by the previous API call specified in
+            the endpoint description.
+        :type cursor: str
         :rtype: :class:`dropbox.file_requests.ListFileRequestsV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -888,18 +917,21 @@ class DropboxBase(object):
         Route attributes:
             scope: file_requests.write
 
-        :param str id: The ID of the file request to update.
-        :param Nullable[str] title: The new title of the file request. Must not
-            be empty.
-        :param Nullable[str] destination: The new path of the folder in the
-            Dropbox where uploaded files will be sent. For apps with the app
-            folder permission, this will be relative to the app folder.
+        :param id: The ID of the file request to update.
+        :type id: str
+        :param title: The new title of the file request. Must not be empty.
+        :type title: Nullable[str]
+        :param destination: The new path of the folder in the Dropbox where
+            uploaded files will be sent. For apps with the app folder
+            permission, this will be relative to the app folder.
+        :type destination: Nullable[str]
         :param deadline: The new deadline for the file request. Deadlines can
             only be set by Professional and Business accounts.
         :type deadline: :class:`dropbox.file_requests.UpdateFileRequestDeadline`
-        :param Nullable[bool] open: Whether to set this file request as open or
-            closed.
-        :param Nullable[str] description: The description of the file request.
+        :param open: Whether to set this file request as open or closed.
+        :type open: Nullable[bool]
+        :param description: The description of the file request.
+        :type description: Nullable[str]
         :rtype: :class:`dropbox.file_requests.FileRequest`
         """
         arg = file_requests.UpdateFileRequestArgs(id,
@@ -934,10 +966,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param Nullable[List[str]] include_property_templates: Field is
-            deprecated. If set to a valid list of template IDs,
-            ``FileMetadata.property_groups`` is set for files with custom
-            properties.
+        :param include_property_templates: Field is deprecated. If set to a
+            valid list of template IDs, ``FileMetadata.property_groups`` is set
+            for files with custom properties.
+        :type include_property_templates: Nullable[List[str]]
         :rtype: :class:`dropbox.files.Metadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -982,11 +1014,11 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param Nullable[str] content_hash: A hash of the file content uploaded
-            in this call. If provided and the uploaded content does not match
-            this hash, an error will be returned. For more information see our
-            `Content hash
+        :param content_hash: A hash of the file content uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1026,13 +1058,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the file to avoid the conflict.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the file to avoid the conflict.
+        :type autorename: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.Metadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1069,13 +1104,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the file to avoid the conflict.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the file to avoid the conflict.
+        :type autorename: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.RelocationResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1109,11 +1147,13 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.RelocationBatchLaunch`
         """
         warnings.warn(
@@ -1147,11 +1187,12 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[:class:`dropbox.files.RelocationPath`] entries: List of
-            entries to be moved or copied. Each entry is
+        :param entries: List of entries to be moved or copied. Each entry is
             :class:`dropbox.files.RelocationPath`.
-        :param bool autorename: If there's a conflict with any file, have the
-            Dropbox server try to autorename that file to avoid the conflict.
+        :type entries: List[:class:`dropbox.files.RelocationPath`]
+        :param autorename: If there's a conflict with any file, have the Dropbox
+            server try to autorename that file to avoid the conflict.
+        :type autorename: bool
         :rtype: :class:`dropbox.files.RelocationBatchV2Launch`
         """
         arg = files.RelocationBatchArgBase(entries,
@@ -1173,13 +1214,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.RelocationBatchJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         warnings.warn(
             'copy_batch/check is deprecated.',
@@ -1203,13 +1245,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.RelocationBatchV2JobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1230,8 +1273,9 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: The path to the file or folder you want to get a copy
+        :param path: The path to the file or folder you want to get a copy
             reference to.
+        :type path: str
         :rtype: :class:`dropbox.files.GetCopyReferenceResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1257,9 +1301,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str copy_reference: A copy reference returned by
+        :param copy_reference: A copy reference returned by
             :meth:`files_copy_reference_get`.
-        :param str path: Path in the user's Dropbox that is the destination.
+        :type copy_reference: str
+        :param path: Path in the user's Dropbox that is the destination.
+        :type path: str
         :rtype: :class:`dropbox.files.SaveCopyReferenceResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1285,9 +1331,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: Path in the user's Dropbox to create.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the folder to avoid the conflict.
+        :param path: Path in the user's Dropbox to create.
+        :type path: str
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the folder to avoid the conflict.
+        :type autorename: bool
         :rtype: :class:`dropbox.files.FolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1317,9 +1365,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: Path in the user's Dropbox to create.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the folder to avoid the conflict.
+        :param path: Path in the user's Dropbox to create.
+        :type path: str
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the folder to avoid the conflict.
+        :type autorename: bool
         :rtype: :class:`dropbox.files.CreateFolderResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1351,13 +1401,15 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[str] paths: List of paths to be created in the user's
-            Dropbox. Duplicate path arguments in the batch are considered only
-            once.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the folder to avoid the conflict.
-        :param bool force_async: Whether to force the create to happen
+        :param paths: List of paths to be created in the user's Dropbox.
+            Duplicate path arguments in the batch are considered only once.
+        :type paths: List[str]
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the folder to avoid the conflict.
+        :type autorename: bool
+        :param force_async: Whether to force the create to happen
             asynchronously.
+        :type force_async: bool
         :rtype: :class:`dropbox.files.CreateFolderBatchLaunch`
         """
         arg = files.CreateFolderBatchArg(paths,
@@ -1381,13 +1433,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.CreateFolderBatchJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1411,10 +1464,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: Path in the user's Dropbox to delete.
-        :param Nullable[str] parent_rev: Perform delete if given "rev" matches
-            the existing file's latest "rev". This field does not support
-            deleting a folder.
+        :param path: Path in the user's Dropbox to delete.
+        :type path: str
+        :param parent_rev: Perform delete if given "rev" matches the existing
+            file's latest "rev". This field does not support deleting a folder.
+        :type parent_rev: Nullable[str]
         :rtype: :class:`dropbox.files.Metadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1448,10 +1502,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: Path in the user's Dropbox to delete.
-        :param Nullable[str] parent_rev: Perform delete if given "rev" matches
-            the existing file's latest "rev". This field does not support
-            deleting a folder.
+        :param path: Path in the user's Dropbox to delete.
+        :type path: str
+        :param parent_rev: Perform delete if given "rev" matches the existing
+            file's latest "rev". This field does not support deleting a folder.
+        :type parent_rev: Nullable[str]
         :rtype: :class:`dropbox.files.DeleteResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1500,13 +1555,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.DeleteBatchJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1526,9 +1582,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path of the file to download.
-        :param Nullable[str] rev: Field is deprecated. Please specify revision
-            in ``path`` instead.
+        :param path: The path of the file to download.
+        :type path: str
+        :param rev: Field is deprecated. Please specify revision in ``path``
+            instead.
+        :type rev: Nullable[str]
         :rtype: (:class:`dropbox.files.FileMetadata`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -1563,9 +1621,11 @@ class DropboxBase(object):
             scope: files.content.read
 
         :param str download_path: Path on local machine to save file.
-        :param str path: The path of the file to download.
-        :param Nullable[str] rev: Field is deprecated. Please specify revision
-            in ``path`` instead.
+        :param path: The path of the file to download.
+        :type path: str
+        :param rev: Field is deprecated. Please specify revision in ``path``
+            instead.
+        :type rev: Nullable[str]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1596,7 +1656,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path of the folder to download.
+        :param path: The path of the folder to download.
+        :type path: str
         :rtype: (:class:`dropbox.files.DownloadZipResult`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -1634,7 +1695,8 @@ class DropboxBase(object):
             scope: files.content.read
 
         :param str download_path: Path on local machine to save file.
-        :param str path: The path of the folder to download.
+        :param path: The path of the folder to download.
+        :type path: str
         :rtype: :class:`dropbox.files.DownloadZipResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1662,12 +1724,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path of the file to be exported.
-        :param Nullable[str] export_format: The file format to which the file
-            should be exported. This must be one of the formats listed in the
-            file's export_options returned by :meth:`files_get_metadata`. If
-            none is specified, the default format (specified in export_as in
-            file metadata) will be used.
+        :param path: The path of the file to be exported.
+        :type path: str
+        :param export_format: The file format to which the file should be
+            exported. This must be one of the formats listed in the file's
+            export_options returned by :meth:`files_get_metadata`. If none is
+            specified, the default format (specified in export_as in file
+            metadata) will be used.
+        :type export_format: Nullable[str]
         :rtype: (:class:`dropbox.files.ExportResult`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -1704,12 +1768,14 @@ class DropboxBase(object):
             scope: files.content.read
 
         :param str download_path: Path on local machine to save file.
-        :param str path: The path of the file to be exported.
-        :param Nullable[str] export_format: The file format to which the file
-            should be exported. This must be one of the formats listed in the
-            file's export_options returned by :meth:`files_get_metadata`. If
-            none is specified, the default format (specified in export_as in
-            file metadata) will be used.
+        :param path: The path of the file to be exported.
+        :type path: str
+        :param export_format: The file format to which the file should be
+            exported. This must be one of the formats listed in the file's
+            export_options returned by :meth:`files_get_metadata`. If none is
+            specified, the default format (specified in export_as in file
+            metadata) will be used.
+        :type export_format: Nullable[str]
         :rtype: :class:`dropbox.files.ExportResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1735,10 +1801,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param List[:class:`dropbox.files.LockFileArg`] entries: List of
-            'entries'. Each 'entry' contains a path of the file which will be
-            locked or queried. Duplicate path arguments in the batch are
-            considered only once.
+        :param entries: List of 'entries'. Each 'entry' contains a path of the
+            file which will be locked or queried. Duplicate path arguments in
+            the batch are considered only once.
+        :type entries: List[:class:`dropbox.files.LockFileArg`]
         :rtype: :class:`dropbox.files.LockFileBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1767,20 +1833,23 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str path: The path of a file or folder on Dropbox.
-        :param bool include_media_info: If true, ``FileMetadata.media_info`` is
-            set for photo and video.
-        :param bool include_deleted: If true,
-            :class:`dropbox.files.DeletedMetadata` will be returned for deleted
-            file or folder, otherwise ``LookupError.not_found`` will be
-            returned.
-        :param bool include_has_explicit_shared_members: If true, the results
-            will include a flag for each file indicating whether or not that
-            file has any explicit members.
-        :param Nullable[:class:`dropbox.files.TemplateFilterBase`]
-            include_property_groups: If set to a valid list of template IDs,
+        :param path: The path of a file or folder on Dropbox.
+        :type path: str
+        :param include_media_info: If true, ``FileMetadata.media_info`` is set
+            for photo and video.
+        :type include_media_info: bool
+        :param include_deleted: If true, :class:`dropbox.files.DeletedMetadata`
+            will be returned for deleted file or folder, otherwise
+            ``LookupError.not_found`` will be returned.
+        :type include_deleted: bool
+        :param include_has_explicit_shared_members: If true, the results will
+            include a flag for each file indicating whether or not that file has
+            any explicit members.
+        :type include_has_explicit_shared_members: bool
+        :param include_property_groups: If set to a valid list of template IDs,
             ``FileMetadata.property_groups`` is set if there exists property
             data associated with the file and each of the listed templates.
+        :type include_property_groups: Nullable[:class:`dropbox.file_properties.TemplateFilterBase`]
         :rtype: :class:`dropbox.files.Metadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1813,9 +1882,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path of the file to preview.
-        :param Nullable[str] rev: Field is deprecated. Please specify revision
-            in ``path`` instead.
+        :param path: The path of the file to preview.
+        :type path: str
+        :param rev: Field is deprecated. Please specify revision in ``path``
+            instead.
+        :type rev: Nullable[str]
         :rtype: (:class:`dropbox.files.FileMetadata`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -1854,9 +1925,11 @@ class DropboxBase(object):
             scope: files.content.read
 
         :param str download_path: Path on local machine to save file.
-        :param str path: The path of the file to preview.
-        :param Nullable[str] rev: Field is deprecated. Please specify revision
-            in ``path`` instead.
+        :param path: The path of the file to preview.
+        :type path: str
+        :param rev: Field is deprecated. Please specify revision in ``path``
+            instead.
+        :type rev: Nullable[str]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1885,7 +1958,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path to the file you want a temporary link to.
+        :param path: The path to the file you want a temporary link to.
+        :type path: str
         :rtype: :class:`dropbox.files.GetTemporaryLinkResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1942,9 +2016,10 @@ class DropboxBase(object):
             the future upload commit. Equivalent to the parameters provided to
             :meth:`files_upload`.
         :type commit_info: :class:`dropbox.files.CommitInfo`
-        :param float duration: How long before this link expires, in seconds.
+        :param duration: How long before this link expires, in seconds.
             Attempting to start an upload with this link longer than this period
             of time after link creation will result in an error.
+        :type duration: float
         :rtype: :class:`dropbox.files.GetTemporaryUploadLinkResult`
         """
         arg = files.GetTemporaryUploadLinkArg(commit_info,
@@ -1973,7 +2048,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str path: The path to the image file you want to thumbnail.
+        :param path: The path to the image file you want to thumbnail.
+        :type path: str
         :param format: The format for the thumbnail image, jpeg (default), png,
             or webp. For images that are photos, jpeg should be preferred, while
             png is better for screenshots and digital arts, and web for
@@ -1987,10 +2063,11 @@ class DropboxBase(object):
         :param quality: Field is only returned for "internal" callers. Quality
             of the thumbnail image.
         :type quality: :class:`dropbox.files.ThumbnailQuality`
-        :param Nullable[bool] exclude_media_info: Normally,
-            ``FileMetadata.media_info`` is set for photo and video. When this
-            flag is true, ``FileMetadata.media_info`` is not populated. This
-            improves latency for use cases where `media_info` is not needed.
+        :param exclude_media_info: Normally, ``FileMetadata.media_info`` is set
+            for photo and video. When this flag is true,
+            ``FileMetadata.media_info`` is not populated. This improves latency
+            for use cases where `media_info` is not needed.
+        :type exclude_media_info: Nullable[bool]
         :rtype: (:class:`dropbox.files.FileMetadata`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -2036,7 +2113,8 @@ class DropboxBase(object):
             scope: files.content.read
 
         :param str download_path: Path on local machine to save file.
-        :param str path: The path to the image file you want to thumbnail.
+        :param path: The path to the image file you want to thumbnail.
+        :type path: str
         :param format: The format for the thumbnail image, jpeg (default), png,
             or webp. For images that are photos, jpeg should be preferred, while
             png is better for screenshots and digital arts, and web for
@@ -2050,10 +2128,11 @@ class DropboxBase(object):
         :param quality: Field is only returned for "internal" callers. Quality
             of the thumbnail image.
         :type quality: :class:`dropbox.files.ThumbnailQuality`
-        :param Nullable[bool] exclude_media_info: Normally,
-            ``FileMetadata.media_info`` is set for photo and video. When this
-            flag is true, ``FileMetadata.media_info`` is not populated. This
-            improves latency for use cases where `media_info` is not needed.
+        :param exclude_media_info: Normally, ``FileMetadata.media_info`` is set
+            for photo and video. When this flag is true,
+            ``FileMetadata.media_info`` is not populated. This improves latency
+            for use cases where `media_info` is not needed.
+        :type exclude_media_info: Nullable[bool]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2108,10 +2187,11 @@ class DropboxBase(object):
         :param quality: Field is only returned for "internal" callers. Quality
             of the thumbnail image.
         :type quality: :class:`dropbox.files.ThumbnailQuality`
-        :param Nullable[bool] exclude_media_info: Normally,
-            ``FileMetadata.media_info`` is set for photo and video. When this
-            flag is true, ``FileMetadata.media_info`` is not populated. This
-            improves latency for use cases where `media_info` is not needed.
+        :param exclude_media_info: Normally, ``FileMetadata.media_info`` is set
+            for photo and video. When this flag is true,
+            ``FileMetadata.media_info`` is not populated. This improves latency
+            for use cases where `media_info` is not needed.
+        :type exclude_media_info: Nullable[bool]
         :rtype: (:class:`dropbox.files.PreviewResult`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -2174,10 +2254,11 @@ class DropboxBase(object):
         :param quality: Field is only returned for "internal" callers. Quality
             of the thumbnail image.
         :type quality: :class:`dropbox.files.ThumbnailQuality`
-        :param Nullable[bool] exclude_media_info: Normally,
-            ``FileMetadata.media_info`` is set for photo and video. When this
-            flag is true, ``FileMetadata.media_info`` is not populated. This
-            improves latency for use cases where `media_info` is not needed.
+        :param exclude_media_info: Normally, ``FileMetadata.media_info`` is set
+            for photo and video. When this flag is true,
+            ``FileMetadata.media_info`` is not populated. This improves latency
+            for use cases where `media_info` is not needed.
+        :type exclude_media_info: Nullable[bool]
         :rtype: :class:`dropbox.files.PreviewResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2211,8 +2292,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param List[:class:`dropbox.files.ThumbnailArg`] entries: List of files
-            to get thumbnails.
+        :param entries: List of files to get thumbnails.
+        :type entries: List[:class:`dropbox.files.ThumbnailArg`]
         :rtype: :class:`dropbox.files.GetThumbnailBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2268,42 +2349,51 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str path: A unique identifier for the file.
-        :param bool recursive: If true, the list folder operation will be
-            applied recursively to all subfolders and the response will contain
-            contents of all subfolders. In some cases, setting
+        :param path: A unique identifier for the file.
+        :type path: str
+        :param recursive: If true, the list folder operation will be applied
+            recursively to all subfolders and the response will contain contents
+            of all subfolders. In some cases, setting
             ``ListFolderArg.recursive`` to ``True`` may lead to performance
             issues or errors, especially when traversing folder structures with
             a large number of items. A workaround for such cases is to set
             ``ListFolderArg.recursive`` to ``False`` and traverse subfolders one
             at a time.
-        :param bool include_media_info: Field is deprecated. If true,
+        :type recursive: bool
+        :param include_media_info: Field is deprecated. If true,
             ``FileMetadata.media_info`` is set for photo and video. This
             parameter will no longer have an effect starting December 2, 2019.
-        :param bool include_deleted: If true, the results will include entries
-            for files and folders that used to exist but were deleted.
-        :param bool include_has_explicit_shared_members: If true, the results
-            will include a flag for each file indicating whether or not that
-            file has any explicit members.
-        :param bool include_mounted_folders: If true, the results will include
+        :type include_media_info: bool
+        :param include_deleted: If true, the results will include entries for
+            files and folders that used to exist but were deleted.
+        :type include_deleted: bool
+        :param include_has_explicit_shared_members: If true, the results will
+            include a flag for each file indicating whether or not that file has
+            any explicit members.
+        :type include_has_explicit_shared_members: bool
+        :param include_mounted_folders: If true, the results will include
             entries under mounted folders which includes app folder, shared
             folder and team folder.
-        :param Nullable[int] limit: The maximum number of results to return per
-            request. Note: This is an approximate number and there can be
-            slightly more entries returned in some cases.
-        :param Nullable[:class:`dropbox.files.SharedLink`] shared_link: A shared
-            link to list the contents of. If the link is password-protected, the
-            password must be provided. If this field is present,
-            ``ListFolderArg.path`` will be relative to root of the shared link.
-            Only non-recursive mode is supported for shared link.
-        :param Nullable[:class:`dropbox.files.TemplateFilterBase`]
-            include_property_groups: If set to a valid list of template IDs,
+        :type include_mounted_folders: bool
+        :param limit: The maximum number of results to return per request. Note:
+            This is an approximate number and there can be slightly more entries
+            returned in some cases.
+        :type limit: Nullable[int]
+        :param shared_link: A shared link to list the contents of. If the link
+            is password-protected, the password must be provided. If this field
+            is present, ``ListFolderArg.path`` will be relative to root of the
+            shared link. Only non-recursive mode is supported for shared link.
+        :type shared_link: Nullable[:class:`dropbox.files.SharedLink`]
+        :param include_property_groups: If set to a valid list of template IDs,
             ``FileMetadata.property_groups`` is set if there exists property
             data associated with the file and each of the listed templates.
-        :param bool include_non_downloadable_files: If true, include files that
-            are not downloadable, i.e. Google Docs.
-        :param bool include_restorable_info: If true, each returned deleted
-            entry will include whether that entry can be restored.
+        :type include_property_groups: Nullable[:class:`dropbox.file_properties.TemplateFilterBase`]
+        :param include_non_downloadable_files: If true, include files that are
+            not downloadable, i.e. Google Docs.
+        :type include_non_downloadable_files: bool
+        :param include_restorable_info: If true, each returned deleted entry
+            will include whether that entry can be restored.
+        :type include_restorable_info: bool
         :rtype: :class:`dropbox.files.ListFolderResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2339,8 +2429,9 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str cursor: The cursor returned by your last call to
+        :param cursor: The cursor returned by your last call to
             :meth:`files_list_folder` or :meth:`files_list_folder_continue`.
+        :type cursor: str
         :rtype: :class:`dropbox.files.ListFolderResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2378,42 +2469,51 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str path: A unique identifier for the file.
-        :param bool recursive: If true, the list folder operation will be
-            applied recursively to all subfolders and the response will contain
-            contents of all subfolders. In some cases, setting
+        :param path: A unique identifier for the file.
+        :type path: str
+        :param recursive: If true, the list folder operation will be applied
+            recursively to all subfolders and the response will contain contents
+            of all subfolders. In some cases, setting
             ``ListFolderArg.recursive`` to ``True`` may lead to performance
             issues or errors, especially when traversing folder structures with
             a large number of items. A workaround for such cases is to set
             ``ListFolderArg.recursive`` to ``False`` and traverse subfolders one
             at a time.
-        :param bool include_media_info: Field is deprecated. If true,
+        :type recursive: bool
+        :param include_media_info: Field is deprecated. If true,
             ``FileMetadata.media_info`` is set for photo and video. This
             parameter will no longer have an effect starting December 2, 2019.
-        :param bool include_deleted: If true, the results will include entries
-            for files and folders that used to exist but were deleted.
-        :param bool include_has_explicit_shared_members: If true, the results
-            will include a flag for each file indicating whether or not that
-            file has any explicit members.
-        :param bool include_mounted_folders: If true, the results will include
+        :type include_media_info: bool
+        :param include_deleted: If true, the results will include entries for
+            files and folders that used to exist but were deleted.
+        :type include_deleted: bool
+        :param include_has_explicit_shared_members: If true, the results will
+            include a flag for each file indicating whether or not that file has
+            any explicit members.
+        :type include_has_explicit_shared_members: bool
+        :param include_mounted_folders: If true, the results will include
             entries under mounted folders which includes app folder, shared
             folder and team folder.
-        :param Nullable[int] limit: The maximum number of results to return per
-            request. Note: This is an approximate number and there can be
-            slightly more entries returned in some cases.
-        :param Nullable[:class:`dropbox.files.SharedLink`] shared_link: A shared
-            link to list the contents of. If the link is password-protected, the
-            password must be provided. If this field is present,
-            ``ListFolderArg.path`` will be relative to root of the shared link.
-            Only non-recursive mode is supported for shared link.
-        :param Nullable[:class:`dropbox.files.TemplateFilterBase`]
-            include_property_groups: If set to a valid list of template IDs,
+        :type include_mounted_folders: bool
+        :param limit: The maximum number of results to return per request. Note:
+            This is an approximate number and there can be slightly more entries
+            returned in some cases.
+        :type limit: Nullable[int]
+        :param shared_link: A shared link to list the contents of. If the link
+            is password-protected, the password must be provided. If this field
+            is present, ``ListFolderArg.path`` will be relative to root of the
+            shared link. Only non-recursive mode is supported for shared link.
+        :type shared_link: Nullable[:class:`dropbox.files.SharedLink`]
+        :param include_property_groups: If set to a valid list of template IDs,
             ``FileMetadata.property_groups`` is set if there exists property
             data associated with the file and each of the listed templates.
-        :param bool include_non_downloadable_files: If true, include files that
-            are not downloadable, i.e. Google Docs.
-        :param bool include_restorable_info: If true, each returned deleted
-            entry will include whether that entry can be restored.
+        :type include_property_groups: Nullable[:class:`dropbox.file_properties.TemplateFilterBase`]
+        :param include_non_downloadable_files: If true, include files that are
+            not downloadable, i.e. Google Docs.
+        :type include_non_downloadable_files: bool
+        :param include_restorable_info: If true, each returned deleted entry
+            will include whether that entry can be restored.
+        :type include_restorable_info: bool
         :rtype: :class:`dropbox.files.ListFolderGetLatestCursorResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2452,14 +2552,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str cursor: A cursor as returned by :meth:`files_list_folder` or
+        :param cursor: A cursor as returned by :meth:`files_list_folder` or
             :meth:`files_list_folder_continue`. Cursors retrieved by setting
             ``ListFolderArg.include_media_info`` to ``True`` are not supported.
-        :param int timeout: A timeout in seconds. The request will block for at
-            most this length of time, plus up to 90 seconds of random jitter
-            added to avoid the thundering herd problem. Care should be taken
-            when using this parameter, as some network infrastructure does not
-            support long timeouts.
+        :type cursor: str
+        :param timeout: A timeout in seconds. The request will block for at most
+            this length of time, plus up to 90 seconds of random jitter added to
+            avoid the thundering herd problem. Care should be taken when using
+            this parameter, as some network infrastructure does not support long
+            timeouts.
+        :type timeout: int
         :rtype: :class:`dropbox.files.ListFolderLongpollResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2496,17 +2598,21 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str path: The path to the file you want to see the revisions of.
+        :param path: The path to the file you want to see the revisions of.
+        :type path: str
         :param mode: Determines the behavior of the API in listing the revisions
             for a given file path or id.
         :type mode: :class:`dropbox.files.ListRevisionsMode`
-        :param int limit: The maximum number of revision entries returned.
-        :param Nullable[str] before_rev: If set, ListRevisions will only return
-            revisions prior to before_rev. Can be set using the last revision
-            from a previous call to list_revisions to fetch the next page of
-            revisions. Only supported in path mode.
-        :param bool include_restorable_info: If true, each returned revision
-            will include whether that revision can be restored.
+        :param limit: The maximum number of revision entries returned.
+        :type limit: int
+        :param before_rev: If set, ListRevisions will only return revisions
+            prior to before_rev. Can be set using the last revision from a
+            previous call to list_revisions to fetch the next page of revisions.
+            Only supported in path mode.
+        :type before_rev: Nullable[str]
+        :param include_restorable_info: If true, each returned revision will
+            include whether that revision can be restored.
+        :type include_restorable_info: bool
         :rtype: :class:`dropbox.files.ListRevisionsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2537,10 +2643,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[:class:`dropbox.files.LockFileArg`] entries: List of
-            'entries'. Each 'entry' contains a path of the file which will be
-            locked or queried. Duplicate path arguments in the batch are
-            considered only once.
+        :param entries: List of 'entries'. Each 'entry' contains a path of the
+            file which will be locked or queried. Duplicate path arguments in
+            the batch are considered only once.
+        :type entries: List[:class:`dropbox.files.LockFileArg`]
         :rtype: :class:`dropbox.files.LockFileBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2569,13 +2675,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the file to avoid the conflict.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the file to avoid the conflict.
+        :type autorename: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.Metadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2613,13 +2722,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool autorename: If there's a conflict, have the Dropbox server
-            try to autorename the file to avoid the conflict.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param autorename: If there's a conflict, have the Dropbox server try to
+            autorename the file to avoid the conflict.
+        :type autorename: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.RelocationResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2653,11 +2765,13 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_shared_folder: Field is deprecated. This flag has no
+        :param allow_shared_folder: Field is deprecated. This flag has no
             effect.
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :type allow_shared_folder: bool
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.RelocationBatchLaunch`
         """
         warnings.warn(
@@ -2693,9 +2807,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param bool allow_ownership_transfer: Allow moves by owner even if it
-            would result in an ownership transfer for the content being moved.
-            This does not apply to copies.
+        :param allow_ownership_transfer: Allow moves by owner even if it would
+            result in an ownership transfer for the content being moved. This
+            does not apply to copies.
+        :type allow_ownership_transfer: bool
         :rtype: :class:`dropbox.files.RelocationBatchV2Launch`
         """
         arg = files.MoveBatchArg(entries,
@@ -2718,13 +2833,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.RelocationBatchJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         warnings.warn(
             'move_batch/check is deprecated.',
@@ -2748,13 +2864,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.RelocationBatchV2JobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -2776,9 +2893,10 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param str path: The fully qualified path to the location in the user's
+        :param path: The fully qualified path to the location in the user's
             Dropbox where the Paper Doc should be created. This should include
             the document's title and end with .paper.
+        :type path: str
         :param import_format: The format of the provided data.
         :type import_format: :class:`dropbox.files.ImportFormat`
         :rtype: :class:`dropbox.files.PaperCreateResult`
@@ -2810,16 +2928,18 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param str path: Path in the user's Dropbox to update. The path must
+        :param path: Path in the user's Dropbox to update. The path must
             correspond to a Paper doc or an error will be returned.
+        :type path: str
         :param import_format: The format of the provided data.
         :type import_format: :class:`dropbox.files.ImportFormat`
         :param doc_update_policy: How the provided content should be applied to
             the doc.
         :type doc_update_policy: :class:`dropbox.files.PaperDocUpdatePolicy`
-        :param Nullable[int] paper_revision: The latest doc revision. Required
-            when doc_update_policy is update. This value must match the current
+        :param paper_revision: The latest doc revision. Required when
+            doc_update_policy is update. This value must match the current
             revision of the doc or error revision_mismatch will be returned.
+        :type paper_revision: Nullable[int]
         :rtype: :class:`dropbox.files.PaperUpdateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2851,10 +2971,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.permanent_delete
 
-        :param str path: Path in the user's Dropbox to delete.
-        :param Nullable[str] parent_rev: Perform delete if given "rev" matches
-            the existing file's latest "rev". This field does not support
-            deleting a folder.
+        :param path: Path in the user's Dropbox to delete.
+        :type path: str
+        :param parent_rev: Perform delete if given "rev" matches the existing
+            file's latest "rev". This field does not support deleting a folder.
+        :type parent_rev: Nullable[str]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -2881,15 +3002,17 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.files.PropertyGroup`] property_groups: The
-            property groups which are to be added to a Dropbox file. No two
-            groups in the input should refer to the same template.
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param property_groups: The property groups which are to be added to a
+            Dropbox file. No two groups in the input should refer to the same
+            template.
+        :type property_groups: List[:class:`dropbox.file_properties.PropertyGroup`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.AddPropertiesError`
+            :class:`dropbox.file_properties.AddPropertiesError`
         """
         warnings.warn(
             'properties/add is deprecated.',
@@ -2916,15 +3039,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.files.PropertyGroup`] property_groups: The
-            property groups "snapshot" updates to force apply. No two groups in
-            the input should refer to the same template.
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param property_groups: The property groups "snapshot" updates to force
+            apply. No two groups in the input should refer to the same template.
+        :type property_groups: List[:class:`dropbox.file_properties.PropertyGroup`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.InvalidPropertyGroupError`
+            :class:`dropbox.file_properties.InvalidPropertyGroupError`
         """
         warnings.warn(
             'properties/overwrite is deprecated.',
@@ -2952,15 +3076,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: A unique identifier for the file or folder.
-        :param List[:class:`dropbox.files.PropertyGroupUpdate`]
-            update_property_groups: The property groups "delta" updates to
+        :param path: A unique identifier for the file or folder.
+        :type path: str
+        :param update_property_groups: The property groups "delta" updates to
             apply.
+        :type update_property_groups: List[:class:`dropbox.file_properties.PropertyGroupUpdate`]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.UpdatePropertiesError`
+            :class:`dropbox.file_properties.UpdatePropertiesError`
         """
         warnings.warn(
             'properties/update is deprecated.',
@@ -2985,8 +3110,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: The path to save the restored file.
-        :param str rev: The revision to restore.
+        :param path: The path to save the restored file.
+        :type path: str
+        :param rev: The revision to restore.
+        :type rev: str
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3014,8 +3141,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str path: The path in Dropbox where the URL will be saved to.
-        :param str url: The URL to be saved.
+        :param path: The path in Dropbox where the URL will be saved to.
+        :type path: str
+        :param url: The URL to be saved.
+        :type url: str
         :rtype: :class:`dropbox.files.SaveUrlResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3040,13 +3169,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.SaveUrlJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -3071,16 +3201,20 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str path: The path in the user's Dropbox to search. Should
-            probably be a folder.
-        :param str query: The string to search for. Query string may be
-            rewritten to improve relevance of results. The string is split on
-            spaces into multiple tokens. For file name searching, the last token
-            is used for prefix matching (i.e. "bat c" matches "bat cave" but not
-            "batman car").
-        :param int start: The starting index within the search results (used for
+        :param path: The path in the user's Dropbox to search. Should probably
+            be a folder.
+        :type path: str
+        :param query: The string to search for. Query string may be rewritten to
+            improve relevance of results. The string is split on spaces into
+            multiple tokens. For file name searching, the last token is used for
+            prefix matching (i.e. "bat c" matches "bat cave" but not "batman
+            car").
+        :type query: str
+        :param start: The starting index within the search results (used for
             paging).
-        :param int max_results: The maximum number of search results to return.
+        :type start: int
+        :param max_results: The maximum number of search results to return.
+        :type max_results: int
         :param mode: The search mode (filename, filename_and_content, or
             deleted_filename). Note that searching file content is only
             available for Dropbox Business accounts.
@@ -3123,14 +3257,16 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str query: The string to search for. May match across multiple
-            fields based on the request arguments.
-        :param Nullable[:class:`dropbox.files.SearchOptions`] options: Options
-            for more targeted search results.
-        :param Nullable[:class:`dropbox.files.SearchMatchFieldOptions`]
-            match_field_options: Options for search results match fields.
-        :param Nullable[bool] include_highlights: Field is deprecated.
-            Deprecated and moved this option to SearchMatchFieldOptions.
+        :param query: The string to search for. May match across multiple fields
+            based on the request arguments.
+        :type query: str
+        :param options: Options for more targeted search results.
+        :type options: Nullable[:class:`dropbox.files.SearchOptions`]
+        :param match_field_options: Options for search results match fields.
+        :type match_field_options: Nullable[:class:`dropbox.files.SearchMatchFieldOptions`]
+        :param include_highlights: Field is deprecated. Deprecated and moved
+            this option to SearchMatchFieldOptions.
+        :type include_highlights: Nullable[bool]
         :rtype: :class:`dropbox.files.SearchV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3162,8 +3298,9 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str cursor: The cursor returned by your last call to
+        :param cursor: The cursor returned by your last call to
             :meth:`files_search_v2`. Used to fetch the next page of results.
+        :type cursor: str
         :rtype: :class:`dropbox.files.SearchV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3190,9 +3327,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: Path to the item to be tagged.
-        :param str tag_text: The value of the tag to add. Will be automatically
+        :param path: Path to the item to be tagged.
+        :type path: str
+        :param tag_text: The value of the tag to add. Will be automatically
             converted to lowercase letters.
+        :type tag_text: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -3217,7 +3356,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param List[str] paths: Path to the items.
+        :param paths: Path to the items.
+        :type paths: List[str]
         :rtype: :class:`dropbox.files.GetTagsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3242,9 +3382,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.write
 
-        :param str path: Path to the item to tag.
-        :param str tag_text: The tag to remove. Will be automatically converted
-            to lowercase letters.
+        :param path: Path to the item to tag.
+        :type path: str
+        :param tag_text: The tag to remove. Will be automatically converted to
+            lowercase letters.
+        :type tag_text: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -3272,10 +3414,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[:class:`dropbox.files.UnlockFileArg`] entries: List of
-            'entries'. Each 'entry' contains a path of the file which will be
-            unlocked. Duplicate path arguments in the batch are considered only
-            once.
+        :param entries: List of 'entries'. Each 'entry' contains a path of the
+            file which will be unlocked. Duplicate path arguments in the batch
+            are considered only once.
+        :type entries: List[:class:`dropbox.files.UnlockFileArg`]
         :rtype: :class:`dropbox.files.LockFileBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3314,11 +3456,11 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param Nullable[str] content_hash: A hash of the file content uploaded
-            in this call. If provided and the uploaded content does not match
-            this hash, an error will be returned. For more information see our
-            `Content hash
+        :param content_hash: A hash of the file content uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3358,11 +3500,13 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param str session_id: The upload session ID (returned by
+        :param session_id: The upload session ID (returned by
             :meth:`files_upload_session_start`).
-        :param int offset: Offset in bytes at which data should be appended. We
-            use this to make sure upload data isn't lost or duplicated in the
-            event of a network error.
+        :type session_id: str
+        :param offset: Offset in bytes at which data should be appended. We use
+            this to make sure upload data isn't lost or duplicated in the event
+            of a network error.
+        :type offset: int
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -3404,15 +3548,16 @@ class DropboxBase(object):
         :param bytes f: Contents to upload.
         :param cursor: Contains the upload session ID and the offset.
         :type cursor: :class:`dropbox.files.UploadSessionCursor`
-        :param bool close: If true, the current session will be closed, at which
+        :param close: If true, the current session will be closed, at which
             point you won't be able to call
             :meth:`files_upload_session_append_v2` anymore with the current
             session.
-        :param Nullable[str] content_hash: A hash of the file content uploaded
-            in this call. If provided and the uploaded content does not match
-            this hash, an error will be returned. For more information see our
-            `Content hash
+        :type close: bool
+        :param content_hash: A hash of the file content uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -3451,14 +3596,14 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param List[:class:`dropbox.files.UploadSessionAppendBatchArgEntry`]
-            entries: Append information for each file in the batch.
-        :param Nullable[str] content_hash: A hash of the entire request body
-            which is all the concatenated pieces of file content that were
-            uploaded in this call. If provided and the uploaded content does not
-            match this hash, an error will be returned. For more information see
-            our `Content hash
+        :param entries: Append information for each file in the batch.
+        :type entries: List[:class:`dropbox.files.UploadSessionAppendBatchArgEntry`]
+        :param content_hash: A hash of the entire request body which is all the
+            concatenated pieces of file content that were uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: :class:`dropbox.files.UploadSessionAppendBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3499,11 +3644,11 @@ class DropboxBase(object):
         :param commit: Contains the path and other optional modifiers for the
             commit.
         :type commit: :class:`dropbox.files.CommitInfo`
-        :param Nullable[str] content_hash: A hash of the file content uploaded
-            in this call. If provided and the uploaded content does not match
-            this hash, an error will be returned. For more information see our
-            `Content hash
+        :param content_hash: A hash of the file content uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: :class:`dropbox.files.FileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3549,8 +3694,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[:class:`dropbox.files.UploadSessionFinishArg`] entries:
-            Commit information for each file in the batch.
+        :param entries: Commit information for each file in the batch.
+        :type entries: List[:class:`dropbox.files.UploadSessionFinishArg`]
         :rtype: :class:`dropbox.files.UploadSessionFinishBatchLaunch`
         """
         warnings.warn(
@@ -3590,8 +3735,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param List[:class:`dropbox.files.UploadSessionFinishArg`] entries:
-            Commit information for each file in the batch.
+        :param entries: Commit information for each file in the batch.
+        :type entries: List[:class:`dropbox.files.UploadSessionFinishArg`]
         :rtype: :class:`dropbox.files.UploadSessionFinishBatchResult`
         """
         arg = files.UploadSessionFinishBatchArg(entries)
@@ -3613,13 +3758,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.files.UploadSessionFinishBatchJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.files.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -3681,18 +3827,19 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param bool close: If true, the current session will be closed, at which
+        :param close: If true, the current session will be closed, at which
             point you won't be able to call
             :meth:`files_upload_session_append_v2` anymore with the current
             session.
-        :param Nullable[:class:`dropbox.files.UploadSessionType`] session_type:
-            Type of upload session you want to start. If not specified, default
-            is ``UploadSessionType.sequential``.
-        :param Nullable[str] content_hash: A hash of the file content uploaded
-            in this call. If provided and the uploaded content does not match
-            this hash, an error will be returned. For more information see our
-            `Content hash
+        :type close: bool
+        :param session_type: Type of upload session you want to start. If not
+            specified, default is ``UploadSessionType.sequential``.
+        :type session_type: Nullable[:class:`dropbox.files.UploadSessionType`]
+        :param content_hash: A hash of the file content uploaded in this call.
+            If provided and the uploaded content does not match this hash, an
+            error will be returned. For more information see our `Content hash
             <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+        :type content_hash: Nullable[str]
         :rtype: :class:`dropbox.files.UploadSessionStartResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3724,10 +3871,11 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param Nullable[:class:`dropbox.files.UploadSessionType`] session_type:
-            Type of upload session you want to start. If not specified, default
-            is ``UploadSessionType.sequential``.
-        :param int num_sessions: The number of upload sessions to start.
+        :param session_type: Type of upload session you want to start. If not
+            specified, default is ``UploadSessionType.sequential``.
+        :type session_type: Nullable[:class:`dropbox.files.UploadSessionType`]
+        :param num_sessions: The number of upload sessions to start.
+        :type num_sessions: int
         :rtype: :class:`dropbox.files.UploadSessionStartBatchResult`
         """
         arg = files.UploadSessionStartBatchArg(num_sessions,
@@ -3786,7 +3934,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str doc_id: The Paper doc ID.
+        :param doc_id: The Paper doc ID.
+        :type doc_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -3824,9 +3973,10 @@ class DropboxBase(object):
             scope: files.content.write
 
         :param bytes f: Contents to upload.
-        :param Nullable[str] parent_folder_id: The Paper folder ID where the
-            Paper document should be created. The API user has to have write
-            access to this folder or error is thrown.
+        :param parent_folder_id: The Paper folder ID where the Paper document
+            should be created. The API user has to have write access to this
+            folder or error is thrown.
+        :type parent_folder_id: Nullable[str]
         :param import_format: The format of provided data.
         :type import_format: :class:`dropbox.paper.ImportFormat`
         :rtype: :class:`dropbox.paper.PaperDocCreateUpdateResult`
@@ -3867,11 +4017,12 @@ class DropboxBase(object):
             scope: files.content.read
 
         :type export_format: :class:`dropbox.paper.ExportFormat`
-        :param bool include_comments: When true, export includes comment threads
+        :param include_comments: When true, export includes comment threads
             (e.g. markdown footnotes). When false or omitted, body only. Other
             formats may adopt this later; currently only markdown uses it. Plain
             bool (not optional): protoc-gen-godbx does not support proto3
             optional yet.
+        :type include_comments: bool
         :rtype: (:class:`dropbox.paper.PaperDocExportResult`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -3920,11 +4071,12 @@ class DropboxBase(object):
 
         :param str download_path: Path on local machine to save file.
         :type export_format: :class:`dropbox.paper.ExportFormat`
-        :param bool include_comments: When true, export includes comment threads
+        :param include_comments: When true, export includes comment threads
             (e.g. markdown footnotes). When false or omitted, body only. Other
             formats may adopt this later; currently only markdown uses it. Plain
             bool (not optional): protoc-gen-godbx does not support proto3
             optional yet.
+        :type include_comments: bool
         :rtype: :class:`dropbox.paper.PaperDocExportResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3966,9 +4118,10 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param int limit: Size limit per batch. The maximum number of users that
-            can be retrieved per batch is 1000. Higher value results in invalid
+        :param limit: Size limit per batch. The maximum number of users that can
+            be retrieved per batch is 1000. Higher value results in invalid
             arguments error.
+        :type limit: int
         :rtype: :class:`dropbox.paper.ListUsersOnFolderResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4006,10 +4159,11 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor obtained from
+        :param cursor: The cursor obtained from
             :meth:`paper_docs_folder_users_list` or
             :meth:`paper_docs_folder_users_list_continue`. Allows for
             pagination.
+        :type cursor: str
         :rtype: :class:`dropbox.paper.ListUsersOnFolderResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4050,7 +4204,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str doc_id: The Paper doc ID.
+        :param doc_id: The Paper doc ID.
+        :type doc_id: str
         :rtype: :class:`dropbox.paper.FoldersContainingPaperDoc`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4079,9 +4234,10 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param Nullable[str] doc_id: Legacy Paper doc identifier.
-        :param Nullable[str] file_id: Dropbox file ID for Cloud Docs (post-PiFS
-            migration).
+        :param doc_id: Legacy Paper doc identifier.
+        :type doc_id: Nullable[str]
+        :param file_id: Dropbox file ID for Cloud Docs (post-PiFS migration).
+        :type file_id: Nullable[str]
         :rtype: :class:`dropbox.paper.PaperDocGetMetadataResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4127,11 +4283,13 @@ class DropboxBase(object):
         :type sort_by: :class:`dropbox.paper.ListPaperDocsSortBy`
         :param sort_order: Allows user to specify the sort order of the result.
         :type sort_order: :class:`dropbox.paper.ListPaperDocsSortOrder`
-        :param int limit: Size limit per batch. The maximum number of docs that
-            can be retrieved per batch is 1000. Higher value results in invalid
+        :param limit: Size limit per batch. The maximum number of docs that can
+            be retrieved per batch is 1000. Higher value results in invalid
             arguments error.
-        :param Nullable[datetime] stop_at_date: Do not return results beyond
-            this date. Behavior depends on sort order.
+        :type limit: int
+        :param stop_at_date: Do not return results beyond this date. Behavior
+            depends on sort order.
+        :type stop_at_date: Nullable[datetime]
         :rtype: :class:`dropbox.paper.ListPaperDocsResponse`
         """
         warnings.warn(
@@ -4167,8 +4325,9 @@ class DropboxBase(object):
         Route attributes:
             scope: files.metadata.read
 
-        :param str cursor: The cursor obtained from :meth:`paper_docs_list` or
+        :param cursor: The cursor obtained from :meth:`paper_docs_list` or
             :meth:`paper_docs_list_continue`. Allows for pagination.
+        :type cursor: str
         :rtype: :class:`dropbox.paper.ListPaperDocsResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4204,7 +4363,8 @@ class DropboxBase(object):
         Route attributes:
             scope: files.permanent_delete
 
-        :param str doc_id: The Paper doc ID.
+        :param doc_id: The Paper doc ID.
+        :type doc_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -4239,7 +4399,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str doc_id: The Paper doc ID.
+        :param doc_id: The Paper doc ID.
+        :type doc_id: str
         :rtype: :class:`dropbox.paper.SharingPolicy`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4323,9 +4484,10 @@ class DropboxBase(object):
         :param bytes f: Contents to upload.
         :param doc_update_policy: The policy used for the current update call.
         :type doc_update_policy: :class:`dropbox.paper.PaperDocUpdatePolicy`
-        :param int revision: The latest doc revision. This value must match the
-            head revision or an error code will be returned. This is to prevent
+        :param revision: The latest doc revision. This value must match the head
+            revision or an error code will be returned. This is to prevent
             colliding writes.
+        :type revision: int
         :param import_format: The format of provided data.
         :type import_format: :class:`dropbox.paper.ImportFormat`
         :rtype: :class:`dropbox.paper.PaperDocCreateUpdateResult`
@@ -4370,13 +4532,15 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param List[:class:`dropbox.paper.AddMember`] members: User which should
-            be added to the Paper doc. Specify only email address or Dropbox
-            account ID.
-        :param Nullable[str] custom_message: A personal message that will be
-            emailed to each successfully added member.
-        :param bool quiet: Clients should set this to true if no email message
-            shall be sent to added users.
+        :param members: User which should be added to the Paper doc. Specify
+            only email address or Dropbox account ID.
+        :type members: List[:class:`dropbox.paper.AddMember`]
+        :param custom_message: A personal message that will be emailed to each
+            successfully added member.
+        :type custom_message: Nullable[str]
+        :param quiet: Clients should set this to true if no email message shall
+            be sent to added users.
+        :type quiet: bool
         :rtype: List[:class:`dropbox.paper.AddPaperDocUserMemberResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -4419,9 +4583,10 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param int limit: Size limit per batch. The maximum number of users that
-            can be retrieved per batch is 1000. Higher value results in invalid
+        :param limit: Size limit per batch. The maximum number of users that can
+            be retrieved per batch is 1000. Higher value results in invalid
             arguments error.
+        :type limit: int
         :param filter_by: Specify this attribute if you want to obtain users
             that have already accessed the Paper doc.
         :type filter_by: :class:`dropbox.paper.UserOnPaperDocFilter`
@@ -4463,9 +4628,9 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor obtained from
-            :meth:`paper_docs_users_list` or
+        :param cursor: The cursor obtained from :meth:`paper_docs_users_list` or
             :meth:`paper_docs_users_list_continue`. Allows for pagination.
+        :type cursor: str
         :rtype: :class:`dropbox.paper.ListUsersOnPaperDocResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4505,7 +4670,7 @@ class DropboxBase(object):
 
         :param member: User which should be removed from the Paper doc. Specify
             only email address or Dropbox account ID.
-        :type member: :class:`dropbox.paper.MemberSelector`
+        :type member: :class:`dropbox.sharing.MemberSelector`
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -4543,17 +4708,19 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.write
 
-        :param str name: The name of the new Paper folder.
-        :param Nullable[str] parent_folder_id: The encrypted Paper folder Id
-            where the new Paper folder should be created. The API user has to
-            have write access to this folder or error is thrown. If not
-            supplied, the new folder will be created at top level.
-        :param Nullable[bool] is_team_folder: Whether the folder to be created
-            should be a team folder. This value will be ignored if
-            parent_folder_id is supplied, as the new folder will inherit the
-            type (private or team folder) from its parent. We will by default
-            create a top-level private folder if both parent_folder_id and
-            is_team_folder are not supplied.
+        :param name: The name of the new Paper folder.
+        :type name: str
+        :param parent_folder_id: The encrypted Paper folder Id where the new
+            Paper folder should be created. The API user has to have write
+            access to this folder or error is thrown. If not supplied, the new
+            folder will be created at top level.
+        :type parent_folder_id: Nullable[str]
+        :param is_team_folder: Whether the folder to be created should be a team
+            folder. This value will be ignored if parent_folder_id is supplied,
+            as the new folder will inherit the type (private or team folder)
+            from its parent. We will by default create a top-level private
+            folder if both parent_folder_id and is_team_folder are not supplied.
+        :type is_team_folder: Nullable[bool]
         :rtype: :class:`dropbox.paper.PaperFolderCreateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -4588,29 +4755,31 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param Nullable[:class:`dropbox.riviera.FileIdOrUrl`] file_id_or_url:
-            Identifier of the document to convert. Callers must set exactly one
-            of the oneof variants: - file_id: a Dropbox-issued file id (format:
-            "id:<id>") for a file the authenticated user has access to. - path:
-            an absolute Dropbox path, e.g. "/folder/report.docx". - url: either
-            a Dropbox shared link (www.dropbox.com) or an external HTTPS URL
-            pointing to a supported document file. - Dropbox shared links are
-            resolved internally using the caller's authenticated identity and
-            the link's visibility / download settings. They therefore require an
-            authenticated user context (anonymous `url` requests against Dropbox
-            links are rejected with an `ACCESS_ERROR`). Links protected by a
-            password are rejected with `shared_link_password_protected`; links
-            with downloads disabled are rejected with
-            `link_download_disabled_error`. - External URLs are fetched over
-            HTTPS through the backend's egress proxy and must point at a
-            supported document file extension. The referenced file must be a
-            document in a supported format; requests against unsupported formats
-            return `unsupported_format_error`.
-        :param bool enable_ocr: Enable OCR for PDF documents. Processing is
-            slower when enabled.
-        :param bool embed_images: When true, embed images as base64 data URIs in
-            the markdown output. This can significantly increase output size.
-        :rtype: :class:`dropbox.riviera.LaunchResultBase`
+        :param file_id_or_url: Identifier of the document to convert. Callers
+            must set exactly one of the oneof variants: - file_id: a
+            Dropbox-issued file id (format: "id:<id>") for a file the
+            authenticated user has access to. - path: an absolute Dropbox path,
+            e.g. "/folder/report.docx". - url: either a Dropbox shared link
+            (www.dropbox.com) or an external HTTPS URL pointing to a supported
+            document file. - Dropbox shared links are resolved internally using
+            the caller's authenticated identity and the link's visibility /
+            download settings. They therefore require an authenticated user
+            context (anonymous `url` requests against Dropbox links are rejected
+            with an `ACCESS_ERROR`). Links protected by a password are rejected
+            with `shared_link_password_protected`; links with downloads disabled
+            are rejected with `link_download_disabled_error`. - External URLs
+            are fetched over HTTPS through the backend's egress proxy and must
+            point at a supported document file extension. The referenced file
+            must be a document in a supported format; requests against
+            unsupported formats return `unsupported_format_error`.
+        :type file_id_or_url: Nullable[:class:`dropbox.riviera.FileIdOrUrl`]
+        :param enable_ocr: Enable OCR for PDF documents. Processing is slower
+            when enabled.
+        :type enable_ocr: bool
+        :param embed_images: When true, embed images as base64 data URIs in the
+            markdown output. This can significantly increase output size.
+        :type embed_images: bool
+        :rtype: :class:`dropbox.async_.LaunchResultBase`
         """
         arg = riviera.GetMarkdownArgs(file_id_or_url,
                                       enable_ocr,
@@ -4631,13 +4800,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.riviera.GetMarkdownAsyncCheckResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.riviera.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4656,28 +4826,28 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param Nullable[:class:`dropbox.riviera.FileIdOrUrl`] file_id_or_url:
-            Identifier of the file to extract metadata from. Callers must set
-            exactly one of the oneof variants: - file_id: a Dropbox-issued file
-            id (format: "id:<id>") for a file the authenticated user has access
-            to. - path: an absolute Dropbox path, e.g. "/folder/photo.jpg". -
-            url: either a Dropbox shared link (www.dropbox.com) or an external
-            HTTPS URL pointing to a supported file. - Dropbox shared links are
-            resolved internally using the caller's authenticated identity and
-            the link's visibility / download settings. They therefore require an
-            authenticated user context (anonymous `url` requests against Dropbox
-            links are rejected with an `ACCESS_ERROR`). Links protected by a
-            password are rejected with `shared_link_password_protected`; links
-            with downloads disabled are rejected with
-            `link_download_disabled_error`. - External URLs are fetched over
-            HTTPS through the backend's egress proxy and must point at a
-            supported file extension. The kind of metadata returned is
+        :param file_id_or_url: Identifier of the file to extract metadata from.
+            Callers must set exactly one of the oneof variants: - file_id: a
+            Dropbox-issued file id (format: "id:<id>") for a file the
+            authenticated user has access to. - path: an absolute Dropbox path,
+            e.g. "/folder/photo.jpg". - url: either a Dropbox shared link
+            (www.dropbox.com) or an external HTTPS URL pointing to a supported
+            file. - Dropbox shared links are resolved internally using the
+            caller's authenticated identity and the link's visibility / download
+            settings. They therefore require an authenticated user context
+            (anonymous `url` requests against Dropbox links are rejected with an
+            `ACCESS_ERROR`). Links protected by a password are rejected with
+            `shared_link_password_protected`; links with downloads disabled are
+            rejected with `link_download_disabled_error`. - External URLs are
+            fetched over HTTPS through the backend's egress proxy and must point
+            at a supported file extension. The kind of metadata returned is
             determined by the file type: image files return EXIF metadata,
             audio/video files return media metadata, PDFs return PDF metadata,
             and MS Office documents (docx, pptx, xlsx) return Office metadata.
             Requests against unsupported formats return
             `unsupported_format_error`.
-        :rtype: :class:`dropbox.riviera.LaunchResultBase`
+        :type file_id_or_url: Nullable[:class:`dropbox.riviera.FileIdOrUrl`]
+        :rtype: :class:`dropbox.async_.LaunchResultBase`
         """
         arg = riviera.GetMetadataArgs(file_id_or_url)
         r = self.request(
@@ -4696,13 +4866,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.riviera.GetMetadataAsyncCheckResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.riviera.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4724,40 +4895,42 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param Nullable[:class:`dropbox.riviera.FileIdOrUrl`] file_id_or_url:
-            Identifier of the media asset to transcribe. Callers must set
-            exactly one of the oneof variants: - file_id: a Dropbox-issued file
-            id (format: "id:<id>") for a file the authenticated user has access
-            to. - path: an absolute Dropbox path, e.g. "/folder/recording.mp4".
-            - url: either a Dropbox shared link (www.dropbox.com) or an external
-            HTTPS URL pointing to a supported audio/video file. - Dropbox shared
-            links are resolved internally using the caller's authenticated
-            identity and the link's visibility / download settings. They
-            therefore require an authenticated user context (anonymous `url`
-            requests against Dropbox links are rejected with an `ACCESS_ERROR`).
-            Links protected by a password are rejected with
-            `shared_link_password_protected`; links with downloads disabled are
-            rejected with `link_download_disabled_error`. - External URLs are
-            fetched over HTTPS through the backend's egress proxy and must point
-            at a supported audio/video file extension. The referenced asset must
-            be an audio or video file in a supported format; requests against
-            files with no audio track return a `no_audio_error`.
+        :param file_id_or_url: Identifier of the media asset to transcribe.
+            Callers must set exactly one of the oneof variants: - file_id: a
+            Dropbox-issued file id (format: "id:<id>") for a file the
+            authenticated user has access to. - path: an absolute Dropbox path,
+            e.g. "/folder/recording.mp4". - url: either a Dropbox shared link
+            (www.dropbox.com) or an external HTTPS URL pointing to a supported
+            audio/video file. - Dropbox shared links are resolved internally
+            using the caller's authenticated identity and the link's visibility
+            / download settings. They therefore require an authenticated user
+            context (anonymous `url` requests against Dropbox links are rejected
+            with an `ACCESS_ERROR`). Links protected by a password are rejected
+            with `shared_link_password_protected`; links with downloads disabled
+            are rejected with `link_download_disabled_error`. - External URLs
+            are fetched over HTTPS through the backend's egress proxy and must
+            point at a supported audio/video file extension. The referenced
+            asset must be an audio or video file in a supported format; requests
+            against files with no audio track return a `no_audio_error`.
+        :type file_id_or_url: Nullable[:class:`dropbox.riviera.FileIdOrUrl`]
         :param timestamp_level: Granularity of the time offsets returned for
             each transcript segment. Defaults to `SENTENCE. - SENTENCE: one
             segment per spoken sentence (recommended). - WORD: one segment per
             word, useful for fine-grained alignment such as captioning or
             highlight-as-you-listen experiences.
         :type timestamp_level: :class:`dropbox.riviera.TimestampLevel`
-        :param str included_special_words: Comma-delimited list of non-lexical
+        :param included_special_words: Comma-delimited list of non-lexical
             filler words to preserve in the transcript output, e.g. `"uh, ah,
             uhm"`. By default these fillers are stripped. Unrecognized tokens
             are ignored. Leave empty to use the default filtering behavior.
-        :param str audio_language: Optional ISO 639-1 two-letter language code
+        :type included_special_words: str
+        :param audio_language: Optional ISO 639-1 two-letter language code
             hinting the spoken language of the source audio (e.g. "en", "ja").
             When empty, the service auto-detects the language; supplying a hint
             improves accuracy and latency for short or ambiguous clips.
             Unsupported languages fall back to auto-detection.
-        :rtype: :class:`dropbox.riviera.LaunchResultBase`
+        :type audio_language: str
+        :rtype: :class:`dropbox.async_.LaunchResultBase`
         """
         arg = riviera.GetTranscriptArgs(file_id_or_url,
                                         timestamp_level,
@@ -4779,13 +4952,14 @@ class DropboxBase(object):
         Route attributes:
             scope: files.content.read
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.riviera.GetTranscriptAsyncCheckResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.riviera.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4813,22 +4987,27 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: File to which to add members.
-        :param List[:class:`dropbox.sharing.MemberSelector`] members: Members to
-            add. Note that even an email address is given, this may result in a
-            user being directly added to the membership if that email is the
-            user's main account email.
-        :param Nullable[str] custom_message: Message to send to added members in
-            their invitation.
-        :param bool quiet: Whether added members should be notified via email
-            and device notifications of their invitation.
-        :param Nullable[:class:`dropbox.sharing.AccessLevel`] access_level:
-            AccessLevel union object, describing what access level we want to
-            give new members.
-        :param bool add_message_as_comment: If the custom message should be
-            added as a comment on the file. Only meant for Paper files.
-        :param Nullable[str] fp_sealed_result: Field is only returned for
-            "internal" callers. The FingerprintJS Sealed Client Result value
+        :param file: File to which to add members.
+        :type file: str
+        :param members: Members to add. Note that even an email address is
+            given, this may result in a user being directly added to the
+            membership if that email is the user's main account email.
+        :type members: List[:class:`dropbox.sharing.MemberSelector`]
+        :param custom_message: Message to send to added members in their
+            invitation.
+        :type custom_message: Nullable[str]
+        :param quiet: Whether added members should be notified via email and
+            device notifications of their invitation.
+        :type quiet: bool
+        :param access_level: AccessLevel union object, describing what access
+            level we want to give new members.
+        :type access_level: Nullable[:class:`dropbox.sharing.AccessLevel`]
+        :param add_message_as_comment: If the custom message should be added as
+            a comment on the file. Only meant for Paper files.
+        :type add_message_as_comment: bool
+        :param fp_sealed_result: Field is only returned for "internal" callers.
+            The FingerprintJS Sealed Client Result value
+        :type fp_sealed_result: Nullable[str]
         :rtype: List[:class:`dropbox.sharing.FileMemberActionResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -4865,16 +5044,20 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param List[:class:`dropbox.sharing.AddMember`] members: The intended
-            list of members to add.  Added members will receive invites to join
-            the shared folder.
-        :param bool quiet: Whether added members should be notified via email
-            and device notifications of their invite.
-        :param Nullable[str] custom_message: Optional message to display to
-            added members in their invitation.
-        :param Nullable[str] fp_sealed_result: Field is only returned for
-            "internal" callers. The FingerprintJS Sealed Client Result value
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param members: The intended list of members to add.  Added members will
+            receive invites to join the shared folder.
+        :type members: List[:class:`dropbox.sharing.AddMember`]
+        :param quiet: Whether added members should be notified via email and
+            device notifications of their invite.
+        :type quiet: bool
+        :param custom_message: Optional message to display to added members in
+            their invitation.
+        :type custom_message: Nullable[str]
+        :param fp_sealed_result: Field is only returned for "internal" callers.
+            The FingerprintJS Sealed Client Result value
+        :type fp_sealed_result: Nullable[str]
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -4902,13 +5085,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.sharing.JobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.sharing.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4927,13 +5111,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.sharing.RemoveMemberJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.sharing.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4952,13 +5137,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.sharing.ShareFolderJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.sharing.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -4985,13 +5171,15 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str path: The path to share.
-        :param bool short_url: Field is deprecated. None
-        :param Nullable[:class:`dropbox.sharing.PendingUploadMode`]
-            pending_upload: If it's okay to share a path that does not yet
+        :param path: The path to share.
+        :type path: str
+        :param short_url: Field is deprecated. None
+        :type short_url: bool
+        :param pending_upload: If it's okay to share a path that does not yet
             exist, set this to either ``PendingUploadMode.file`` or
             ``PendingUploadMode.folder`` to indicate whether to assume it's a
             file or folder.
+        :type pending_upload: Nullable[:class:`dropbox.sharing.PendingUploadMode`]
         :rtype: :class:`dropbox.sharing.PathLinkMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5025,9 +5213,11 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str path: The path to be shared by the shared link.
-        :param Nullable[:class:`dropbox.sharing.SharedLinkSettings`] settings:
-            The requested settings for the newly created shared link.
+        :param path: The path to be shared by the shared link.
+        :type path: str
+        :param settings: The requested settings for the newly created shared
+            link.
+        :type settings: Nullable[:class:`dropbox.sharing.SharedLinkSettings`]
         :rtype: :class:`dropbox.sharing.SharedLinkMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5053,12 +5243,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str file: The file to query.
-        :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
-            list of `FileAction`s corresponding to `FilePermission`s that should
-            appear in the response's ``SharedFileMetadata.permissions`` field
-            describing the actions the authenticated user can perform on the
-            file.
+        :param file: The file to query.
+        :type file: str
+        :param actions: A list of `FileAction`s corresponding to
+            `FilePermission`s that should appear in the response's
+            ``SharedFileMetadata.permissions`` field describing the actions the
+            authenticated user can perform on the file.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FileAction`]]
         :rtype: :class:`dropbox.sharing.SharedFileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5084,12 +5275,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param List[str] files: The files to query.
-        :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
-            list of `FileAction`s corresponding to `FilePermission`s that should
-            appear in the response's ``SharedFileMetadata.permissions`` field
-            describing the actions the authenticated user can perform on the
-            file.
+        :param files: The files to query.
+        :type files: List[str]
+        :param actions: A list of `FileAction`s corresponding to
+            `FilePermission`s that should appear in the response's
+            ``SharedFileMetadata.permissions`` field describing the actions the
+            authenticated user can perform on the file.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FileAction`]]
         :rtype: List[:class:`dropbox.sharing.GetFileMetadataBatchResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -5115,12 +5307,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
-            list of `FolderAction`s corresponding to `FolderPermission`s that
-            should appear in the response's ``SharedFolderMetadata.permissions``
-            field describing the actions the authenticated user can perform on
-            the folder.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param actions: A list of `FolderAction`s corresponding to
+            `FolderPermission`s that should appear in the response's
+            ``SharedFolderMetadata.permissions`` field describing the actions
+            the authenticated user can perform on the folder.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FolderAction`]]
         :rtype: :class:`dropbox.sharing.SharedFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5148,12 +5341,15 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str url: URL of the shared link.
-        :param Nullable[str] path: If the shared link is to a folder, this
-            parameter can be used to retrieve the metadata for a specific file
-            or sub-folder in this folder. A relative path should be used.
-        :param Nullable[str] link_password: If the shared link has a password,
-            this parameter can be used.
+        :param url: URL of the shared link.
+        :type url: str
+        :param path: If the shared link is to a folder, this parameter can be
+            used to retrieve the metadata for a specific file or sub-folder in
+            this folder. A relative path should be used.
+        :type path: Nullable[str]
+        :param link_password: If the shared link has a password, this parameter
+            can be used.
+        :type link_password: Nullable[str]
         :rtype: (:class:`dropbox.sharing.SharedLinkMetadata`,
                  :class:`requests.models.Response`)
         :raises: :class:`.exceptions.ApiError`
@@ -5191,12 +5387,15 @@ class DropboxBase(object):
             scope: sharing.read
 
         :param str download_path: Path on local machine to save file.
-        :param str url: URL of the shared link.
-        :param Nullable[str] path: If the shared link is to a folder, this
-            parameter can be used to retrieve the metadata for a specific file
-            or sub-folder in this folder. A relative path should be used.
-        :param Nullable[str] link_password: If the shared link has a password,
-            this parameter can be used.
+        :param url: URL of the shared link.
+        :type url: str
+        :param path: If the shared link is to a folder, this parameter can be
+            used to retrieve the metadata for a specific file or sub-folder in
+            this folder. A relative path should be used.
+        :type path: Nullable[str]
+        :param link_password: If the shared link has a password, this parameter
+            can be used.
+        :type link_password: Nullable[str]
         :rtype: :class:`dropbox.sharing.SharedLinkMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5225,12 +5424,15 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str url: URL of the shared link.
-        :param Nullable[str] path: If the shared link is to a folder, this
-            parameter can be used to retrieve the metadata for a specific file
-            or sub-folder in this folder. A relative path should be used.
-        :param Nullable[str] link_password: If the shared link has a password,
-            this parameter can be used.
+        :param url: URL of the shared link.
+        :type url: str
+        :param path: If the shared link is to a folder, this parameter can be
+            used to retrieve the metadata for a specific file or sub-folder in
+            this folder. A relative path should be used.
+        :type path: Nullable[str]
+        :param link_password: If the shared link has a password, this parameter
+            can be used.
+        :type link_password: Nullable[str]
         :rtype: :class:`dropbox.sharing.SharedLinkMetadata`
         """
         arg = sharing.GetSharedLinkMetadataArg(url,
@@ -5258,8 +5460,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param Nullable[str] path: See :meth:`sharing_get_shared_links`
-            description.
+        :param path: See :meth:`sharing_get_shared_links` description.
+        :type path: Nullable[str]
         :rtype: :class:`dropbox.sharing.GetSharedLinksResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5291,13 +5493,16 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str file: The file for which you want to see members.
-        :param Nullable[List[:class:`dropbox.sharing.MemberAction`]] actions:
-            The actions for which to return permissions on a member.
-        :param bool include_inherited: Whether to include members who only have
+        :param file: The file for which you want to see members.
+        :type file: str
+        :param actions: The actions for which to return permissions on a member.
+        :type actions: Nullable[List[:class:`dropbox.sharing.MemberAction`]]
+        :param include_inherited: Whether to include members who only have
             access from a parent shared folder.
-        :param int limit: Number of members to return max per query. Defaults to
-            100 if no limit is specified.
+        :type include_inherited: bool
+        :param limit: Number of members to return max per query. Defaults to 100
+            if no limit is specified.
+        :type limit: int
         :rtype: :class:`dropbox.sharing.SharedFileMembers`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5329,9 +5534,11 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param List[str] files: Files for which to return members.
-        :param int limit: Number of members to return max per query. Defaults to
+        :param files: Files for which to return members.
+        :type files: List[str]
+        :param limit: Number of members to return max per query. Defaults to
             1000 if no limit is specified.
+        :type limit: int
         :rtype: List[:class:`dropbox.sharing.ListFileMembersBatchResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -5358,10 +5565,11 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor returned by your last call to
+        :param cursor: The cursor returned by your last call to
             :meth:`sharing_list_file_members`,
             :meth:`sharing_list_file_members_continue`, or
             :meth:`sharing_list_file_members_batch`.
+        :type cursor: str
         :rtype: :class:`dropbox.sharing.SharedFileMembers`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5388,12 +5596,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str shared_folder_id: The ID for the shared folder. When path is
+        :param shared_folder_id: The ID for the shared folder. When path is
             provided, the folder ID will be extracted from the path instead.
-        :param Nullable[str] path: Optional path to get inherited members. When
-            omitted, uses shared_folder_id to return direct members. When
-            provided, extracts folder ID from this path and returns users who
-            have access through parent shared folder.
+        :type shared_folder_id: str
+        :param path: Optional path to get inherited members. When omitted, uses
+            shared_folder_id to return direct members. When provided, extracts
+            folder ID from this path and returns users who have access through
+            parent shared folder.
+        :type path: Nullable[str]
         :rtype: :class:`dropbox.sharing.SharedFolderMembers`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5422,9 +5632,10 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor returned by your last call to
+        :param cursor: The cursor returned by your last call to
             :meth:`sharing_list_folder_members` or
             :meth:`sharing_list_folder_members_continue`.
+        :type cursor: str
         :rtype: :class:`dropbox.sharing.SharedFolderMembers`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5449,12 +5660,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param int limit: The maximum number of results to return per request.
-        :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
-            list of `FolderAction`s corresponding to `FolderPermission`s that
-            should appear in the response's ``SharedFolderMetadata.permissions``
-            field describing the actions the authenticated user can perform on
-            the folder.
+        :param limit: The maximum number of results to return per request.
+        :type limit: int
+        :param actions: A list of `FolderAction`s corresponding to
+            `FolderPermission`s that should appear in the response's
+            ``SharedFolderMetadata.permissions`` field describing the actions
+            the authenticated user can perform on the folder.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FolderAction`]]
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
         """
         arg = sharing.ListFoldersArgs(limit,
@@ -5478,8 +5690,9 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor returned by the previous API call
-            specified in the endpoint description.
+        :param cursor: The cursor returned by the previous API call specified in
+            the endpoint description.
+        :type cursor: str
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5505,12 +5718,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param int limit: The maximum number of results to return per request.
-        :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
-            list of `FolderAction`s corresponding to `FolderPermission`s that
-            should appear in the response's ``SharedFolderMetadata.permissions``
-            field describing the actions the authenticated user can perform on
-            the folder.
+        :param limit: The maximum number of results to return per request.
+        :type limit: int
+        :param actions: A list of `FolderAction`s corresponding to
+            `FolderPermission`s that should appear in the response's
+            ``SharedFolderMetadata.permissions`` field describing the actions
+            the authenticated user can perform on the folder.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FolderAction`]]
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
         """
         arg = sharing.ListFoldersArgs(limit,
@@ -5535,8 +5749,9 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: The cursor returned by the previous API call
-            specified in the endpoint description.
+        :param cursor: The cursor returned by the previous API call specified in
+            the endpoint description.
+        :type cursor: str
         :rtype: :class:`dropbox.sharing.ListFoldersResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5561,13 +5776,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param int limit: Number of files to return max per query. Defaults to
-            100 if no limit is specified.
-        :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
-            list of `FileAction`s corresponding to `FilePermission`s that should
-            appear in the response's ``SharedFileMetadata.permissions`` field
-            describing the actions the authenticated user can perform on the
-            file.
+        :param limit: Number of files to return max per query. Defaults to 100
+            if no limit is specified.
+        :type limit: int
+        :param actions: A list of `FileAction`s corresponding to
+            `FilePermission`s that should appear in the response's
+            ``SharedFileMetadata.permissions`` field describing the actions the
+            authenticated user can perform on the file.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FileAction`]]
         :rtype: :class:`dropbox.sharing.ListFilesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5592,7 +5808,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str cursor: Cursor in ``ListFilesResult.cursor``.
+        :param cursor: Cursor in ``ListFilesResult.cursor``.
+        :type cursor: str
         :rtype: :class:`dropbox.sharing.ListFilesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5625,12 +5842,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param Nullable[str] path: See :meth:`sharing_list_shared_links`
-            description.
-        :param Nullable[str] cursor: The cursor returned by your last call to
+        :param path: See :meth:`sharing_list_shared_links` description.
+        :type path: Nullable[str]
+        :param cursor: The cursor returned by your last call to
             :meth:`sharing_list_shared_links`.
-        :param Nullable[bool] direct_only: See :meth:`sharing_list_shared_links`
-            description.
+        :type cursor: Nullable[str]
+        :param direct_only: See :meth:`sharing_list_shared_links` description.
+        :type direct_only: Nullable[bool]
         :rtype: :class:`dropbox.sharing.ListSharedLinksResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5664,11 +5882,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str url: URL of the shared link to change its settings.
+        :param url: URL of the shared link to change its settings.
+        :type url: str
         :param settings: Set of settings for the shared link.
         :type settings: :class:`dropbox.sharing.SharedLinkSettings`
-        :param bool remove_expiration: If set to true, removes the expiration of
-            the shared link.
+        :param remove_expiration: If set to true, removes the expiration of the
+            shared link.
+        :type remove_expiration: bool
         :rtype: :class:`dropbox.sharing.SharedLinkMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5696,7 +5916,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID of the shared folder to mount.
+        :param shared_folder_id: The ID of the shared folder to mount.
+        :type shared_folder_id: str
         :rtype: :class:`dropbox.sharing.SharedFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5722,7 +5943,8 @@ class DropboxBase(object):
         Route attributes:
             scope: private:sharing.write
 
-        :param str file_id: The id for the file or folder.
+        :param file_id: The id for the file or folder.
+        :type file_id: str
         :rtype: :class:`dropbox.sharing.RelinquishAccessResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5746,7 +5968,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: The path or id for the file.
+        :param file: The path or id for the file.
+        :type file: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -5775,11 +5998,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param bool leave_a_copy: Keep a copy of the folder's contents upon
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param leave_a_copy: Keep a copy of the folder's contents upon
             relinquishing membership. This must be set to false when the folder
             is within a team folder or another shared folder.
-        :rtype: :class:`dropbox.sharing.LaunchEmptyResult`
+        :type leave_a_copy: bool
+        :rtype: :class:`dropbox.async_.LaunchEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -5804,7 +6029,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: File from which to remove members.
+        :param file: File from which to remove members.
+        :type file: str
         :param member: Member to remove from this file. Note that even if an
             email is specified, it may result in the removal of a user (not an
             invitee) if the user's main account corresponds to that email
@@ -5839,7 +6065,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: File from which to remove members.
+        :param file: File from which to remove members.
+        :type file: str
         :param member: Member to remove from this file. Note that even if an
             email is specified, it may result in the removal of a user (not an
             invitee) if the user's main account corresponds to that email
@@ -5872,15 +6099,17 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
         :param member: The member to remove from the folder.
         :type member: :class:`dropbox.sharing.MemberSelector`
-        :param bool leave_a_copy: If true, the removed user will keep their copy
-            of the folder after it's unshared, assuming it was mounted.
-            Otherwise, it will be removed from their Dropbox. This must be set
-            to false when removing a group, or when the folder is within a team
-            folder or another shared folder.
-        :rtype: :class:`dropbox.sharing.LaunchResultBase`
+        :param leave_a_copy: If true, the removed user will keep their copy of
+            the folder after it's unshared, assuming it was mounted. Otherwise,
+            it will be removed from their Dropbox. This must be set to false
+            when removing a group, or when the folder is within a team folder or
+            another shared folder.
+        :type leave_a_copy: bool
+        :rtype: :class:`dropbox.async_.LaunchResultBase`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -5909,7 +6138,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str url: URL of the shared link.
+        :param url: URL of the shared link.
+        :type url: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -5941,7 +6171,8 @@ class DropboxBase(object):
         :param access_inheritance: The access inheritance settings for the
             folder.
         :type access_inheritance: :class:`dropbox.sharing.AccessInheritance`
-        :param str shared_folder_id: The ID for the shared folder.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
         :rtype: :class:`dropbox.sharing.ShareFolderLaunch`
         :raises: :class:`.exceptions.ApiError`
 
@@ -5979,13 +6210,13 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
-            list of `FolderAction`s corresponding to `FolderPermission`s that
-            should appear in the response's ``SharedFolderMetadata.permissions``
-            field describing the actions the authenticated user can perform on
-            the folder.
-        :param Nullable[:class:`dropbox.sharing.LinkSettings`] link_settings:
-            Settings on the link for this folder.
+        :param actions: A list of `FolderAction`s corresponding to
+            `FolderPermission`s that should appear in the response's
+            ``SharedFolderMetadata.permissions`` field describing the actions
+            the authenticated user can perform on the folder.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FolderAction`]]
+        :param link_settings: Settings on the link for this folder.
+        :type link_settings: Nullable[:class:`dropbox.sharing.LinkSettings`]
         :rtype: :class:`dropbox.sharing.ShareFolderLaunch`
         :raises: :class:`.exceptions.ApiError`
 
@@ -6020,9 +6251,11 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param str to_dropbox_id: A account or team member ID to transfer
-            ownership to.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param to_dropbox_id: A account or team member ID to transfer ownership
+            to.
+        :type to_dropbox_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -6048,7 +6281,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -6072,7 +6306,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: The file to unshare.
+        :param file: The file to unshare.
+        :type file: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -6101,12 +6336,14 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param bool leave_a_copy: If true, members of this shared folder will
-            get a copy of this folder after it's unshared. Otherwise, it will be
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param leave_a_copy: If true, members of this shared folder will get a
+            copy of this folder after it's unshared. Otherwise, it will be
             removed from their Dropbox. The current user, who is an owner, will
             always retain their copy.
-        :rtype: :class:`dropbox.sharing.LaunchEmptyResult`
+        :type leave_a_copy: bool
+        :rtype: :class:`dropbox.async_.LaunchEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -6132,7 +6369,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: File for which we are changing a member's access.
+        :param file: File for which we are changing a member's access.
+        :type file: str
         :param member: The member whose access we are changing.
         :type member: :class:`dropbox.sharing.MemberSelector`
         :param access_level: The new access level for the member.
@@ -6165,16 +6403,19 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str file: File that we are changing the policy for.
-        :param Nullable[List[:class:`dropbox.sharing.FileAction`]] actions: A
-            list of `FileAction`s corresponding to `FilePermission`s that should
-            appear in the response's ``SharedFileMetadata.permissions`` field
-            describing the actions the authenticated user can perform on the
+        :param file: File that we are changing the policy for.
+        :type file: str
+        :param actions: A list of `FileAction`s corresponding to
+            `FilePermission`s that should appear in the response's
+            ``SharedFileMetadata.permissions`` field describing the actions the
+            authenticated user can perform on the file.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FileAction`]]
+        :param link_settings: Field is deprecated. Settings on the link for the
             file.
-        :param Nullable[:class:`dropbox.sharing.LinkSettings`] link_settings:
-            Field is deprecated. Settings on the link for the file.
-        :param Nullable[:class:`dropbox.sharing.ViewerInfoPolicy`]
-            viewer_info_policy: The presence and seen state policy on the file.
+        :type link_settings: Nullable[:class:`dropbox.sharing.LinkSettings`]
+        :param viewer_info_policy: The presence and seen state policy on the
+            file.
+        :type viewer_info_policy: Nullable[:class:`dropbox.sharing.ViewerInfoPolicy`]
         :rtype: :class:`dropbox.sharing.SharedFileMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -6204,7 +6445,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
         :param member: The member of the shared folder to update.  Only the
             ``MemberSelector.dropbox_id`` may be set at this time.
         :type member: :class:`dropbox.sharing.MemberSelector`
@@ -6244,27 +6486,28 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.write
 
-        :param str shared_folder_id: The ID for the shared folder.
-        :param Nullable[:class:`dropbox.sharing.MemberPolicy`] member_policy:
-            Who can be a member of this shared folder. Only applicable if the
-            current user is on a team.
-        :param Nullable[:class:`dropbox.sharing.AclUpdatePolicy`]
-            acl_update_policy: Who can add and remove members of this shared
+        :param shared_folder_id: The ID for the shared folder.
+        :type shared_folder_id: str
+        :param member_policy: Who can be a member of this shared folder. Only
+            applicable if the current user is on a team.
+        :type member_policy: Nullable[:class:`dropbox.sharing.MemberPolicy`]
+        :param acl_update_policy: Who can add and remove members of this shared
             folder.
-        :param Nullable[:class:`dropbox.sharing.ViewerInfoPolicy`]
-            viewer_info_policy: Who can enable/disable viewer info for this
+        :type acl_update_policy: Nullable[:class:`dropbox.sharing.AclUpdatePolicy`]
+        :param viewer_info_policy: Who can enable/disable viewer info for this
             shared folder.
-        :param Nullable[:class:`dropbox.sharing.SharedLinkPolicy`]
-            shared_link_policy: The policy to apply to shared links created for
-            content inside this shared folder. The current user must be on a
+        :type viewer_info_policy: Nullable[:class:`dropbox.sharing.ViewerInfoPolicy`]
+        :param shared_link_policy: The policy to apply to shared links created
+            for content inside this shared folder. The current user must be on a
             team to set this policy to ``SharedLinkPolicy.members``.
-        :param Nullable[:class:`dropbox.sharing.LinkSettings`] link_settings:
-            Settings on the link for this folder.
-        :param Nullable[List[:class:`dropbox.sharing.FolderAction`]] actions: A
-            list of `FolderAction`s corresponding to `FolderPermission`s that
-            should appear in the response's ``SharedFolderMetadata.permissions``
-            field describing the actions the authenticated user can perform on
-            the folder.
+        :type shared_link_policy: Nullable[:class:`dropbox.sharing.SharedLinkPolicy`]
+        :param link_settings: Settings on the link for this folder.
+        :type link_settings: Nullable[:class:`dropbox.sharing.LinkSettings`]
+        :param actions: A list of `FolderAction`s corresponding to
+            `FolderPermission`s that should appear in the response's
+            ``SharedFolderMetadata.permissions`` field describing the actions
+            the authenticated user can perform on the folder.
+        :type actions: Nullable[List[:class:`dropbox.sharing.FolderAction`]]
         :rtype: :class:`dropbox.sharing.SharedFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -6304,10 +6547,10 @@ class DropboxBase(object):
         Route attributes:
             scope: account_info.read
 
-        :param List[:class:`dropbox.users.UserFeature`] features: A list of
-            features in :class:`dropbox.users.UserFeature`. If the list is
-            empty, this route will return
-            :class:`dropbox.users.UserFeaturesGetValuesBatchError`.
+        :param features: A list of features in
+            :class:`dropbox.users.UserFeature`. If the list is empty, this route
+            will return :class:`dropbox.users.UserFeaturesGetValuesBatchError`.
+        :type features: List[:class:`dropbox.users.UserFeature`]
         :rtype: :class:`dropbox.users.UserFeaturesGetValuesBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -6331,7 +6574,8 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param str account_id: A user's account identifier.
+        :param account_id: A user's account identifier.
+        :type account_id: str
         :rtype: :class:`dropbox.users.BasicAccount`
         :raises: :class:`.exceptions.ApiError`
 
@@ -6356,8 +6600,9 @@ class DropboxBase(object):
         Route attributes:
             scope: sharing.read
 
-        :param List[str] account_ids: List of user account identifiers.  Should
-            not contain any duplicate account IDs.
+        :param account_ids: List of user account identifiers.  Should not
+            contain any duplicate account IDs.
+        :type account_ids: List[str]
         :rtype: List[:class:`dropbox.users.BasicAccount`]
         :raises: :class:`.exceptions.ApiError`
 

--- a/dropbox/base_team.py
+++ b/dropbox/base_team.py
@@ -88,9 +88,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: files.team_metadata.write
 
-        :param str template_id: An identifier for template added by route  See
+        :param template_id: An identifier for template added by route  See
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
+        :type template_id: str
         :rtype: :class:`dropbox.file_properties.GetTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -140,9 +141,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: files.team_metadata.write
 
-        :param str template_id: An identifier for a template created by
+        :param template_id: An identifier for a template created by
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
+        :type template_id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -171,17 +173,19 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: files.team_metadata.write
 
-        :param str template_id: An identifier for template added by  See
+        :param template_id: An identifier for template added by  See
             :meth:`file_properties_templates_add_for_user` or
             :meth:`file_properties_templates_add_for_team`.
-        :param Nullable[str] name: A display name for the template. template
-            names can be up to 256 bytes.
-        :param Nullable[str] description: Description for the new template.
-            Template descriptions can be up to 1024 bytes.
-        :param
-            Nullable[List[:class:`dropbox.file_properties.PropertyFieldTemplate`]]
-            add_fields: Property field templates to be added to the group
+        :type template_id: str
+        :param name: A display name for the template. template names can be up
+            to 256 bytes.
+        :type name: Nullable[str]
+        :param description: Description for the new template. Template
+            descriptions can be up to 1024 bytes.
+        :type description: Nullable[str]
+        :param add_fields: Property field templates to be added to the group
             template. There can be up to 32 properties in a single template.
+        :type add_fields: Nullable[List[:class:`dropbox.file_properties.PropertyFieldTemplate`]]
         :rtype: :class:`dropbox.file_properties.UpdateTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -232,13 +236,17 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param str team_member_id: The team's member id.
-        :param bool include_web_sessions: Whether to list web sessions of the
-            team's member.
-        :param bool include_desktop_clients: Whether to list linked desktop
-            devices of the team's member.
-        :param bool include_mobile_clients: Whether to list linked mobile
-            devices of the team's member.
+        :param team_member_id: The team's member id.
+        :type team_member_id: str
+        :param include_web_sessions: Whether to list web sessions of the team's
+            member.
+        :type include_web_sessions: bool
+        :param include_desktop_clients: Whether to list linked desktop devices
+            of the team's member.
+        :type include_desktop_clients: bool
+        :param include_mobile_clients: Whether to list linked mobile devices of
+            the team's member.
+        :type include_mobile_clients: bool
         :rtype: :class:`dropbox.team.ListMemberDevicesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -269,17 +277,21 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param Nullable[str] cursor: At the first call to the
+        :param cursor: At the first call to the
             :meth:`team_devices_list_members_devices` the cursor shouldn't be
             passed. Then, if the result of the call includes a cursor, the
             following requests should include the received cursors in order to
             receive the next sub list of team devices.
-        :param bool include_web_sessions: Whether to list web sessions of the
+        :type cursor: Nullable[str]
+        :param include_web_sessions: Whether to list web sessions of the team
+            members.
+        :type include_web_sessions: bool
+        :param include_desktop_clients: Whether to list desktop clients of the
             team members.
-        :param bool include_desktop_clients: Whether to list desktop clients of
-            the team members.
-        :param bool include_mobile_clients: Whether to list mobile clients of
-            the team members.
+        :type include_desktop_clients: bool
+        :param include_mobile_clients: Whether to list mobile clients of the
+            team members.
+        :type include_mobile_clients: bool
         :rtype: :class:`dropbox.team.ListMembersDevicesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -310,17 +322,21 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param Nullable[str] cursor: At the first call to the
+        :param cursor: At the first call to the
             :meth:`team_devices_list_team_devices` the cursor shouldn't be
             passed. Then, if the result of the call includes a cursor, the
             following requests should include the received cursors in order to
             receive the next sub list of team devices.
-        :param bool include_web_sessions: Whether to list web sessions of the
+        :type cursor: Nullable[str]
+        :param include_web_sessions: Whether to list web sessions of the team
+            members.
+        :type include_web_sessions: bool
+        :param include_desktop_clients: Whether to list desktop clients of the
             team members.
-        :param bool include_desktop_clients: Whether to list desktop clients of
-            the team members.
-        :param bool include_mobile_clients: Whether to list mobile clients of
-            the team members.
+        :type include_desktop_clients: bool
+        :param include_mobile_clients: Whether to list mobile clients of the
+            team members.
+        :type include_mobile_clients: bool
         :rtype: :class:`dropbox.team.ListTeamDevicesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -400,9 +416,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param List[:class:`dropbox.team.Feature`] features: A list of features
-            in :class:`dropbox.team.Feature`. If the list is empty, this route
-            will return :class:`dropbox.team.FeaturesGetValuesBatchError`.
+        :param features: A list of features in :class:`dropbox.team.Feature`. If
+            the list is empty, this route will return
+            :class:`dropbox.team.FeaturesGetValuesBatchError`.
+        :type features: List[:class:`dropbox.team.Feature`]
         :rtype: :class:`dropbox.team.FeaturesGetValuesBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -448,14 +465,16 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: groups.write
 
-        :param str group_name: Group name.
-        :param bool add_creator_as_owner: Automatically add the creator of the
-            group.
-        :param Nullable[str] group_external_id: The creator of a team can
-            associate an arbitrary external ID to the group.
-        :param Nullable[:class:`dropbox.team.GroupManagementType`]
-            group_management_type: Whether the team can be managed by selected
-            users, or only by team admins.
+        :param group_name: Group name.
+        :type group_name: str
+        :param add_creator_as_owner: Automatically add the creator of the group.
+        :type add_creator_as_owner: bool
+        :param group_external_id: The creator of a team can associate an
+            arbitrary external ID to the group.
+        :type group_external_id: Nullable[str]
+        :param group_management_type: Whether the team can be managed by
+            selected users, or only by team admins.
+        :type group_management_type: Nullable[:class:`dropbox.team_common.GroupManagementType`]
         :rtype: :class:`dropbox.team.GroupFullInfo`
         :raises: :class:`.exceptions.ApiError`
 
@@ -488,7 +507,7 @@ class DropboxTeamBase(object):
         :param arg: Argument for selecting a single group, either by group_id or
             by external group ID.
         :type arg: :class:`dropbox.team.GroupSelector`
-        :rtype: :class:`dropbox.team.LaunchEmptyResult`
+        :rtype: :class:`dropbox.async_.LaunchEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -540,9 +559,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: groups.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
-        :rtype: :class:`dropbox.team.PollEmptyResult`
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
+        :rtype: :class:`dropbox.async_.PollEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -565,7 +585,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: groups.read
 
-        :param int limit: Number of results to return per call.
+        :param limit: Number of results to return per call.
+        :type limit: int
         :rtype: :class:`dropbox.team.GroupsListResult`
         """
         arg = team.GroupsListArg(limit)
@@ -586,8 +607,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: groups.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            groups.
+        :param cursor: Indicates from what point to get the next set of groups.
+        :type cursor: str
         :rtype: :class:`dropbox.team.GroupsListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -618,8 +639,8 @@ class DropboxTeamBase(object):
 
         :param group: Group to which users will be added.
         :type group: :class:`dropbox.team.GroupSelector`
-        :param List[:class:`dropbox.team.MemberAccess`] members: List of users
-            to be added to the group.
+        :param members: List of users to be added to the group.
+        :type members: List[:class:`dropbox.team.MemberAccess`]
         :rtype: :class:`dropbox.team.GroupMembersChangeResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -648,7 +669,8 @@ class DropboxTeamBase(object):
 
         :param group: The group whose members are to be listed.
         :type group: :class:`dropbox.team.GroupSelector`
-        :param int limit: Number of results to return per call.
+        :param limit: Number of results to return per call.
+        :type limit: int
         :rtype: :class:`dropbox.team.GroupsMembersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -675,8 +697,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: groups.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            groups.
+        :param cursor: Indicates from what point to get the next set of groups.
+        :type cursor: str
         :rtype: :class:`dropbox.team.GroupsMembersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -709,8 +731,8 @@ class DropboxTeamBase(object):
 
         :param group: Group from which users will be removed.
         :type group: :class:`dropbox.team.GroupSelector`
-        :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users
-            to be removed from the group.
+        :param users: List of users to be removed from the group.
+        :type users: List[:class:`dropbox.team.UserSelectorArg`]
         :rtype: :class:`dropbox.team.GroupMembersChangeResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -742,10 +764,11 @@ class DropboxTeamBase(object):
 
         :param access_type: New group access type the user will have.
         :type access_type: :class:`dropbox.team.GroupAccessType`
-        :param bool return_members: Whether to return the list of members in the
+        :param return_members: Whether to return the list of members in the
             group. Note that the default value will cause all the group members
             to be returned in the response. This may take a long time for large
             groups.
+        :type return_members: bool
         :rtype: List[:class:`dropbox.team.GroupsGetInfoItem`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -779,15 +802,17 @@ class DropboxTeamBase(object):
 
         :param group: Specify a group.
         :type group: :class:`dropbox.team.GroupSelector`
-        :param Nullable[str] new_group_name: Optional argument. Set group name
-            to this if provided.
-        :param Nullable[str] new_group_external_id: Optional argument. New group
-            external ID. If the argument is None, the group's external_id won't
-            be updated. If the argument is empty string, the group's external id
-            will be cleared.
-        :param Nullable[:class:`dropbox.team.GroupManagementType`]
-            new_group_management_type: Set new group management type, if
+        :param new_group_name: Optional argument. Set group name to this if
             provided.
+        :type new_group_name: Nullable[str]
+        :param new_group_external_id: Optional argument. New group external ID.
+            If the argument is None, the group's external_id won't be updated.
+            If the argument is empty string, the group's external id will be
+            cleared.
+        :type new_group_external_id: Nullable[str]
+        :param new_group_management_type: Set new group management type, if
+            provided.
+        :type new_group_management_type: Nullable[:class:`dropbox.team_common.GroupManagementType`]
         :rtype: :class:`dropbox.team.GroupFullInfo`
         :raises: :class:`.exceptions.ApiError`
 
@@ -820,13 +845,16 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str name: Policy name.
-        :param Nullable[str] description: A description of the legal hold
-            policy.
-        :param List[str] members: List of team member IDs added to the hold.
-        :param Nullable[datetime] start_date: start date of the legal hold
-            policy.
-        :param Nullable[datetime] end_date: end date of the legal hold policy.
+        :param name: Policy name.
+        :type name: str
+        :param description: A description of the legal hold policy.
+        :type description: Nullable[str]
+        :param members: List of team member IDs added to the hold.
+        :type members: List[str]
+        :param start_date: start date of the legal hold policy.
+        :type start_date: Nullable[datetime]
+        :param end_date: end date of the legal hold policy.
+        :type end_date: Nullable[datetime]
         :rtype: :class:`dropbox.team.LegalHoldPolicy`
         :raises: :class:`.exceptions.ApiError`
 
@@ -855,7 +883,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str id: The legal hold Id.
+        :param id: The legal hold Id.
+        :type id: str
         :rtype: :class:`dropbox.team.LegalHoldPolicy`
         :raises: :class:`.exceptions.ApiError`
 
@@ -881,7 +910,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str id: The legal hold Id.
+        :param id: The legal hold Id.
+        :type id: str
         :rtype: :class:`dropbox.team.LegalHoldsListHeldRevisionResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -908,10 +938,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str id: The legal hold Id.
-        :param Nullable[str] cursor: The cursor idicates where to continue
-            reading file metadata entries for the next API call. When there are
-            no more entries, the cursor will return none.
+        :param id: The legal hold Id.
+        :type id: str
+        :param cursor: The cursor idicates where to continue reading file
+            metadata entries for the next API call. When there are no more
+            entries, the cursor will return none.
+        :type cursor: Nullable[str]
         :rtype: :class:`dropbox.team.LegalHoldsListHeldRevisionResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -937,8 +969,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param bool include_released: Whether to return holds that were
-            released.
+        :param include_released: Whether to return holds that were released.
+        :type include_released: bool
         :rtype: :class:`dropbox.team.LegalHoldsListPoliciesResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -963,7 +995,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str id: The legal hold Id.
+        :param id: The legal hold Id.
+        :type id: str
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -991,11 +1024,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.governance.write
 
-        :param str id: The legal hold Id.
-        :param Nullable[str] name: Policy new name.
-        :param Nullable[str] description: Policy new description.
-        :param Nullable[List[str]] members: List of team member IDs to apply the
-            policy on.
+        :param id: The legal hold Id.
+        :type id: str
+        :param name: Policy new name.
+        :type name: Nullable[str]
+        :param description: Policy new description.
+        :type description: Nullable[str]
+        :param members: List of team member IDs to apply the policy on.
+        :type members: Nullable[List[str]]
         :rtype: :class:`dropbox.team.LegalHoldPolicy`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1023,7 +1059,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param str team_member_id: The team member id.
+        :param team_member_id: The team member id.
+        :type team_member_id: str
         :rtype: :class:`dropbox.team.ListMemberAppsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1048,11 +1085,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param Nullable[str] cursor: At the first call to the
+        :param cursor: At the first call to the
             :meth:`team_linked_apps_list_members_linked_apps` the cursor
             shouldn't be passed. Then, if the result of the call includes a
             cursor, the following requests should include the received cursors
             in order to receive the next sub list of the team applications.
+        :type cursor: Nullable[str]
         :rtype: :class:`dropbox.team.ListMembersAppsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1077,11 +1115,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.list
 
-        :param Nullable[str] cursor: At the first call to the
+        :param cursor: At the first call to the
             :meth:`team_linked_apps_list_team_linked_apps` the cursor shouldn't
             be passed. Then, if the result of the call includes a cursor, the
             following requests should include the received cursors in order to
             receive the next sub list of the team applications.
+        :type cursor: Nullable[str]
         :rtype: :class:`dropbox.team.ListTeamAppsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1111,12 +1150,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.modify
 
-        :param str app_id: The application's unique id.
-        :param str team_member_id: The unique id of the member owning the
-            device.
-        :param bool keep_app_folder: Field is deprecated. This flag is not
-            longer supported, the application dedicated folder (in case the
-            application uses one) will be kept.
+        :param app_id: The application's unique id.
+        :type app_id: str
+        :param team_member_id: The unique id of the member owning the device.
+        :type team_member_id: str
+        :param keep_app_folder: Field is deprecated. This flag is not longer
+            supported, the application dedicated folder (in case the application
+            uses one) will be kept.
+        :type keep_app_folder: bool
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -1142,8 +1183,7 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: sessions.modify
 
-        :type revoke_linked_app:
-        List[:class:`dropbox.team.RevokeLinkedApiAppArg`]
+        :type revoke_linked_app: List[:class:`dropbox.team.RevokeLinkedApiAppArg`]
         :rtype: :class:`dropbox.team.RevokeLinkedAppBatchResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1167,8 +1207,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param Nullable[List[:class:`dropbox.team.UserSelectorArg`]] users: List
-            of users to be added/removed.
+        :param users: List of users to be added/removed.
+        :type users: Nullable[List[:class:`dropbox.team.UserSelectorArg`]]
         :rtype: :class:`dropbox.team.ExcludedUsersUpdateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1192,7 +1232,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param int limit: Number of results to return per call.
+        :param limit: Number of results to return per call.
+        :type limit: int
         :rtype: :class:`dropbox.team.ExcludedUsersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1216,8 +1257,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            users.
+        :param cursor: Indicates from what point to get the next set of users.
+        :type cursor: str
         :rtype: :class:`dropbox.team.ExcludedUsersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1241,8 +1282,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param Nullable[List[:class:`dropbox.team.UserSelectorArg`]] users: List
-            of users to be added/removed.
+        :param users: List of users to be added/removed.
+        :type users: Nullable[List[:class:`dropbox.team.UserSelectorArg`]]
         :rtype: :class:`dropbox.team.ExcludedUsersUpdateResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1269,7 +1310,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users.
+        :param users: List of users.
+        :type users: List[:class:`dropbox.team.UserSelectorArg`]
         :rtype: List[:class:`dropbox.team.CustomQuotaResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -1297,7 +1339,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.UserSelectorArg`] users: List of users.
+        :param users: List of users.
+        :type users: List[:class:`dropbox.team.UserSelectorArg`]
         :rtype: List[:class:`dropbox.team.RemoveCustomQuotaResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -1325,8 +1368,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param List[:class:`dropbox.team.UserCustomQuotaArg`] users_and_quotas:
-            List of users and their custom quotas.
+        :param users_and_quotas: List of users and their custom quotas.
+        :type users_and_quotas: List[:class:`dropbox.team.UserCustomQuotaArg`]
         :rtype: List[:class:`dropbox.team.CustomQuotaResult`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -1361,8 +1404,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.MemberAddArg`] new_members: Details of
-            new members to be added to the team.
+        :param new_members: Details of new members to be added to the team.
+        :type new_members: List[:class:`dropbox.team.MemberAddArg`]
         :rtype: :class:`dropbox.team.MembersAddLaunch`
         """
         arg = team.MembersAddArg(new_members,
@@ -1391,8 +1434,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.MemberAddV2Arg`] new_members: Details
-            of new members to be added to the team.
+        :param new_members: Details of new members to be added to the team.
+        :type new_members: List[:class:`dropbox.team.MemberAddV2Arg`]
         :rtype: :class:`dropbox.team.MembersAddLaunchV2Result`
         """
         arg = team.MembersAddV2Arg(new_members,
@@ -1415,13 +1458,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.team.MembersAddJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1442,13 +1486,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.team.MembersAddJobStatusV2Result`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1571,8 +1616,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param List[:class:`dropbox.team.UserSelectorArg`] members: List of team
-            members.
+        :param members: List of team members.
+        :type members: List[:class:`dropbox.team.UserSelectorArg`]
         :rtype: List[:class:`dropbox.team.MembersGetInfoItem`]
         :raises: :class:`.exceptions.ApiError`
 
@@ -1599,8 +1644,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param List[:class:`dropbox.team.UserSelectorArg`] members: List of team
-            members.
+        :param members: List of team members.
+        :type members: List[:class:`dropbox.team.UserSelectorArg`]
         :rtype: :class:`dropbox.team.MembersGetInfoV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1625,8 +1670,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param int limit: Number of results to return per call.
-        :param bool include_removed: Whether to return removed members.
+        :param limit: Number of results to return per call.
+        :type limit: int
+        :param include_removed: Whether to return removed members.
+        :type include_removed: bool
         :rtype: :class:`dropbox.team.MembersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1652,8 +1699,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param int limit: Number of results to return per call.
-        :param bool include_removed: Whether to return removed members.
+        :param limit: Number of results to return per call.
+        :type limit: int
+        :param include_removed: Whether to return removed members.
+        :type include_removed: bool
         :rtype: :class:`dropbox.team.MembersListV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1680,8 +1729,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            members.
+        :param cursor: Indicates from what point to get the next set of members.
+        :type cursor: str
         :rtype: :class:`dropbox.team.MembersListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1707,8 +1756,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            members.
+        :param cursor: Indicates from what point to get the next set of members.
+        :type cursor: str
         :rtype: :class:`dropbox.team.MembersListV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1744,7 +1793,7 @@ class DropboxTeamBase(object):
         :param transfer_admin_id: Errors during the transfer process will be
             sent via email to this user.
         :type transfer_admin_id: :class:`dropbox.team.UserSelectorArg`
-        :rtype: :class:`dropbox.team.LaunchEmptyResult`
+        :rtype: :class:`dropbox.async_.LaunchEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -1771,13 +1820,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
-        :rtype: :class:`dropbox.team.PollEmptyResult`
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
+        :rtype: :class:`dropbox.async_.PollEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1843,29 +1893,32 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.delete
 
-        :param Nullable[:class:`dropbox.team.UserSelectorArg`] transfer_dest_id:
-            If provided, files from the deleted member account will be
-            transferred to this user.
-        :param Nullable[:class:`dropbox.team.UserSelectorArg`]
-            transfer_admin_id: If provided, errors during the transfer process
-            will be sent via email to this user. If the transfer_dest_id
+        :param transfer_dest_id: If provided, files from the deleted member
+            account will be transferred to this user.
+        :type transfer_dest_id: Nullable[:class:`dropbox.team.UserSelectorArg`]
+        :param transfer_admin_id: If provided, errors during the transfer
+            process will be sent via email to this user. If the transfer_dest_id
             argument was provided, then this argument must be provided as well.
-        :param bool keep_account: Downgrade the member to a Basic account. The
-            user will retain the email address associated with their Dropbox
-            account and data in their account that is not restricted to team
-            members. In order to keep the account the argument ``wipe_data``
-            should be set to ``False``.
-        :param bool retain_team_shares: If provided, allows removed users to
-            keep access to Dropbox folders (not Dropbox Paper folders) already
+        :type transfer_admin_id: Nullable[:class:`dropbox.team.UserSelectorArg`]
+        :param keep_account: Downgrade the member to a Basic account. The user
+            will retain the email address associated with their Dropbox account
+            and data in their account that is not restricted to team members. In
+            order to keep the account the argument ``wipe_data`` should be set
+            to ``False``.
+        :type keep_account: bool
+        :param retain_team_shares: If provided, allows removed users to keep
+            access to Dropbox folders (not Dropbox Paper folders) already
             explicitly shared with them (not via a group) when they are
             downgraded to a Basic account. Users will not retain access to
             folders that do not allow external sharing. In order to keep the
             sharing relationships, the arguments ``wipe_data`` should be set to
             ``False`` and ``keep_account`` should be set to ``True``.
-        :param bool permanently_delete_files: Permanently delete the data in the
+        :type retain_team_shares: bool
+        :param permanently_delete_files: Permanently delete the data in the
             deleted member's account. After permanent deletion, the data is no
             longer available to be transferred to a different user.
-        :rtype: :class:`dropbox.team.LaunchEmptyResult`
+        :type permanently_delete_files: bool
+        :rtype: :class:`dropbox.async_.LaunchEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
@@ -1896,13 +1949,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.delete
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
-        :rtype: :class:`dropbox.team.PollEmptyResult`
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
+        :rtype: :class:`dropbox.async_.PollEmptyResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -1924,8 +1978,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
-            new_secondary_emails: List of users and secondary emails to add.
+        :param new_secondary_emails: List of users and secondary emails to add.
+        :type new_secondary_emails: List[:class:`dropbox.team.UserSecondaryEmailsArg`]
         :rtype: :class:`dropbox.team.AddSecondaryEmailsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -1951,9 +2005,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
-            emails_to_delete: List of users and their secondary emails to
+        :param emails_to_delete: List of users and their secondary emails to
             delete.
+        :type emails_to_delete: List[:class:`dropbox.team.UserSecondaryEmailsArg`]
         :rtype: :class:`dropbox.team.DeleteSecondaryEmailsResult`
         """
         arg = team.DeleteSecondaryEmailsArg(emails_to_delete)
@@ -1974,9 +2028,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param List[:class:`dropbox.team.UserSecondaryEmailsArg`]
-            emails_to_resend: List of users and secondary emails to resend
+        :param emails_to_resend: List of users and secondary emails to resend
             verification emails to.
+        :type emails_to_resend: List[:class:`dropbox.team.UserSecondaryEmailsArg`]
         :rtype: :class:`dropbox.team.ResendVerificationEmailResult`
         """
         arg = team.ResendVerificationEmailArg(emails_to_resend)
@@ -2058,9 +2112,9 @@ class DropboxTeamBase(object):
 
         :param user: Identity of user whose role will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
-        :param Nullable[List[str]] new_roles: The new roles for the member. Send
-            empty list to make user member only. For now, only up to one role is
-            allowed.
+        :param new_roles: The new roles for the member. Send empty list to make
+            user member only. For now, only up to one role is allowed.
+        :type new_roles: Nullable[List[str]]
         :rtype: :class:`dropbox.team.MembersSetPermissions2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2093,14 +2147,20 @@ class DropboxTeamBase(object):
 
         :param user: Identity of user whose profile will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
-        :param Nullable[str] new_email: New email for member.
-        :param Nullable[str] new_external_id: New external ID for member.
-        :param Nullable[str] new_given_name: New given name for member.
-        :param Nullable[str] new_surname: New surname for member.
-        :param Nullable[str] new_persistent_id: New persistent ID. This field
-            only available to teams using persistent ID SAML configuration.
-        :param Nullable[bool] new_is_directory_restricted: New value for whether
-            the user is a directory restricted user.
+        :param new_email: New email for member.
+        :type new_email: Nullable[str]
+        :param new_external_id: New external ID for member.
+        :type new_external_id: Nullable[str]
+        :param new_given_name: New given name for member.
+        :type new_given_name: Nullable[str]
+        :param new_surname: New surname for member.
+        :type new_surname: Nullable[str]
+        :param new_persistent_id: New persistent ID. This field only available
+            to teams using persistent ID SAML configuration.
+        :type new_persistent_id: Nullable[str]
+        :param new_is_directory_restricted: New value for whether the user is a
+            directory restricted user.
+        :type new_is_directory_restricted: Nullable[bool]
         :rtype: :class:`dropbox.team.TeamMemberInfo`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2138,14 +2198,20 @@ class DropboxTeamBase(object):
 
         :param user: Identity of user whose profile will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
-        :param Nullable[str] new_email: New email for member.
-        :param Nullable[str] new_external_id: New external ID for member.
-        :param Nullable[str] new_given_name: New given name for member.
-        :param Nullable[str] new_surname: New surname for member.
-        :param Nullable[str] new_persistent_id: New persistent ID. This field
-            only available to teams using persistent ID SAML configuration.
-        :param Nullable[bool] new_is_directory_restricted: New value for whether
-            the user is a directory restricted user.
+        :param new_email: New email for member.
+        :type new_email: Nullable[str]
+        :param new_external_id: New external ID for member.
+        :type new_external_id: Nullable[str]
+        :param new_given_name: New given name for member.
+        :type new_given_name: Nullable[str]
+        :param new_surname: New surname for member.
+        :type new_surname: Nullable[str]
+        :param new_persistent_id: New persistent ID. This field only available
+            to teams using persistent ID SAML configuration.
+        :type new_persistent_id: Nullable[str]
+        :param new_is_directory_restricted: New value for whether the user is a
+            directory restricted user.
+        :type new_is_directory_restricted: Nullable[bool]
         :rtype: :class:`dropbox.team.TeamMemberInfoV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2180,7 +2246,7 @@ class DropboxTeamBase(object):
         :param user: Identity of the user whose profile photo will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
         :param photo: Image to set as the member's new profile photo.
-        :type photo: :class:`dropbox.team.PhotoSourceArg`
+        :type photo: :class:`dropbox.account.PhotoSourceArg`
         :rtype: :class:`dropbox.team.TeamMemberInfo`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2210,7 +2276,7 @@ class DropboxTeamBase(object):
         :param user: Identity of the user whose profile photo will be set.
         :type user: :class:`dropbox.team.UserSelectorArg`
         :param photo: Image to set as the member's new profile photo.
-        :type photo: :class:`dropbox.team.PhotoSourceArg`
+        :type photo: :class:`dropbox.account.PhotoSourceArg`
         :rtype: :class:`dropbox.team.TeamMemberInfoV2Result`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2238,8 +2304,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: members.write
 
-        :param bool wipe_data: If provided, controls if the user's data will be
+        :param wipe_data: If provided, controls if the user's data will be
             deleted on their linked devices.
+        :type wipe_data: bool
         :rtype: None
         :raises: :class:`.exceptions.ApiError`
 
@@ -2296,8 +2363,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.member
 
-        :param int limit: Field is deprecated. Specifying a value here has no
+        :param limit: Field is deprecated. Specifying a value here has no
             effect.
+        :type limit: int
         :rtype: :class:`dropbox.team.TeamNamespacesListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2323,8 +2391,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.member
 
-        :param str cursor: Indicates from what point to get the next set of
+        :param cursor: Indicates from what point to get the next set of
             team-accessible namespaces.
+        :type cursor: str
         :rtype: :class:`dropbox.team.TeamNamespacesListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2350,11 +2419,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: files.team_metadata.write
 
-        :rtype: :class:`dropbox.team.AddTemplateResult`
+        :rtype: :class:`dropbox.file_properties.AddTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.ModifyTemplateError`
+            :class:`dropbox.file_properties.ModifyTemplateError`
         """
         warnings.warn(
             'properties/template/add is deprecated.',
@@ -2380,14 +2449,15 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: files.team_metadata.write
 
-        :param str template_id: An identifier for template added by route  See
+        :param template_id: An identifier for template added by route  See
             :meth:`team_templates_add_for_user` or
             :meth:`team_templates_add_for_team`.
-        :rtype: :class:`dropbox.team.GetTemplateResult`
+        :type template_id: str
+        :rtype: :class:`dropbox.file_properties.GetTemplateResult`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.TemplateError`
+            :class:`dropbox.file_properties.TemplateError`
         """
         warnings.warn(
             'properties/template/get is deprecated.',
@@ -2412,10 +2482,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param Nullable[datetime] start_date: Optional starting date
-            (inclusive). If start_date is None or too long ago, this field will
-            be set to 6 months ago.
-        :param Nullable[datetime] end_date: Optional ending date (exclusive).
+        :param start_date: Optional starting date (inclusive). If start_date is
+            None or too long ago, this field will be set to 6 months ago.
+        :type start_date: Nullable[datetime]
+        :param end_date: Optional ending date (exclusive).
+        :type end_date: Nullable[datetime]
         :rtype: :class:`dropbox.team.GetActivityReport`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2446,10 +2517,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param Nullable[datetime] start_date: Optional starting date
-            (inclusive). If start_date is None or too long ago, this field will
-            be set to 6 months ago.
-        :param Nullable[datetime] end_date: Optional ending date (exclusive).
+        :param start_date: Optional starting date (inclusive). If start_date is
+            None or too long ago, this field will be set to 6 months ago.
+        :type start_date: Nullable[datetime]
+        :param end_date: Optional ending date (exclusive).
+        :type end_date: Nullable[datetime]
         :rtype: :class:`dropbox.team.GetDevicesReport`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2480,10 +2552,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param Nullable[datetime] start_date: Optional starting date
-            (inclusive). If start_date is None or too long ago, this field will
-            be set to 6 months ago.
-        :param Nullable[datetime] end_date: Optional ending date (exclusive).
+        :param start_date: Optional starting date (inclusive). If start_date is
+            None or too long ago, this field will be set to 6 months ago.
+        :type start_date: Nullable[datetime]
+        :param end_date: Optional ending date (exclusive).
+        :type end_date: Nullable[datetime]
         :rtype: :class:`dropbox.team.GetMembershipReport`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2514,10 +2587,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param Nullable[datetime] start_date: Optional starting date
-            (inclusive). If start_date is None or too long ago, this field will
-            be set to 6 months ago.
-        :param Nullable[datetime] end_date: Optional ending date (exclusive).
+        :param start_date: Optional starting date (inclusive). If start_date is
+            None or too long ago, this field will be set to 6 months ago.
+        :type start_date: Nullable[datetime]
+        :param end_date: Optional ending date (exclusive).
+        :type end_date: Nullable[datetime]
         :rtype: :class:`dropbox.team.GetStorageReport`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2551,10 +2625,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.write
 
-        :param Nullable[List[str]] domains: List of domains represented by valid
-            string representation (RFC-1034/5).
-        :param Nullable[List[str]] emails: List of emails represented by valid
-            string representation (RFC-5322/822).
+        :param domains: List of domains represented by valid string
+            representation (RFC-1034/5).
+        :type domains: Nullable[List[str]]
+        :param emails: List of emails represented by valid string representation
+            (RFC-5322/822).
+        :type emails: Nullable[List[str]]
         :rtype: :class:`dropbox.team.SharingAllowlistAddResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2583,7 +2659,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param int limit: The number of entries to fetch at one time.
+        :param limit: The number of entries to fetch at one time.
+        :type limit: int
         :rtype: :class:`dropbox.team.SharingAllowlistListResponse`
         """
         arg = team.SharingAllowlistListArg(limit)
@@ -2604,9 +2681,10 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.read
 
-        :param str cursor: The cursor returned from a previous call to
+        :param cursor: The cursor returned from a previous call to
             :meth:`team_sharing_allowlist_list` or
             :meth:`team_sharing_allowlist_list_continue`.
+        :type cursor: str
         :rtype: :class:`dropbox.team.SharingAllowlistListResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2635,10 +2713,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_info.write
 
-        :param Nullable[List[str]] domains: List of domains represented by valid
-            string representation (RFC-1034/5).
-        :param Nullable[List[str]] emails: List of emails represented by valid
-            string representation (RFC-5322/822).
+        :param domains: List of domains represented by valid string
+            representation (RFC-1034/5).
+        :type domains: Nullable[List[str]]
+        :param emails: List of emails represented by valid string representation
+            (RFC-5322/822).
+        :type emails: Nullable[List[str]]
         :rtype: :class:`dropbox.team.SharingAllowlistRemoveResponse`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2664,7 +2744,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str team_folder_id: The ID of the team folder.
+        :param team_folder_id: The ID of the team folder.
+        :type team_folder_id: str
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         """
         arg = team.TeamFolderIdArg(team_folder_id)
@@ -2690,8 +2771,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param bool force_async_off: Whether to force the archive to happen
+        :param force_async_off: Whether to force the archive to happen
             synchronously.
+        :type force_async_off: bool
         :rtype: :class:`dropbox.team.TeamFolderArchiveLaunch`
         """
         arg = team.TeamFolderArchiveArg(team_folder_id,
@@ -2717,13 +2799,14 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str async_job_id: Id of the asynchronous job. This is the value
-            of a response returned from the method that launched the job.
+        :param async_job_id: Id of the asynchronous job. This is the value of a
+            response returned from the method that launched the job.
+        :type async_job_id: str
         :rtype: :class:`dropbox.team.TeamFolderArchiveJobStatus`
         :raises: :class:`.exceptions.ApiError`
 
         If this raises, ApiError will contain:
-            :class:`dropbox.team.PollError`
+            :class:`dropbox.async_.PollError`
         """
         arg = async_.PollArg(async_job_id)
         r = self.request(
@@ -2745,10 +2828,11 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str name: Name for the new team folder.
-        :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: The
-            sync setting to apply to this team folder. Only permitted if the
-            team has team selective sync enabled.
+        :param name: Name for the new team folder.
+        :type name: str
+        :param sync_setting: The sync setting to apply to this team folder. Only
+            permitted if the team has team selective sync enabled.
+        :type sync_setting: Nullable[:class:`dropbox.files.SyncSettingArg`]
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2774,7 +2858,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.read
 
-        :param List[str] team_folder_ids: The list of team folder IDs.
+        :param team_folder_ids: The list of team folder IDs.
+        :type team_folder_ids: List[str]
         :rtype: List[:class:`dropbox.team.TeamFolderGetInfoItem`]
         """
         arg = team.TeamFolderIdListArg(team_folder_ids)
@@ -2794,7 +2879,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.read
 
-        :param int limit: The maximum number of results to return per request.
+        :param limit: The maximum number of results to return per request.
+        :type limit: int
         :rtype: :class:`dropbox.team.TeamFolderListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2820,8 +2906,9 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.read
 
-        :param str cursor: Indicates from what point to get the next set of team
+        :param cursor: Indicates from what point to get the next set of team
             folders.
+        :type cursor: str
         :rtype: :class:`dropbox.team.TeamFolderListResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2847,7 +2934,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str team_folder_id: The ID of the team folder.
+        :param team_folder_id: The ID of the team folder.
+        :type team_folder_id: str
         :rtype: None
         """
         arg = team.TeamFolderIdArg(team_folder_id)
@@ -2869,7 +2957,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str name: New team folder name.
+        :param name: New team folder name.
+        :type name: str
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2895,7 +2984,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param str team_folder_id: The ID of the team folder.
+        :param team_folder_id: The ID of the team folder.
+        :type team_folder_id: str
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         """
         arg = team.TeamFolderIdArg(team_folder_id)
@@ -2918,12 +3008,12 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: team_data.content.write
 
-        :param Nullable[:class:`dropbox.team.SyncSettingArg`] sync_setting: Sync
-            setting to apply to the team folder itself. Only meaningful if the
-            team folder is not a shared team root.
-        :param Nullable[List[:class:`dropbox.team.ContentSyncSettingArg`]]
-            content_sync_settings: Sync settings to apply to contents of this
+        :param sync_setting: Sync setting to apply to the team folder itself.
+            Only meaningful if the team folder is not a shared team root.
+        :type sync_setting: Nullable[:class:`dropbox.files.SyncSettingArg`]
+        :param content_sync_settings: Sync settings to apply to contents of this
             team folder.
+        :type content_sync_settings: Nullable[List[:class:`dropbox.files.ContentSyncSettingArg`]]
         :rtype: :class:`dropbox.team.TeamFolderMetadata`
         :raises: :class:`.exceptions.ApiError`
 
@@ -2989,22 +3079,23 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: events.read
 
-        :param int limit: The maximal number of results to return per call. Note
+        :param limit: The maximal number of results to return per call. Note
             that some calls may not return ``limit`` number of events, and may
             even return no events, even with `has_more` set to true. In this
             case, callers should fetch again using
             :meth:`team_log_get_events_continue`.
-        :param Nullable[str] account_id: Filter the events by account ID. Return
-            only events with this account_id as either Actor, Context, or
-            Participants.
-        :param Nullable[:class:`dropbox.team_log.TimeRange`] time: Filter by
-            time range.
-        :param Nullable[:class:`dropbox.team_log.EventCategory`] category:
-            Filter the returned events to a single category. Note that category
-            shouldn't be provided together with event_type.
-        :param Nullable[:class:`dropbox.team_log.EventTypeArg`] event_type:
-            Filter the returned events to a single event type. Note that
-            event_type shouldn't be provided together with category.
+        :type limit: int
+        :param account_id: Filter the events by account ID. Return only events
+            with this account_id as either Actor, Context, or Participants.
+        :type account_id: Nullable[str]
+        :param time: Filter by time range.
+        :type time: Nullable[:class:`dropbox.team_common.TimeRange`]
+        :param category: Filter the returned events to a single category. Note
+            that category shouldn't be provided together with event_type.
+        :type category: Nullable[:class:`dropbox.team_log.EventCategory`]
+        :param event_type: Filter the returned events to a single event type.
+            Note that event_type shouldn't be provided together with category.
+        :type event_type: Nullable[:class:`dropbox.team_log.EventTypeArg`]
         :rtype: :class:`dropbox.team_log.GetTeamEventsResult`
         :raises: :class:`.exceptions.ApiError`
 
@@ -3033,8 +3124,8 @@ class DropboxTeamBase(object):
         Route attributes:
             scope: events.read
 
-        :param str cursor: Indicates from what point to get the next set of
-            events.
+        :param cursor: Indicates from what point to get the next set of events.
+        :type cursor: str
         :rtype: :class:`dropbox.team_log.GetTeamEventsResult`
         :raises: :class:`.exceptions.ApiError`
 

--- a/dropbox/check.py
+++ b/dropbox/check.py
@@ -11,8 +11,8 @@ class EchoArg(bb.Struct):
     """
     Contains the arguments to be sent to the Dropbox servers.
 
-    :ivar check.EchoArg.query: The string that you'd like to be echoed back to
-        you.
+    :ivar EchoArg.query:
+        The string that you'd like to be echoed back to you.
     """
 
     __slots__ = [
@@ -43,7 +43,8 @@ class EchoError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar check.EchoError.user_requested: The request was successful.
+    :ivar EchoError.user_requested:
+        The request was successful.
     """
 
     _catch_all = 'other'
@@ -77,8 +78,8 @@ class EchoResult(bb.Struct):
     """
     EchoResult contains the result returned from the Dropbox servers.
 
-    :ivar check.EchoResult.result: If everything worked correctly, this would be
-        the same as query.
+    :ivar EchoResult.result:
+        If everything worked correctly, this would be the same as query.
     """
 
     __slots__ = [

--- a/dropbox/common.py
+++ b/dropbox/common.py
@@ -43,15 +43,19 @@ class PathRoot(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar common.PathRoot.home: Paths are relative to the authenticating user's
-        home namespace, whether or not that user belongs to a team.
-    :ivar str common.PathRoot.root: Paths are relative to the authenticating
-        user's root namespace (This results in
-        :field:`PathRootError.invalid_root` if the user's root namespace has
-        changed.).
-    :ivar str common.PathRoot.namespace_id: Paths are relative to given
-        namespace id (This results in :field:`PathRootError.no_permission` if
-        you don't have access to this namespace.).
+    :ivar PathRoot.home:
+        Paths are relative to the authenticating user's home namespace, whether
+        or not that user belongs to a team.
+    :ivar PathRoot.root:
+        Paths are relative to the authenticating user's root namespace (This
+        results in ``PathRootError.invalid_root`` if the user's root namespace
+        has changed.).
+    :vartype PathRoot.root: str
+    :ivar PathRoot.namespace_id:
+        Paths are relative to given namespace id (This results in
+        ``PathRootError.no_permission`` if you don't have access to this
+        namespace.).
+    :vartype PathRoot.namespace_id: str
     """
 
     _catch_all = 'other'
@@ -153,11 +157,13 @@ class PathRootError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar RootInfo PathRootError.invalid_root: The root namespace id in
-        Dropbox-API-Path-Root header is not valid. The value of this error is
-        the user's latest root info.
-    :ivar common.PathRootError.no_permission: You don't have permission to
-        access the namespace id in Dropbox-API-Path-Root header.
+    :ivar PathRootError.invalid_root:
+        The root namespace id in Dropbox-API-Path-Root header is not valid. The
+        value of this error is the user's latest root info.
+    :vartype PathRootError.invalid_root: RootInfo
+    :ivar PathRootError.no_permission:
+        You don't have permission to access the namespace id in
+        Dropbox-API-Path-Root header.
     """
 
     _catch_all = 'other'
@@ -223,13 +229,14 @@ class RootInfo(bb.Struct):
     """
     Information about current user's root.
 
-    :ivar common.RootInfo.root_namespace_id: The namespace ID for user's root
-        namespace. It will be the namespace ID of the shared team root if the
-        user is member of a team with a separate team root, or the user root if
-        user is member of a team with separate distinct roots for users.
-        Otherwise it will be the same as ``RootInfo.home_namespace_id``.
-    :ivar common.RootInfo.home_namespace_id: The namespace ID for user's home
-        namespace.
+    :ivar RootInfo.root_namespace_id:
+        The namespace ID for user's root namespace. It will be the namespace ID
+        of the shared team root if the user is member of a team with a separate
+        team root, or the user root if user is member of a team with separate
+        distinct roots for users. Otherwise it will be the same as
+        ``RootInfo.home_namespace_id``.
+    :ivar RootInfo.home_namespace_id:
+        The namespace ID for user's home namespace.
     """
 
     __slots__ = [
@@ -264,8 +271,8 @@ class TeamRootInfo(RootInfo):
     """
     Root info when user is member of a team with a separate root namespace ID.
 
-    :ivar common.TeamRootInfo.home_path: The path for user's home directory
-        under the shared team root.
+    :ivar TeamRootInfo.home_path:
+        The path for user's home directory under the shared team root.
     """
 
     __slots__ = [
@@ -297,8 +304,8 @@ class UserRootInfo(RootInfo):
     Root info when user is not member of a team or the user is a member of a
     team and the team does not have a separate root namespace.
 
-    :ivar common.UserRootInfo.home_path: The path for user's home directory
-        under the distinct user root.
+    :ivar UserRootInfo.home_path:
+        The path for user's home directory under the distinct user root.
     """
 
     __slots__ = [

--- a/dropbox/contacts.py
+++ b/dropbox/contacts.py
@@ -11,8 +11,8 @@ from dropbox import common
 
 class DeleteManualContactsArg(bb.Struct):
     """
-    :ivar contacts.DeleteManualContactsArg.email_addresses: List of manually
-        added contacts to be deleted.
+    :ivar DeleteManualContactsArg.email_addresses:
+        List of manually added contacts to be deleted.
     """
 
     __slots__ = [
@@ -41,9 +41,10 @@ class DeleteManualContactsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [str] contacts.DeleteManualContactsError.contacts_not_found:
+    :ivar DeleteManualContactsError.contacts_not_found:
         Can't delete contacts from this list. Make sure the list only has
         manually added contacts. The deletion was cancelled.
+    :vartype DeleteManualContactsError.contacts_not_found: list of [str]
     """
 
     _catch_all = 'other'

--- a/dropbox/dropbox_client.py
+++ b/dropbox/dropbox_client.py
@@ -473,7 +473,7 @@ class _DropboxTransport(object):
         :param route_style: The style of the route.
         :param str request_arg: A JSON-serializable Python object representing
             the argument for the route.
-        :param auth_type str
+        :param str auth_type: The auth type of the route.
         :param Optional[bytes] request_binary: Bytes representing the binary
             payload. Use None if there is no binary payload.
         :param Optional[float] timeout: Maximum duration in seconds

--- a/dropbox/file_properties.py
+++ b/dropbox/file_properties.py
@@ -29,11 +29,11 @@ from stone.backends.python_rsrc import stone_validators as bv
 
 class AddPropertiesArg(bb.Struct):
     """
-    :ivar file_properties.AddPropertiesArg.path: A unique identifier for the
-        file or folder.
-    :ivar file_properties.AddPropertiesArg.property_groups: The property groups
-        which are to be added to a Dropbox file. No two groups in the input
-        should refer to the same template.
+    :ivar AddPropertiesArg.path:
+        A unique identifier for the file or folder.
+    :ivar AddPropertiesArg.property_groups:
+        The property groups which are to be added to a Dropbox file. No two
+        groups in the input should refer to the same template.
     """
 
     __slots__ = [
@@ -70,10 +70,11 @@ class TemplateError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str file_properties.TemplateError.template_not_found: Template does
-        not exist for the given identifier.
-    :ivar file_properties.TemplateError.restricted_content: You do not have
-        permission to modify this template.
+    :ivar TemplateError.template_not_found:
+        Template does not exist for the given identifier.
+    :vartype TemplateError.template_not_found: str
+    :ivar TemplateError.restricted_content:
+        You do not have permission to modify this template.
     """
 
     _catch_all = 'other'
@@ -140,8 +141,9 @@ class PropertiesError(TemplateError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.PropertiesError.unsupported_folder: This folder cannot
-        be tagged. Tagging folders is not supported for team-owned templates.
+    :ivar PropertiesError.unsupported_folder:
+        This folder cannot be tagged. Tagging folders is not supported for
+        team-owned templates.
     """
 
     # Attribute is overwritten below the class definition
@@ -195,12 +197,12 @@ class InvalidPropertyGroupError(PropertiesError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.InvalidPropertyGroupError.property_field_too_large:
+    :ivar InvalidPropertyGroupError.property_field_too_large:
         One or more of the supplied property field values is too large.
-    :ivar file_properties.InvalidPropertyGroupError.does_not_fit_template: One
-        or more of the supplied property fields does not conform to the template
-        specifications.
-    :ivar file_properties.InvalidPropertyGroupError.duplicate_property_groups:
+    :ivar InvalidPropertyGroupError.does_not_fit_template:
+        One or more of the supplied property fields does not conform to the
+        template specifications.
+    :ivar InvalidPropertyGroupError.duplicate_property_groups:
         There are 2 or more property groups referring to the same templates in
         the input.
     """
@@ -247,8 +249,8 @@ class AddPropertiesError(InvalidPropertyGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.AddPropertiesError.property_group_already_exists: A
-        property group associated with this template and file already exists.
+    :ivar AddPropertiesError.property_group_already_exists:
+        A property group associated with this template and file already exists.
     """
 
     # Attribute is overwritten below the class definition
@@ -271,13 +273,14 @@ class PropertyGroupTemplate(bb.Struct):
     """
     Defines how a property group may be structured.
 
-    :ivar file_properties.PropertyGroupTemplate.name: Display name for the
-        template. Template names can be up to 256 bytes.
-    :ivar file_properties.PropertyGroupTemplate.description: Description for the
-        template. Template descriptions can be up to 1024 bytes.
-    :ivar file_properties.PropertyGroupTemplate.fields: Definitions of the
-        property fields associated with this template. There can be up to 32
-        properties in a single template.
+    :ivar PropertyGroupTemplate.name:
+        Display name for the template. Template names can be up to 256 bytes.
+    :ivar PropertyGroupTemplate.description:
+        Description for the template. Template descriptions can be up to 1024
+        bytes.
+    :ivar PropertyGroupTemplate.fields:
+        Definitions of the property fields associated with this template. There
+        can be up to 32 properties in a single template.
     """
 
     __slots__ = [
@@ -338,8 +341,8 @@ AddTemplateArg_validator = bv.Struct(AddTemplateArg)
 
 class AddTemplateResult(bb.Struct):
     """
-    :ivar file_properties.AddTemplateResult.template_id: An identifier for
-        template added by  See
+    :ivar AddTemplateResult.template_id:
+        An identifier for template added by  See
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
@@ -367,8 +370,8 @@ AddTemplateResult_validator = bv.Struct(AddTemplateResult)
 
 class GetTemplateArg(bb.Struct):
     """
-    :ivar file_properties.GetTemplateArg.template_id: An identifier for template
-        added by route  See
+    :ivar GetTemplateArg.template_id:
+        An identifier for template added by route  See
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
@@ -416,8 +419,8 @@ GetTemplateResult_validator = bv.Struct(GetTemplateResult)
 
 class ListTemplateResult(bb.Struct):
     """
-    :ivar file_properties.ListTemplateResult.template_ids: List of identifiers
-        for templates added by  See
+    :ivar ListTemplateResult.template_ids:
+        List of identifiers for templates added by  See
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
@@ -451,8 +454,8 @@ class LogicalOperator(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.LogicalOperator.or_operator: Append a query with an
-        "or" operator.
+    :ivar LogicalOperator.or_operator:
+        Append a query with an "or" operator.
     """
 
     _catch_all = 'other'
@@ -488,8 +491,8 @@ class LookUpPropertiesError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.LookUpPropertiesError.property_group_not_found: No
-        property group was found.
+    :ivar LookUpPropertiesError.property_group_not_found:
+        No property group was found.
     """
 
     _catch_all = 'other'
@@ -525,15 +528,17 @@ class LookupError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.LookupError.not_found: There is nothing at the given
-        path.
-    :ivar file_properties.LookupError.not_file: We were expecting a file, but
-        the given path refers to something that isn't a file.
-    :ivar file_properties.LookupError.not_folder: We were expecting a folder,
-        but the given path refers to something that isn't a folder.
-    :ivar file_properties.LookupError.restricted_content: The file cannot be
-        transferred because the content is restricted. For example, we might
-        restrict a file due to legal requirements.
+    :ivar LookupError.not_found:
+        There is nothing at the given path.
+    :ivar LookupError.not_file:
+        We were expecting a file, but the given path refers to something that
+        isn't a file.
+    :ivar LookupError.not_folder:
+        We were expecting a folder, but the given path refers to something that
+        isn't a folder.
+    :ivar LookupError.restricted_content:
+        The file cannot be transferred because the content is restricted. For
+        example, we might restrict a file due to legal requirements.
     """
 
     _catch_all = 'other'
@@ -628,16 +633,16 @@ class ModifyTemplateError(TemplateError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.ModifyTemplateError.conflicting_property_names: A
-        property field key with that name already exists in the template.
-    :ivar file_properties.ModifyTemplateError.too_many_properties: There are too
-        many properties in the changed template. The maximum number of
-        properties per template is 32.
-    :ivar file_properties.ModifyTemplateError.too_many_templates: There are too
-        many templates for the team.
-    :ivar file_properties.ModifyTemplateError.template_attribute_too_large: The
-        template name, description or one or more of the property field keys is
-        too large.
+    :ivar ModifyTemplateError.conflicting_property_names:
+        A property field key with that name already exists in the template.
+    :ivar ModifyTemplateError.too_many_properties:
+        There are too many properties in the changed template. The maximum
+        number of properties per template is 32.
+    :ivar ModifyTemplateError.too_many_templates:
+        There are too many templates for the team.
+    :ivar ModifyTemplateError.template_attribute_too_large:
+        The template name, description or one or more of the property field keys
+        is too large.
     """
 
     # Attribute is overwritten below the class definition
@@ -688,11 +693,11 @@ ModifyTemplateError_validator = bv.Union(ModifyTemplateError)
 
 class OverwritePropertyGroupArg(bb.Struct):
     """
-    :ivar file_properties.OverwritePropertyGroupArg.path: A unique identifier
-        for the file or folder.
-    :ivar file_properties.OverwritePropertyGroupArg.property_groups: The
-        property groups "snapshot" updates to force apply. No two groups in the
-        input should refer to the same template.
+    :ivar OverwritePropertyGroupArg.path:
+        A unique identifier for the file or folder.
+    :ivar OverwritePropertyGroupArg.property_groups:
+        The property groups "snapshot" updates to force apply. No two groups in
+        the input should refer to the same template.
     """
 
     __slots__ = [
@@ -725,9 +730,11 @@ OverwritePropertyGroupArg_validator = bv.Struct(OverwritePropertyGroupArg)
 
 class PropertiesSearchArg(bb.Struct):
     """
-    :ivar file_properties.PropertiesSearchArg.queries: Queries to search.
-    :ivar file_properties.PropertiesSearchArg.template_filter: Filter results to
-        contain only properties associated with these template IDs.
+    :ivar PropertiesSearchArg.queries:
+        Queries to search.
+    :ivar PropertiesSearchArg.template_filter:
+        Filter results to contain only properties associated with these template
+        IDs.
     """
 
     __slots__ = [
@@ -760,8 +767,8 @@ PropertiesSearchArg_validator = bv.Struct(PropertiesSearchArg)
 
 class PropertiesSearchContinueArg(bb.Struct):
     """
-    :ivar file_properties.PropertiesSearchContinueArg.cursor: The cursor
-        returned by your last call to
+    :ivar PropertiesSearchContinueArg.cursor:
+        The cursor returned by your last call to
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_properties_search`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_properties_search_continue`.
@@ -793,8 +800,8 @@ class PropertiesSearchContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.PropertiesSearchContinueError.reset: Indicates that
-        the cursor has been invalidated. Call
+    :ivar PropertiesSearchContinueError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_properties_search`
         to obtain a new cursor.
     """
@@ -881,14 +888,14 @@ PropertiesSearchError_validator = bv.Union(PropertiesSearchError)
 
 class PropertiesSearchMatch(bb.Struct):
     """
-    :ivar file_properties.PropertiesSearchMatch.id: The ID for the matched file
-        or folder.
-    :ivar file_properties.PropertiesSearchMatch.path: The path for the matched
-        file or folder.
-    :ivar file_properties.PropertiesSearchMatch.is_deleted: Whether the file or
-        folder is deleted.
-    :ivar file_properties.PropertiesSearchMatch.property_groups: List of custom
-        property groups associated with the file.
+    :ivar PropertiesSearchMatch.id:
+        The ID for the matched file or folder.
+    :ivar PropertiesSearchMatch.path:
+        The path for the matched file or folder.
+    :ivar PropertiesSearchMatch.is_deleted:
+        Whether the file or folder is deleted.
+    :ivar PropertiesSearchMatch.property_groups:
+        List of custom property groups associated with the file.
     """
 
     __slots__ = [
@@ -941,8 +948,9 @@ class PropertiesSearchMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str file_properties.PropertiesSearchMode.field_name: Search for a
-        value associated with this field name.
+    :ivar PropertiesSearchMode.field_name:
+        Search for a value associated with this field name.
+    :vartype PropertiesSearchMode.field_name: str
     """
 
     _catch_all = 'other'
@@ -995,12 +1003,12 @@ PropertiesSearchMode_validator = bv.Union(PropertiesSearchMode)
 
 class PropertiesSearchQuery(bb.Struct):
     """
-    :ivar file_properties.PropertiesSearchQuery.query: The property field value
-        for which to search across templates.
-    :ivar file_properties.PropertiesSearchQuery.mode: The mode with which to
-        perform the search.
-    :ivar file_properties.PropertiesSearchQuery.logical_operator: The logical
-        operator with which to append the query.
+    :ivar PropertiesSearchQuery.query:
+        The property field value for which to search across templates.
+    :ivar PropertiesSearchQuery.mode:
+        The mode with which to perform the search.
+    :ivar PropertiesSearchQuery.logical_operator:
+        The logical operator with which to append the query.
     """
 
     __slots__ = [
@@ -1041,9 +1049,10 @@ PropertiesSearchQuery_validator = bv.Struct(PropertiesSearchQuery)
 
 class PropertiesSearchResult(bb.Struct):
     """
-    :ivar file_properties.PropertiesSearchResult.matches: A list (possibly
-        empty) of matches for the query.
-    :ivar file_properties.PropertiesSearchResult.cursor: Pass the cursor into
+    :ivar PropertiesSearchResult.matches:
+        A list (possibly empty) of matches for the query.
+    :ivar PropertiesSearchResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_properties_search_continue`
         to continue to receive search results. Cursor will be null when there
         are no more results.
@@ -1082,10 +1091,12 @@ class PropertyField(bb.Struct):
     Raw key/value data to be associated with a Dropbox file. Property fields are
     added to Dropbox files as a :class:`PropertyGroup`.
 
-    :ivar file_properties.PropertyField.name: Key of the property field
-        associated with a file and template. Keys can be up to 256 bytes.
-    :ivar file_properties.PropertyField.value: Value of the property field
-        associated with a file and template. Values can be up to 1024 bytes.
+    :ivar PropertyField.name:
+        Key of the property field associated with a file and template. Keys can
+        be up to 256 bytes.
+    :ivar PropertyField.value:
+        Value of the property field associated with a file and template. Values
+        can be up to 1024 bytes.
     """
 
     __slots__ = [
@@ -1121,10 +1132,12 @@ class PropertyFieldTemplate(bb.Struct):
     Defines how a single property field may be structured. Used exclusively by
     :class:`PropertyGroupTemplate`.
 
-    :ivar file_properties.PropertyFieldTemplate.name: Key of the property field
-        being described. Property field keys can be up to 256 bytes.
-    :ivar file_properties.PropertyFieldTemplate.description: Description of the
-        property field. Property field descriptions can be up to 1024 bytes.
+    :ivar PropertyFieldTemplate.name:
+        Key of the property field being described. Property field keys can be up
+        to 256 bytes.
+    :ivar PropertyFieldTemplate.description:
+        Description of the property field. Property field descriptions can be up
+        to 1024 bytes.
     """
 
     __slots__ = [
@@ -1170,10 +1183,11 @@ class PropertyGroup(bb.Struct):
     file as a :class:`PropertyGroup`. The possible key names and value types in
     this group are defined by the corresponding :class:`PropertyGroupTemplate`.
 
-    :ivar file_properties.PropertyGroup.template_id: A unique identifier for the
-        associated template.
-    :ivar file_properties.PropertyGroup.fields: The actual properties associated
-        with the template. There can be up to 32 property types per template.
+    :ivar PropertyGroup.template_id:
+        A unique identifier for the associated template.
+    :ivar PropertyGroup.fields:
+        The actual properties associated with the template. There can be up to
+        32 property types per template.
     """
 
     __slots__ = [
@@ -1208,14 +1222,14 @@ class PropertyGroupUpdate(bb.Struct):
     """
     Property routes
 
-    :ivar file_properties.PropertyGroupUpdate.template_id: A unique identifier
-        for a property template.
-    :ivar file_properties.PropertyGroupUpdate.add_or_update_fields: Property
-        fields to update. If the property field already exists, it is updated.
-        If the property field doesn't exist, it will be created as long as the
-        property group already exists.
-    :ivar file_properties.PropertyGroupUpdate.remove_fields: Property fields to
-        remove (by name), provided they exist.
+    :ivar PropertyGroupUpdate.template_id:
+        A unique identifier for a property template.
+    :ivar PropertyGroupUpdate.add_or_update_fields:
+        Property fields to update. If the property field already exists, it is
+        updated. If the property field doesn't exist, it will be created as long
+        as the property group already exists.
+    :ivar PropertyGroupUpdate.remove_fields:
+        Property fields to remove (by name), provided they exist.
     """
 
     __slots__ = [
@@ -1262,8 +1276,9 @@ class PropertyType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.PropertyType.string: The associated property field
-        will be of type string. Unicode is supported.
+    :ivar PropertyType.string:
+        The associated property field will be of type string. Unicode is
+        supported.
     """
 
     _catch_all = 'other'
@@ -1295,10 +1310,10 @@ PropertyType_validator = bv.Union(PropertyType)
 
 class RemovePropertiesArg(bb.Struct):
     """
-    :ivar file_properties.RemovePropertiesArg.path: A unique identifier for the
-        file or folder.
-    :ivar file_properties.RemovePropertiesArg.property_template_ids: A list of
-        identifiers for a template created by
+    :ivar RemovePropertiesArg.path:
+        A unique identifier for the file or folder.
+    :ivar RemovePropertiesArg.property_template_ids:
+        A list of identifiers for a template created by
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
@@ -1375,8 +1390,8 @@ RemovePropertiesError_validator = bv.Union(RemovePropertiesError)
 
 class RemoveTemplateArg(bb.Struct):
     """
-    :ivar file_properties.RemoveTemplateArg.template_id: An identifier for a
-        template created by
+    :ivar RemoveTemplateArg.template_id:
+        An identifier for a template created by
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
@@ -1408,9 +1423,10 @@ class TemplateFilterBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [str] file_properties.TemplateFilterBase.filter_some: Only
-        templates with an ID in the supplied list will be returned (a subset of
-        templates will be returned).
+    :ivar TemplateFilterBase.filter_some:
+        Only templates with an ID in the supplied list will be returned (a
+        subset of templates will be returned).
+    :vartype TemplateFilterBase.filter_some: list of [str]
     """
 
     _catch_all = 'other'
@@ -1468,8 +1484,9 @@ class TemplateFilter(TemplateFilterBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.TemplateFilter.filter_none: No templates will be
-        filtered from the result (all templates will be returned).
+    :ivar TemplateFilter.filter_none:
+        No templates will be filtered from the result (all templates will be
+        returned).
     """
 
     # Attribute is overwritten below the class definition
@@ -1494,10 +1511,10 @@ class TemplateOwnerType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_properties.TemplateOwnerType.user: Template will be associated
-        with a user.
-    :ivar file_properties.TemplateOwnerType.team: Template will be associated
-        with a team.
+    :ivar TemplateOwnerType.user:
+        Template will be associated with a user.
+    :ivar TemplateOwnerType.team:
+        Template will be associated with a team.
     """
 
     _catch_all = 'other'
@@ -1539,10 +1556,10 @@ TemplateOwnerType_validator = bv.Union(TemplateOwnerType)
 
 class UpdatePropertiesArg(bb.Struct):
     """
-    :ivar file_properties.UpdatePropertiesArg.path: A unique identifier for the
-        file or folder.
-    :ivar file_properties.UpdatePropertiesArg.update_property_groups: The
-        property groups "delta" updates to apply.
+    :ivar UpdatePropertiesArg.path:
+        A unique identifier for the file or folder.
+    :ivar UpdatePropertiesArg.update_property_groups:
+        The property groups "delta" updates to apply.
     """
 
     __slots__ = [
@@ -1616,18 +1633,19 @@ UpdatePropertiesError_validator = bv.Union(UpdatePropertiesError)
 
 class UpdateTemplateArg(bb.Struct):
     """
-    :ivar file_properties.UpdateTemplateArg.template_id: An identifier for
-        template added by  See
+    :ivar UpdateTemplateArg.template_id:
+        An identifier for template added by  See
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.
-    :ivar file_properties.UpdateTemplateArg.name: A display name for the
-        template. template names can be up to 256 bytes.
-    :ivar file_properties.UpdateTemplateArg.description: Description for the new
-        template. Template descriptions can be up to 1024 bytes.
-    :ivar file_properties.UpdateTemplateArg.add_fields: Property field templates
-        to be added to the group template. There can be up to 32 properties in a
-        single template.
+    :ivar UpdateTemplateArg.name:
+        A display name for the template. template names can be up to 256 bytes.
+    :ivar UpdateTemplateArg.description:
+        Description for the new template. Template descriptions can be up to
+        1024 bytes.
+    :ivar UpdateTemplateArg.add_fields:
+        Property field templates to be added to the group template. There can be
+        up to 32 properties in a single template.
     """
 
     __slots__ = [
@@ -1676,8 +1694,8 @@ UpdateTemplateArg_validator = bv.Struct(UpdateTemplateArg)
 
 class UpdateTemplateResult(bb.Struct):
     """
-    :ivar file_properties.UpdateTemplateResult.template_id: An identifier for
-        template added by route  See
+    :ivar UpdateTemplateResult.template_id:
+        An identifier for template added by route  See
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_user`
         or
         :meth:`dropbox.dropbox_client.Dropbox.file_properties_templates_add_for_team`.

--- a/dropbox/file_requests.py
+++ b/dropbox/file_requests.py
@@ -22,8 +22,8 @@ class GeneralFileRequestsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.GeneralFileRequestsError.disabled_for_team: This user's
-        Dropbox Business team doesn't allow file requests.
+    :ivar GeneralFileRequestsError.disabled_for_team:
+        This user's Dropbox Business team doesn't allow file requests.
     """
 
     _catch_all = 'other'
@@ -71,8 +71,8 @@ class CountFileRequestsResult(bb.Struct):
     """
     Result for :meth:`dropbox.dropbox_client.Dropbox.file_requests_count`.
 
-    :ivar file_requests.CountFileRequestsResult.file_request_count: The number
-        file requests owner by this user.
+    :ivar CountFileRequestsResult.file_request_count:
+        The number file requests owner by this user.
     """
 
     __slots__ = [
@@ -99,21 +99,23 @@ class CreateFileRequestArgs(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.file_requests_create`.
 
-    :ivar file_requests.CreateFileRequestArgs.title: The title of the file
-        request. Must not be empty.
-    :ivar file_requests.CreateFileRequestArgs.destination: The path of the
-        folder in the Dropbox where uploaded files will be sent. For apps with
-        the app folder permission, this will be relative to the app folder.
-    :ivar file_requests.CreateFileRequestArgs.deadline: The deadline for the
-        file request. Deadlines can only be set by Professional and Business
-        accounts.
-    :ivar file_requests.CreateFileRequestArgs.open: Whether or not the file
-        request should be open. If the file request is closed, it will not
-        accept any file submissions, but it can be opened later.
-    :ivar file_requests.CreateFileRequestArgs.description: A description of the
-        file request.
-    :ivar file_requests.CreateFileRequestArgs.video_project_id: If this request
-        was created from video project, its id.
+    :ivar CreateFileRequestArgs.title:
+        The title of the file request. Must not be empty.
+    :ivar CreateFileRequestArgs.destination:
+        The path of the folder in the Dropbox where uploaded files will be sent.
+        For apps with the app folder permission, this will be relative to the
+        app folder.
+    :ivar CreateFileRequestArgs.deadline:
+        The deadline for the file request. Deadlines can only be set by
+        Professional and Business accounts.
+    :ivar CreateFileRequestArgs.open:
+        Whether or not the file request should be open. If the file request is
+        closed, it will not accept any file submissions, but it can be opened
+        later.
+    :ivar CreateFileRequestArgs.description:
+        A description of the file request.
+    :ivar CreateFileRequestArgs.video_project_id:
+        If this request was created from video project, its id.
     """
 
     __slots__ = [
@@ -184,24 +186,24 @@ class FileRequestError(GeneralFileRequestsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.FileRequestError.not_found: This file request ID was not
-        found.
-    :ivar file_requests.FileRequestError.not_a_folder: The specified path is not
-        a folder.
-    :ivar file_requests.FileRequestError.app_lacks_access: This file request is
-        not accessible to this app. Apps with the app folder permission can only
-        access file requests in their app folder.
-    :ivar file_requests.FileRequestError.no_permission: This user doesn't have
-        permission to access or modify this file request.
-    :ivar file_requests.FileRequestError.email_unverified: This user's email
-        address is not verified. File requests are only available on accounts
-        with a verified email address. Users can verify their email address
-        `here <https://www.dropbox.com/help/317>`_.
-    :ivar file_requests.FileRequestError.validation_error: There was an error
-        validating the request. For example, the title was invalid, or there
-        were disallowed characters in the destination path.
-    :ivar file_requests.FileRequestError.no_write_permission: This user doesn't
-        have permission to edit files in a destination folder
+    :ivar FileRequestError.not_found:
+        This file request ID was not found.
+    :ivar FileRequestError.not_a_folder:
+        The specified path is not a folder.
+    :ivar FileRequestError.app_lacks_access:
+        This file request is not accessible to this app. Apps with the app
+        folder permission can only access file requests in their app folder.
+    :ivar FileRequestError.no_permission:
+        This user doesn't have permission to access or modify this file request.
+    :ivar FileRequestError.email_unverified:
+        This user's email address is not verified. File requests are only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
+    :ivar FileRequestError.validation_error:
+        There was an error validating the request. For example, the title was
+        invalid, or there were disallowed characters in the destination path.
+    :ivar FileRequestError.no_write_permission:
+        This user doesn't have permission to edit files in a destination folder
     """
 
     # Attribute is overwritten below the class definition
@@ -288,11 +290,11 @@ class CreateFileRequestError(FileRequestError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.CreateFileRequestError.invalid_location: File requests
-        are not available on the specified folder.
-    :ivar file_requests.CreateFileRequestError.rate_limit: The user has reached
-        the rate limit for creating file requests. The limit is currently 4000
-        file requests total.
+    :ivar CreateFileRequestError.invalid_location:
+        File requests are not available on the specified folder.
+    :ivar CreateFileRequestError.rate_limit:
+        The user has reached the rate limit for creating file requests. The
+        limit is currently 4000 file requests total.
     """
 
     # Attribute is overwritten below the class definition
@@ -340,8 +342,8 @@ class DeleteAllClosedFileRequestsResult(bb.Struct):
     Result for
     :meth:`dropbox.dropbox_client.Dropbox.file_requests_delete_all_closed`.
 
-    :ivar file_requests.DeleteAllClosedFileRequestsResult.file_requests: The
-        file requests deleted for this user.
+    :ivar DeleteAllClosedFileRequestsResult.file_requests:
+        The file requests deleted for this user.
     """
 
     __slots__ = [
@@ -368,8 +370,8 @@ class DeleteFileRequestArgs(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.file_requests_delete`.
 
-    :ivar file_requests.DeleteFileRequestArgs.ids: List IDs of the file requests
-        to delete.
+    :ivar DeleteFileRequestArgs.ids:
+        List IDs of the file requests to delete.
     """
 
     __slots__ = [
@@ -400,8 +402,8 @@ class DeleteFileRequestError(FileRequestError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.DeleteFileRequestError.file_request_open: One or more
-        file requests currently open.
+    :ivar DeleteFileRequestError.file_request_open:
+        One or more file requests currently open.
     """
 
     # Attribute is overwritten below the class definition
@@ -424,8 +426,8 @@ class DeleteFileRequestsResult(bb.Struct):
     """
     Result for :meth:`dropbox.dropbox_client.Dropbox.file_requests_delete`.
 
-    :ivar file_requests.DeleteFileRequestsResult.file_requests: The file
-        requests deleted by the request.
+    :ivar DeleteFileRequestsResult.file_requests:
+        The file requests deleted by the request.
     """
 
     __slots__ = [
@@ -453,25 +455,30 @@ class FileRequest(bb.Struct):
     A `file request <https://www.dropbox.com/help/9090>`_ for receiving files
     into the user's Dropbox account.
 
-    :ivar file_requests.FileRequest.id: The ID of the file request.
-    :ivar file_requests.FileRequest.url: The URL of the file request.
-    :ivar file_requests.FileRequest.title: The title of the file request.
-    :ivar file_requests.FileRequest.destination: The path of the folder in the
-        Dropbox where uploaded files will be sent. This can be None if the
-        destination was removed. For apps with the app folder permission, this
-        will be relative to the app folder.
-    :ivar file_requests.FileRequest.created: When this file request was created.
-    :ivar file_requests.FileRequest.deadline: The deadline for this file
-        request. Only set if the request has a deadline.
-    :ivar file_requests.FileRequest.is_open: Whether or not the file request is
-        open. If the file request is closed, it will not accept any more file
-        submissions.
-    :ivar file_requests.FileRequest.file_count: The number of files this file
-        request has received.
-    :ivar file_requests.FileRequest.description: A description of the file
-        request.
-    :ivar file_requests.FileRequest.video_project_id: If this request was
-        created from video project, its id.
+    :ivar FileRequest.id:
+        The ID of the file request.
+    :ivar FileRequest.url:
+        The URL of the file request.
+    :ivar FileRequest.title:
+        The title of the file request.
+    :ivar FileRequest.destination:
+        The path of the folder in the Dropbox where uploaded files will be sent.
+        This can be None if the destination was removed. For apps with the app
+        folder permission, this will be relative to the app folder.
+    :ivar FileRequest.created:
+        When this file request was created.
+    :ivar FileRequest.deadline:
+        The deadline for this file request. Only set if the request has a
+        deadline.
+    :ivar FileRequest.is_open:
+        Whether or not the file request is open. If the file request is closed,
+        it will not accept any more file submissions.
+    :ivar FileRequest.file_count:
+        The number of files this file request has received.
+    :ivar FileRequest.description:
+        A description of the file request.
+    :ivar FileRequest.video_project_id:
+        If this request was created from video project, its id.
     """
 
     __slots__ = [
@@ -568,11 +575,11 @@ FileRequest_validator = bv.Struct(FileRequest)
 
 class FileRequestDeadline(bb.Struct):
     """
-    :ivar file_requests.FileRequestDeadline.deadline: The deadline for this file
-        request.
-    :ivar file_requests.FileRequestDeadline.allow_late_uploads: If set, allow
-        uploads after the deadline has passed. These uploads will be marked
-        overdue.
+    :ivar FileRequestDeadline.deadline:
+        The deadline for this file request.
+    :ivar FileRequestDeadline.allow_late_uploads:
+        If set, allow uploads after the deadline has passed. These uploads will
+        be marked overdue.
     """
 
     __slots__ = [
@@ -607,8 +614,8 @@ class GetFileRequestArgs(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.file_requests_get`.
 
-    :ivar file_requests.GetFileRequestArgs.id: The ID of the file request to
-        retrieve.
+    :ivar GetFileRequestArgs.id:
+        The ID of the file request to retrieve.
     """
 
     __slots__ = [
@@ -723,8 +730,8 @@ class ListFileRequestsArg(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.file_requests_list`.
 
-    :ivar file_requests.ListFileRequestsArg.limit: The maximum number of file
-        requests that should be returned per request.
+    :ivar ListFileRequestsArg.limit:
+        The maximum number of file requests that should be returned per request.
     """
 
     __slots__ = [
@@ -749,8 +756,9 @@ ListFileRequestsArg_validator = bv.Struct(ListFileRequestsArg)
 
 class ListFileRequestsContinueArg(bb.Struct):
     """
-    :ivar file_requests.ListFileRequestsContinueArg.cursor: The cursor returned
-        by the previous API call specified in the endpoint description.
+    :ivar ListFileRequestsContinueArg.cursor:
+        The cursor returned by the previous API call specified in the endpoint
+        description.
     """
 
     __slots__ = [
@@ -781,8 +789,8 @@ class ListFileRequestsContinueError(GeneralFileRequestsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.ListFileRequestsContinueError.invalid_cursor: The cursor
-        is invalid.
+    :ivar ListFileRequestsContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     # Attribute is overwritten below the class definition
@@ -819,9 +827,9 @@ class ListFileRequestsResult(bb.Struct):
     """
     Result for :meth:`dropbox.dropbox_client.Dropbox.file_requests_list`.
 
-    :ivar file_requests.ListFileRequestsResult.file_requests: The file requests
-        owned by this user. Apps with the app folder permission will only see
-        file requests in their app folder.
+    :ivar ListFileRequestsResult.file_requests:
+        The file requests owned by this user. Apps with the app folder
+        permission will only see file requests in their app folder.
     """
 
     __slots__ = [
@@ -849,15 +857,17 @@ class ListFileRequestsV2Result(bb.Struct):
     Result for :meth:`dropbox.dropbox_client.Dropbox.file_requests_list` and
     :meth:`dropbox.dropbox_client.Dropbox.file_requests_list_continue`.
 
-    :ivar file_requests.ListFileRequestsV2Result.file_requests: The file
-        requests owned by this user. Apps with the app folder permission will
-        only see file requests in their app folder.
-    :ivar file_requests.ListFileRequestsV2Result.cursor: Pass the cursor into
+    :ivar ListFileRequestsV2Result.file_requests:
+        The file requests owned by this user. Apps with the app folder
+        permission will only see file requests in their app folder.
+    :ivar ListFileRequestsV2Result.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.file_requests_list_continue` to
         obtain additional file requests.
-    :ivar file_requests.ListFileRequestsV2Result.has_more: Is true if there are
-        additional file requests that have not been returned yet. An additional
-        call to :route:list/continue` can retrieve them.
+    :ivar ListFileRequestsV2Result.has_more:
+        Is true if there are additional file requests that have not been
+        returned yet. An additional call to :route:list/continue` can retrieve
+        them.
     """
 
     __slots__ = [
@@ -900,20 +910,21 @@ class UpdateFileRequestArgs(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.file_requests_update`.
 
-    :ivar file_requests.UpdateFileRequestArgs.id: The ID of the file request to
-        update.
-    :ivar file_requests.UpdateFileRequestArgs.title: The new title of the file
-        request. Must not be empty.
-    :ivar file_requests.UpdateFileRequestArgs.destination: The new path of the
-        folder in the Dropbox where uploaded files will be sent. For apps with
-        the app folder permission, this will be relative to the app folder.
-    :ivar file_requests.UpdateFileRequestArgs.deadline: The new deadline for the
-        file request. Deadlines can only be set by Professional and Business
-        accounts.
-    :ivar file_requests.UpdateFileRequestArgs.open: Whether to set this file
-        request as open or closed.
-    :ivar file_requests.UpdateFileRequestArgs.description: The description of
-        the file request.
+    :ivar UpdateFileRequestArgs.id:
+        The ID of the file request to update.
+    :ivar UpdateFileRequestArgs.title:
+        The new title of the file request. Must not be empty.
+    :ivar UpdateFileRequestArgs.destination:
+        The new path of the folder in the Dropbox where uploaded files will be
+        sent. For apps with the app folder permission, this will be relative to
+        the app folder.
+    :ivar UpdateFileRequestArgs.deadline:
+        The new deadline for the file request. Deadlines can only be set by
+        Professional and Business accounts.
+    :ivar UpdateFileRequestArgs.open:
+        Whether to set this file request as open or closed.
+    :ivar UpdateFileRequestArgs.description:
+        The description of the file request.
     """
 
     __slots__ = [
@@ -982,11 +993,11 @@ class UpdateFileRequestDeadline(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar file_requests.UpdateFileRequestDeadline.no_update: Do not change the
-        file request's deadline.
-    :ivar Optional[FileRequestDeadline]
-        file_requests.UpdateFileRequestDeadline.update: If :val:`null`, the file
-        request's deadline is cleared.
+    :ivar UpdateFileRequestDeadline.no_update:
+        Do not change the file request's deadline.
+    :ivar UpdateFileRequestDeadline.update:
+        If None, the file request's deadline is cleared.
+    :vartype UpdateFileRequestDeadline.update: Optional[FileRequestDeadline]
     """
 
     _catch_all = 'other'

--- a/dropbox/files.py
+++ b/dropbox/files.py
@@ -18,9 +18,11 @@ from dropbox import users_common
 
 class AddTagArg(bb.Struct):
     """
-    :ivar files.AddTagArg.path: Path to the item to be tagged.
-    :ivar files.AddTagArg.tag_text: The value of the tag to add. Will be
-        automatically converted to lowercase letters.
+    :ivar AddTagArg.path:
+        Path to the item to be tagged.
+    :ivar AddTagArg.tag_text:
+        The value of the tag to add. Will be automatically converted to
+        lowercase letters.
     """
 
     __slots__ = [
@@ -110,8 +112,8 @@ class AddTagError(BaseTagError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.AddTagError.too_many_tags: The item already has the maximum
-        supported number of tags.
+    :ivar AddTagError.too_many_tags:
+        The item already has the maximum supported number of tags.
     """
 
     # Attribute is overwritten below the class definition
@@ -132,18 +134,20 @@ AddTagError_validator = bv.Union(AddTagError)
 
 class GetMetadataArg(bb.Struct):
     """
-    :ivar files.GetMetadataArg.path: The path of a file or folder on Dropbox.
-    :ivar files.GetMetadataArg.include_media_info: If true,
-        ``FileMetadata.media_info`` is set for photo and video.
-    :ivar files.GetMetadataArg.include_deleted: If true,
-        :class:`DeletedMetadata` will be returned for deleted file or folder,
-        otherwise ``LookupError.not_found`` will be returned.
-    :ivar files.GetMetadataArg.include_has_explicit_shared_members: If true, the
-        results will include a flag for each file indicating whether or not that
-        file has any explicit members.
-    :ivar files.GetMetadataArg.include_property_groups: If set to a valid list
-        of template IDs, ``FileMetadata.property_groups`` is set if there exists
-        property data associated with the file and each of the listed templates.
+    :ivar GetMetadataArg.path:
+        The path of a file or folder on Dropbox.
+    :ivar GetMetadataArg.include_media_info:
+        If true, ``FileMetadata.media_info`` is set for photo and video.
+    :ivar GetMetadataArg.include_deleted:
+        If true, :class:`DeletedMetadata` will be returned for deleted file or
+        folder, otherwise ``LookupError.not_found`` will be returned.
+    :ivar GetMetadataArg.include_has_explicit_shared_members:
+        If true, the results will include a flag for each file indicating
+        whether or not that file has any explicit members.
+    :ivar GetMetadataArg.include_property_groups:
+        If set to a valid list of template IDs, ``FileMetadata.property_groups``
+        is set if there exists property data associated with the file and each
+        of the listed templates.
     """
 
     __slots__ = [
@@ -200,8 +204,8 @@ GetMetadataArg_validator = bv.Struct(GetMetadataArg)
 
 class AlphaGetMetadataArg(GetMetadataArg):
     """
-    :ivar files.AlphaGetMetadataArg.include_property_templates: Field is
-        deprecated. If set to a valid list of template IDs,
+    :ivar AlphaGetMetadataArg.include_property_templates:
+        Field is deprecated. If set to a valid list of template IDs,
         ``FileMetadata.property_groups`` is set for files with custom
         properties.
     """
@@ -322,28 +326,33 @@ AlphaGetMetadataError_validator = bv.Union(AlphaGetMetadataError)
 
 class CommitInfo(bb.Struct):
     """
-    :ivar files.CommitInfo.path: Path in the user's Dropbox to save the file.
-    :ivar files.CommitInfo.mode: Selects what to do if the file already exists.
-    :ivar files.CommitInfo.autorename: If there's a conflict, as determined by
-        ``mode``, have the Dropbox server try to autorename the file to avoid
-        conflict.
-    :ivar files.CommitInfo.client_modified: The value to store as the
-        ``client_modified`` timestamp. Dropbox automatically records the time at
-        which the file was written to the Dropbox servers. It can also record an
-        additional timestamp, provided by Dropbox desktop clients, mobile
-        clients, and API apps of when the file was actually created or modified.
-    :ivar files.CommitInfo.mute: Normally, users are made aware of any file
-        modifications in their Dropbox account via notifications in the client
-        software. If ``True``, this tells the clients that this modification
-        shouldn't result in a user notification.
-    :ivar files.CommitInfo.property_groups: List of custom properties to add to
-        file.
-    :ivar files.CommitInfo.strict_conflict: Be more strict about how each
-        :class:`WriteMode` detects conflict. For example, always return a
-        conflict error when ``mode`` = ``WriteMode.update`` and the given "rev"
-        doesn't match the existing file's "rev", even if the existing file has
-        been deleted. This also forces a conflict even when the target path
-        refers to a file with identical contents.
+    :ivar CommitInfo.path:
+        Path in the user's Dropbox to save the file.
+    :ivar CommitInfo.mode:
+        Selects what to do if the file already exists.
+    :ivar CommitInfo.autorename:
+        If there's a conflict, as determined by ``mode``, have the Dropbox
+        server try to autorename the file to avoid conflict.
+    :ivar CommitInfo.client_modified:
+        The value to store as the ``client_modified`` timestamp. Dropbox
+        automatically records the time at which the file was written to the
+        Dropbox servers. It can also record an additional timestamp, provided by
+        Dropbox desktop clients, mobile clients, and API apps of when the file
+        was actually created or modified.
+    :ivar CommitInfo.mute:
+        Normally, users are made aware of any file modifications in their
+        Dropbox account via notifications in the client software. If ``True``,
+        this tells the clients that this modification shouldn't result in a user
+        notification.
+    :ivar CommitInfo.property_groups:
+        List of custom properties to add to file.
+    :ivar CommitInfo.strict_conflict:
+        Be more strict about how each :class:`WriteMode` detects conflict. For
+        example, always return a conflict error when ``mode`` =
+        ``WriteMode.update`` and the given "rev" doesn't match the existing
+        file's "rev", even if the existing file has been deleted. This also
+        forces a conflict even when the target path refers to a file with
+        identical contents.
     """
 
     __slots__ = [
@@ -416,9 +425,10 @@ CommitInfo_validator = bv.Struct(CommitInfo)
 
 class ContentSyncSetting(bb.Struct):
     """
-    :ivar files.ContentSyncSetting.id: Id of the item this setting is applied
-        to.
-    :ivar files.ContentSyncSetting.sync_setting: Setting for this item.
+    :ivar ContentSyncSetting.id:
+        Id of the item this setting is applied to.
+    :ivar ContentSyncSetting.sync_setting:
+        Setting for this item.
     """
 
     __slots__ = [
@@ -451,9 +461,10 @@ ContentSyncSetting_validator = bv.Struct(ContentSyncSetting)
 
 class ContentSyncSettingArg(bb.Struct):
     """
-    :ivar files.ContentSyncSettingArg.id: Id of the item this setting is applied
-        to.
-    :ivar files.ContentSyncSettingArg.sync_setting: Setting for this item.
+    :ivar ContentSyncSettingArg.id:
+        Id of the item this setting is applied to.
+    :ivar ContentSyncSettingArg.sync_setting:
+        Setting for this item.
     """
 
     __slots__ = [
@@ -486,9 +497,11 @@ ContentSyncSettingArg_validator = bv.Struct(ContentSyncSettingArg)
 
 class CreateFolderArg(bb.Struct):
     """
-    :ivar files.CreateFolderArg.path: Path in the user's Dropbox to create.
-    :ivar files.CreateFolderArg.autorename: If there's a conflict, have the
-        Dropbox server try to autorename the folder to avoid the conflict.
+    :ivar CreateFolderArg.path:
+        Path in the user's Dropbox to create.
+    :ivar CreateFolderArg.autorename:
+        If there's a conflict, have the Dropbox server try to autorename the
+        folder to avoid the conflict.
     """
 
     __slots__ = [
@@ -521,13 +534,14 @@ CreateFolderArg_validator = bv.Struct(CreateFolderArg)
 
 class CreateFolderBatchArg(bb.Struct):
     """
-    :ivar files.CreateFolderBatchArg.paths: List of paths to be created in the
-        user's Dropbox. Duplicate path arguments in the batch are considered
-        only once.
-    :ivar files.CreateFolderBatchArg.autorename: If there's a conflict, have the
-        Dropbox server try to autorename the folder to avoid the conflict.
-    :ivar files.CreateFolderBatchArg.force_async: Whether to force the create to
-        happen asynchronously.
+    :ivar CreateFolderBatchArg.paths:
+        List of paths to be created in the user's Dropbox. Duplicate path
+        arguments in the batch are considered only once.
+    :ivar CreateFolderBatchArg.autorename:
+        If there's a conflict, have the Dropbox server try to autorename the
+        folder to avoid the conflict.
+    :ivar CreateFolderBatchArg.force_async:
+        Whether to force the create to happen asynchronously.
     """
 
     __slots__ = [
@@ -572,8 +586,8 @@ class CreateFolderBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.CreateFolderBatchError.too_many_files: The operation would
-        involve too many files or folders.
+    :ivar CreateFolderBatchError.too_many_files:
+        The operation would involve too many files or folders.
     """
 
     _catch_all = 'other'
@@ -609,10 +623,12 @@ class CreateFolderBatchJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar CreateFolderBatchResult CreateFolderBatchJobStatus.complete: The batch
-        create folder has finished.
-    :ivar CreateFolderBatchError CreateFolderBatchJobStatus.failed: The batch
-        create folder has failed.
+    :ivar CreateFolderBatchJobStatus.complete:
+        The batch create folder has finished.
+    :vartype CreateFolderBatchJobStatus.complete: CreateFolderBatchResult
+    :ivar CreateFolderBatchJobStatus.failed:
+        The batch create folder has failed.
+    :vartype CreateFolderBatchJobStatus.failed: CreateFolderBatchError
     """
 
     _catch_all = 'other'
@@ -771,9 +787,9 @@ FileOpsResult_validator = bv.Struct(FileOpsResult)
 
 class CreateFolderBatchResult(FileOpsResult):
     """
-    :ivar files.CreateFolderBatchResult.entries: Each entry in
-        ``CreateFolderBatchArg.paths`` will appear at the same position inside
-        ``CreateFolderBatchResult.entries``.
+    :ivar CreateFolderBatchResult.entries:
+        Each entry in ``CreateFolderBatchArg.paths`` will appear at the same
+        position inside ``CreateFolderBatchResult.entries``.
     """
 
     __slots__ = [
@@ -924,8 +940,8 @@ CreateFolderEntryError_validator = bv.Union(CreateFolderEntryError)
 
 class CreateFolderEntryResult(bb.Struct):
     """
-    :ivar files.CreateFolderEntryResult.metadata: Metadata of the created
-        folder.
+    :ivar CreateFolderEntryResult.metadata:
+        Metadata of the created folder.
     """
 
     __slots__ = [
@@ -993,7 +1009,8 @@ CreateFolderError_validator = bv.Union(CreateFolderError)
 
 class CreateFolderResult(FileOpsResult):
     """
-    :ivar files.CreateFolderResult.metadata: Metadata of the created folder.
+    :ivar CreateFolderResult.metadata:
+        Metadata of the created folder.
     """
 
     __slots__ = [
@@ -1019,10 +1036,11 @@ CreateFolderResult_validator = bv.Struct(CreateFolderResult)
 
 class DeleteArg(bb.Struct):
     """
-    :ivar files.DeleteArg.path: Path in the user's Dropbox to delete.
-    :ivar files.DeleteArg.parent_rev: Perform delete if given "rev" matches the
-        existing file's latest "rev". This field does not support deleting a
-        folder.
+    :ivar DeleteArg.path:
+        Path in the user's Dropbox to delete.
+    :ivar DeleteArg.parent_rev:
+        Perform delete if given "rev" matches the existing file's latest "rev".
+        This field does not support deleting a folder.
     """
 
     __slots__ = [
@@ -1081,8 +1099,8 @@ class DeleteBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.DeleteBatchError.too_many_write_operations: Field is deprecated.
-        Use ``DeleteError.too_many_write_operations``.
+    :ivar DeleteBatchError.too_many_write_operations:
+        Field is deprecated. Use ``DeleteError.too_many_write_operations``.
         :meth:`dropbox.dropbox_client.Dropbox.files_delete_batch` now provides
         smaller granularity about which entry has failed because of this.
     """
@@ -1120,10 +1138,12 @@ class DeleteBatchJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar DeleteBatchResult DeleteBatchJobStatus.complete: The batch delete has
-        finished.
-    :ivar DeleteBatchError DeleteBatchJobStatus.failed: The batch delete has
-        failed.
+    :ivar DeleteBatchJobStatus.complete:
+        The batch delete has finished.
+    :vartype DeleteBatchJobStatus.complete: DeleteBatchResult
+    :ivar DeleteBatchJobStatus.failed:
+        The batch delete has failed.
+    :vartype DeleteBatchJobStatus.failed: DeleteBatchError
     """
 
     _catch_all = 'other'
@@ -1263,9 +1283,9 @@ DeleteBatchLaunch_validator = bv.Union(DeleteBatchLaunch)
 
 class DeleteBatchResult(FileOpsResult):
     """
-    :ivar files.DeleteBatchResult.entries: Each entry in
-        ``DeleteBatchArg.entries`` will appear at the same position inside
-        ``DeleteBatchResult.entries``.
+    :ivar DeleteBatchResult.entries:
+        Each entry in ``DeleteBatchArg.entries`` will appear at the same
+        position inside ``DeleteBatchResult.entries``.
     """
 
     __slots__ = [
@@ -1291,7 +1311,8 @@ DeleteBatchResult_validator = bv.Struct(DeleteBatchResult)
 
 class DeleteBatchResultData(bb.Struct):
     """
-    :ivar files.DeleteBatchResultData.metadata: Metadata of the deleted object.
+    :ivar DeleteBatchResultData.metadata:
+        Metadata of the deleted object.
     """
 
     __slots__ = [
@@ -1392,10 +1413,11 @@ class DeleteError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.DeleteError.too_many_write_operations: There are too many write
-        operations in user's Dropbox. Please retry this request.
-    :ivar files.DeleteError.too_many_files: There are too many files in one
-        request. Please retry with fewer files.
+    :ivar DeleteError.too_many_write_operations:
+        There are too many write operations in user's Dropbox. Please retry this
+        request.
+    :ivar DeleteError.too_many_files:
+        There are too many files in one request. Please retry with fewer files.
     """
 
     _catch_all = 'other'
@@ -1495,7 +1517,8 @@ DeleteError_validator = bv.Union(DeleteError)
 
 class DeleteResult(FileOpsResult):
     """
-    :ivar files.DeleteResult.metadata: Metadata of the deleted object.
+    :ivar DeleteResult.metadata:
+        Metadata of the deleted object.
     """
 
     __slots__ = [
@@ -1523,22 +1546,26 @@ class Metadata(bb.Struct):
     """
     Metadata for a file or folder.
 
-    :ivar files.Metadata.name: The last component of the path (including
-        extension). This never contains a slash.
-    :ivar files.Metadata.path_lower: The lowercased full path in the user's
-        Dropbox. This always starts with a slash. This field will be null if the
-        file or folder is not mounted.
-    :ivar files.Metadata.path_display: The cased path to be used for display
-        purposes only. In rare instances the casing will not correctly match the
-        user's filesystem, but this behavior will match the path provided in the
-        Core API v1, and at least the last path component will have the correct
-        casing. Changes to only the casing of paths won't be returned by
+    :ivar Metadata.name:
+        The last component of the path (including extension). This never
+        contains a slash.
+    :ivar Metadata.path_lower:
+        The lowercased full path in the user's Dropbox. This always starts with
+        a slash. This field will be null if the file or folder is not mounted.
+    :ivar Metadata.path_display:
+        The cased path to be used for display purposes only. In rare instances
+        the casing will not correctly match the user's filesystem, but this
+        behavior will match the path provided in the Core API v1, and at least
+        the last path component will have the correct casing. Changes to only
+        the casing of paths won't be returned by
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue`. This
         field will be null if the file or folder is not mounted.
-    :ivar files.Metadata.parent_shared_folder_id: Field is deprecated. Please
-        use ``FileSharingInfo.parent_shared_folder_id`` or
+    :ivar Metadata.parent_shared_folder_id:
+        Field is deprecated. Please use
+        ``FileSharingInfo.parent_shared_folder_id`` or
         ``FolderSharingInfo.parent_shared_folder_id`` instead.
-    :ivar files.Metadata.preview_url: The preview URL of the file.
+    :ivar Metadata.preview_url:
+        The preview URL of the file.
     """
 
     __slots__ = [
@@ -1598,8 +1625,8 @@ class DeletedMetadata(Metadata):
     Indicates that there used to be a file or folder at this path, but it no
     longer exists.
 
-    :ivar files.DeletedMetadata.is_restorable: If present, indicates whether
-        this deleted entry can be restored.
+    :ivar DeletedMetadata.is_restorable:
+        If present, indicates whether this deleted entry can be restored.
     """
 
     __slots__ = [
@@ -1636,8 +1663,10 @@ class Dimensions(bb.Struct):
     """
     Dimensions for a photo or video.
 
-    :ivar files.Dimensions.height: Height of the photo/video.
-    :ivar files.Dimensions.width: Width of the photo/video.
+    :ivar Dimensions.height:
+        Height of the photo/video.
+    :ivar Dimensions.width:
+        Width of the photo/video.
     """
 
     __slots__ = [
@@ -1670,9 +1699,10 @@ Dimensions_validator = bv.Struct(Dimensions)
 
 class DownloadArg(bb.Struct):
     """
-    :ivar files.DownloadArg.path: The path of the file to download.
-    :ivar files.DownloadArg.rev: Field is deprecated. Please specify revision in
-        ``path`` instead.
+    :ivar DownloadArg.path:
+        The path of the file to download.
+    :ivar DownloadArg.rev:
+        Field is deprecated. Please specify revision in ``path`` instead.
     """
 
     __slots__ = [
@@ -1709,8 +1739,8 @@ class DownloadError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.DownloadError.unsupported_file: This file type cannot be
-        downloaded directly; use
+    :ivar DownloadError.unsupported_file:
+        This file type cannot be downloaded directly; use
         :meth:`dropbox.dropbox_client.Dropbox.files_export` instead.
     """
 
@@ -1772,7 +1802,8 @@ DownloadError_validator = bv.Union(DownloadError)
 
 class DownloadZipArg(bb.Struct):
     """
-    :ivar files.DownloadZipArg.path: The path of the folder to download.
+    :ivar DownloadZipArg.path:
+        The path of the folder to download.
     """
 
     __slots__ = [
@@ -1801,10 +1832,10 @@ class DownloadZipError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.DownloadZipError.too_large: The folder or a file is too large to
-        download.
-    :ivar files.DownloadZipError.too_many_files: The folder has too many files
-        to download.
+    :ivar DownloadZipError.too_large:
+        The folder or a file is too large to download.
+    :ivar DownloadZipError.too_many_files:
+        The folder has too many files to download.
     """
 
     _catch_all = 'other'
@@ -1897,10 +1928,11 @@ DownloadZipResult_validator = bv.Struct(DownloadZipResult)
 
 class ExportArg(bb.Struct):
     """
-    :ivar files.ExportArg.path: The path of the file to be exported.
-    :ivar files.ExportArg.export_format: The file format to which the file
-        should be exported. This must be one of the formats listed in the file's
-        export_options returned by
+    :ivar ExportArg.path:
+        The path of the file to be exported.
+    :ivar ExportArg.export_format:
+        The file format to which the file should be exported. This must be one
+        of the formats listed in the file's export_options returned by
         :meth:`dropbox.dropbox_client.Dropbox.files_get_metadata`. If none is
         specified, the default format (specified in export_as in file metadata)
         will be used.
@@ -1940,12 +1972,13 @@ class ExportError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ExportError.non_exportable: This file type cannot be exported.
-        Use :meth:`dropbox.dropbox_client.Dropbox.files_download` instead.
-    :ivar files.ExportError.invalid_export_format: The specified export format
-        is not a valid option for this file type.
-    :ivar files.ExportError.retry_error: The exportable content is not yet
-        available. Please retry later.
+    :ivar ExportError.non_exportable:
+        This file type cannot be exported. Use
+        :meth:`dropbox.dropbox_client.Dropbox.files_download` instead.
+    :ivar ExportError.invalid_export_format:
+        The specified export format is not a valid option for this file type.
+    :ivar ExportError.retry_error:
+        The exportable content is not yet available. Please retry later.
     """
 
     _catch_all = 'other'
@@ -2028,11 +2061,11 @@ class ExportInfo(bb.Struct):
     """
     Export information for a file.
 
-    :ivar files.ExportInfo.export_as: Format to which the file can be exported
-        to.
-    :ivar files.ExportInfo.export_options: Additional formats to which the file
-        can be exported. These values can be specified as the export_format in
-        /files/export.
+    :ivar ExportInfo.export_as:
+        Format to which the file can be exported to.
+    :ivar ExportInfo.export_options:
+        Additional formats to which the file can be exported. These values can
+        be specified as the export_format in /files/export.
     """
 
     __slots__ = [
@@ -2065,16 +2098,19 @@ ExportInfo_validator = bv.Struct(ExportInfo)
 
 class ExportMetadata(bb.Struct):
     """
-    :ivar files.ExportMetadata.name: The last component of the path (including
-        extension). This never contains a slash.
-    :ivar files.ExportMetadata.size: The file size in bytes.
-    :ivar files.ExportMetadata.export_hash: A hash based on the exported file
-        content. This field can be used to verify data integrity. Similar to
-        content hash. For more information see our `Content hash
+    :ivar ExportMetadata.name:
+        The last component of the path (including extension). This never
+        contains a slash.
+    :ivar ExportMetadata.size:
+        The file size in bytes.
+    :ivar ExportMetadata.export_hash:
+        A hash based on the exported file content. This field can be used to
+        verify data integrity. Similar to content hash. For more information see
+        our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
-    :ivar files.ExportMetadata.paper_revision: If the file is a Paper doc, this
-        gives the latest doc revision which can be used in
-        :meth:`dropbox.dropbox_client.Dropbox.files_paper_update`.
+    :ivar ExportMetadata.paper_revision:
+        If the file is a Paper doc, this gives the latest doc revision which can
+        be used in :meth:`dropbox.dropbox_client.Dropbox.files_paper_update`.
     """
 
     __slots__ = [
@@ -2123,9 +2159,10 @@ ExportMetadata_validator = bv.Struct(ExportMetadata)
 
 class ExportResult(bb.Struct):
     """
-    :ivar files.ExportResult.export_metadata: Metadata for the exported version
-        of the file.
-    :ivar files.ExportResult.file_metadata: Metadata for the original file.
+    :ivar ExportResult.export_metadata:
+        Metadata for the exported version of the file.
+    :ivar ExportResult.file_metadata:
+        Metadata for the original file.
     """
 
     __slots__ = [
@@ -2162,17 +2199,26 @@ class FileCategory(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.FileCategory.image: jpg, png, gif, and more.
-    :ivar files.FileCategory.document: doc, docx, txt, and more.
-    :ivar files.FileCategory.pdf: pdf.
-    :ivar files.FileCategory.spreadsheet: xlsx, xls, csv, and more.
-    :ivar files.FileCategory.presentation: ppt, pptx, key, and more.
-    :ivar files.FileCategory.audio: mp3, wav, mid, and more.
-    :ivar files.FileCategory.video: mov, wmv, mp4, and more.
-    :ivar files.FileCategory.folder: dropbox folder.
-    :ivar files.FileCategory.paper: dropbox paper doc.
-    :ivar files.FileCategory.others: any file not in one of the categories
-        above.
+    :ivar FileCategory.image:
+        jpg, png, gif, and more.
+    :ivar FileCategory.document:
+        doc, docx, txt, and more.
+    :ivar FileCategory.pdf:
+        pdf.
+    :ivar FileCategory.spreadsheet:
+        xlsx, xls, csv, and more.
+    :ivar FileCategory.presentation:
+        ppt, pptx, key, and more.
+    :ivar FileCategory.audio:
+        mp3, wav, mid, and more.
+    :ivar FileCategory.video:
+        mov, wmv, mp4, and more.
+    :ivar FileCategory.folder:
+        dropbox folder.
+    :ivar FileCategory.paper:
+        dropbox paper doc.
+    :ivar FileCategory.others:
+        any file not in one of the categories above.
     """
 
     _catch_all = 'other'
@@ -2294,7 +2340,8 @@ FileCategory_validator = bv.Union(FileCategory)
 
 class FileLock(bb.Struct):
     """
-    :ivar files.FileLock.content: The lock description.
+    :ivar FileLock.content:
+        The lock description.
     """
 
     __slots__ = [
@@ -2323,9 +2370,11 @@ class FileLockContent(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.FileLockContent.unlocked: Empty type to indicate no lock.
-    :ivar SingleUserLock FileLockContent.single_user: A lock held by a single
-        user.
+    :ivar FileLockContent.unlocked:
+        Empty type to indicate no lock.
+    :ivar FileLockContent.single_user:
+        A lock held by a single user.
+    :vartype FileLockContent.single_user: SingleUserLock
     """
 
     _catch_all = 'other'
@@ -2388,13 +2437,14 @@ FileLockContent_validator = bv.Union(FileLockContent)
 
 class FileLockMetadata(bb.Struct):
     """
-    :ivar files.FileLockMetadata.is_lockholder: True if caller holds the file
-        lock.
-    :ivar files.FileLockMetadata.lockholder_name: The display name of the lock
-        holder.
-    :ivar files.FileLockMetadata.lockholder_account_id: The account ID of the
-        lock holder if known.
-    :ivar files.FileLockMetadata.created: The timestamp of the lock was created.
+    :ivar FileLockMetadata.is_lockholder:
+        True if caller holds the file lock.
+    :ivar FileLockMetadata.lockholder_name:
+        The display name of the lock holder.
+    :ivar FileLockMetadata.lockholder_account_id:
+        The account ID of the lock holder if known.
+    :ivar FileLockMetadata.created:
+        The timestamp of the lock was created.
     """
 
     __slots__ = [
@@ -2443,51 +2493,58 @@ FileLockMetadata_validator = bv.Struct(FileLockMetadata)
 
 class FileMetadata(Metadata):
     """
-    :ivar files.FileMetadata.id: A unique identifier for the file.
-    :ivar files.FileMetadata.client_modified: For files, this is the
-        modification time set by the desktop client when the file was added to
-        Dropbox. Since this time is not verified (the Dropbox server stores
-        whatever the desktop client sends up), this should only be used for
-        display purposes (such as sorting) and not, for example, to determine if
-        a file has changed or not.
-    :ivar files.FileMetadata.server_modified: The last time the file was
-        modified on Dropbox.
-    :ivar files.FileMetadata.rev: A unique identifier for the current revision
-        of a file. This field is the same rev as elsewhere in the API and can be
-        used to detect changes and avoid conflicts.
-    :ivar files.FileMetadata.size: The file size in bytes.
-    :ivar files.FileMetadata.media_info: Additional information if the file is a
-        photo or video. This field will not be set on entries returned by
+    :ivar FileMetadata.id:
+        A unique identifier for the file.
+    :ivar FileMetadata.client_modified:
+        For files, this is the modification time set by the desktop client when
+        the file was added to Dropbox. Since this time is not verified (the
+        Dropbox server stores whatever the desktop client sends up), this should
+        only be used for display purposes (such as sorting) and not, for
+        example, to determine if a file has changed or not.
+    :ivar FileMetadata.server_modified:
+        The last time the file was modified on Dropbox.
+    :ivar FileMetadata.rev:
+        A unique identifier for the current revision of a file. This field is
+        the same rev as elsewhere in the API and can be used to detect changes
+        and avoid conflicts.
+    :ivar FileMetadata.size:
+        The file size in bytes.
+    :ivar FileMetadata.media_info:
+        Additional information if the file is a photo or video. This field will
+        not be set on entries returned by
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder`,
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue`, or
         :meth:`dropbox.dropbox_client.Dropbox.files_get_thumbnail_batch`,
         starting December 2, 2019.
-    :ivar files.FileMetadata.symlink_info: Set if this file is a symlink.
-    :ivar files.FileMetadata.sharing_info: Set if this file is contained in a
-        shared folder.
-    :ivar files.FileMetadata.is_downloadable: If true, file can be downloaded
-        directly; else the file must be exported.
-    :ivar files.FileMetadata.export_info: Information about format this file can
-        be exported to. This filed must be set if ``is_downloadable`` is set to
-        false.
-    :ivar files.FileMetadata.property_groups: Additional information if the file
-        has custom properties with the property template specified.
-    :ivar files.FileMetadata.has_explicit_shared_members: This flag will only be
-        present if include_has_explicit_shared_members is true in
-        :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` or
+    :ivar FileMetadata.symlink_info:
+        Set if this file is a symlink.
+    :ivar FileMetadata.sharing_info:
+        Set if this file is contained in a shared folder.
+    :ivar FileMetadata.is_downloadable:
+        If true, file can be downloaded directly; else the file must be
+        exported.
+    :ivar FileMetadata.export_info:
+        Information about format this file can be exported to. This filed must
+        be set if ``is_downloadable`` is set to false.
+    :ivar FileMetadata.property_groups:
+        Additional information if the file has custom properties with the
+        property template specified.
+    :ivar FileMetadata.has_explicit_shared_members:
+        This flag will only be present if include_has_explicit_shared_members is
+        true in :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` or
         :meth:`dropbox.dropbox_client.Dropbox.files_get_metadata`. If this flag
         is present, it will be true if this file has any explicit shared
         members. This is different from sharing_info in that this could be true
         in the case where a file has explicit members but is not contained
         within a shared folder.
-    :ivar files.FileMetadata.content_hash: A hash of the file content. This
-        field can be used to verify data integrity. For more information see our
-        `Content hash
+    :ivar FileMetadata.content_hash:
+        A hash of the file content. This field can be used to verify data
+        integrity. For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
-    :ivar files.FileMetadata.file_lock_info: If present, the metadata associated
-        with the file's current lock.
-    :ivar files.FileMetadata.is_restorable: If present, indicates whether this
-        file revision can be restored.
+    :ivar FileMetadata.file_lock_info:
+        If present, the metadata associated with the file's current lock.
+    :ivar FileMetadata.is_restorable:
+        If present, indicates whether this file revision can be restored.
     """
 
     __slots__ = [
@@ -2636,8 +2693,8 @@ class SharingInfo(bb.Struct):
     """
     Sharing info for a file or folder.
 
-    :ivar files.SharingInfo.read_only: True if the file or folder is inside a
-        read-only shared folder.
+    :ivar SharingInfo.read_only:
+        True if the file or folder is inside a read-only shared folder.
     """
 
     __slots__ = [
@@ -2664,10 +2721,11 @@ class FileSharingInfo(SharingInfo):
     """
     Sharing info for a file which is contained by a shared folder.
 
-    :ivar files.FileSharingInfo.parent_shared_folder_id: ID of shared folder
-        that holds this file.
-    :ivar files.FileSharingInfo.modified_by: The last user who modified the
-        file. This field will be null if the user's account has been deleted.
+    :ivar FileSharingInfo.parent_shared_folder_id:
+        ID of shared folder that holds this file.
+    :ivar FileSharingInfo.modified_by:
+        The last user who modified the file. This field will be null if the
+        user's account has been deleted.
     """
 
     __slots__ = [
@@ -2746,15 +2804,18 @@ FileStatus_validator = bv.Union(FileStatus)
 
 class FolderMetadata(Metadata):
     """
-    :ivar files.FolderMetadata.id: A unique identifier for the folder.
-    :ivar files.FolderMetadata.shared_folder_id: Field is deprecated. Please use
-        ``sharing_info`` instead.
-    :ivar files.FolderMetadata.sharing_info: Set if the folder is contained in a
-        shared folder or is a shared folder mount point.
-    :ivar files.FolderMetadata.property_groups: Additional information if the
-        file has custom properties with the property template specified. Note
-        that only properties associated with user-owned templates, not
-        team-owned templates, can be attached to folders.
+    :ivar FolderMetadata.id:
+        A unique identifier for the folder.
+    :ivar FolderMetadata.shared_folder_id:
+        Field is deprecated. Please use ``sharing_info`` instead.
+    :ivar FolderMetadata.sharing_info:
+        Set if the folder is contained in a shared folder or is a shared folder
+        mount point.
+    :ivar FolderMetadata.property_groups:
+        Additional information if the file has custom properties with the
+        property template specified. Note that only properties associated with
+        user-owned templates, not team-owned templates, can be attached to
+        folders.
     """
 
     __slots__ = [
@@ -2816,17 +2877,18 @@ class FolderSharingInfo(SharingInfo):
     Sharing info for a folder which is contained in a shared folder or is a
     shared folder mount point.
 
-    :ivar files.FolderSharingInfo.parent_shared_folder_id: Set if the folder is
-        contained by a shared folder.
-    :ivar files.FolderSharingInfo.shared_folder_id: If this folder is a shared
-        folder mount point, the ID of the shared folder mounted at this
-        location.
-    :ivar files.FolderSharingInfo.traverse_only: Specifies that the folder can
-        only be traversed and the user can only see a limited subset of the
-        contents of this folder because they don't have read access to this
-        folder. They do, however, have access to some sub folder.
-    :ivar files.FolderSharingInfo.no_access: Specifies that the folder cannot be
-        accessed by the user.
+    :ivar FolderSharingInfo.parent_shared_folder_id:
+        Set if the folder is contained by a shared folder.
+    :ivar FolderSharingInfo.shared_folder_id:
+        If this folder is a shared folder mount point, the ID of the shared
+        folder mounted at this location.
+    :ivar FolderSharingInfo.traverse_only:
+        Specifies that the folder can only be traversed and the user can only
+        see a limited subset of the contents of this folder because they don't
+        have read access to this folder. They do, however, have access to some
+        sub folder.
+    :ivar FolderSharingInfo.no_access:
+        Specifies that the folder cannot be accessed by the user.
     """
 
     __slots__ = [
@@ -2877,8 +2939,8 @@ FolderSharingInfo_validator = bv.Struct(FolderSharingInfo)
 
 class GetCopyReferenceArg(bb.Struct):
     """
-    :ivar files.GetCopyReferenceArg.path: The path to the file or folder you
-        want to get a copy reference to.
+    :ivar GetCopyReferenceArg.path:
+        The path to the file or folder you want to get a copy reference to.
     """
 
     __slots__ = [
@@ -2956,12 +3018,14 @@ GetCopyReferenceError_validator = bv.Union(GetCopyReferenceError)
 
 class GetCopyReferenceResult(bb.Struct):
     """
-    :ivar files.GetCopyReferenceResult.metadata: Metadata of the file or folder.
-    :ivar files.GetCopyReferenceResult.copy_reference: A copy reference to the
-        file or folder.
-    :ivar files.GetCopyReferenceResult.expires: The expiration date of the copy
-        reference. This value is currently set to be far enough in the future so
-        that expiration is effectively not an issue.
+    :ivar GetCopyReferenceResult.metadata:
+        Metadata of the file or folder.
+    :ivar GetCopyReferenceResult.copy_reference:
+        A copy reference to the file or folder.
+    :ivar GetCopyReferenceResult.expires:
+        The expiration date of the copy reference. This value is currently set
+        to be far enough in the future so that expiration is effectively not an
+        issue.
     """
 
     __slots__ = [
@@ -3002,7 +3066,8 @@ GetCopyReferenceResult_validator = bv.Struct(GetCopyReferenceResult)
 
 class GetTagsArg(bb.Struct):
     """
-    :ivar files.GetTagsArg.paths: Path to the items.
+    :ivar GetTagsArg.paths:
+        Path to the items.
     """
 
     __slots__ = [
@@ -3027,8 +3092,8 @@ GetTagsArg_validator = bv.Struct(GetTagsArg)
 
 class GetTagsResult(bb.Struct):
     """
-    :ivar files.GetTagsResult.paths_to_tags: List of paths and their
-        corresponding tags.
+    :ivar GetTagsResult.paths_to_tags:
+        List of paths and their corresponding tags.
     """
 
     __slots__ = [
@@ -3053,8 +3118,8 @@ GetTagsResult_validator = bv.Struct(GetTagsResult)
 
 class GetTemporaryLinkArg(bb.Struct):
     """
-    :ivar files.GetTemporaryLinkArg.path: The path to the file you want a
-        temporary link to.
+    :ivar GetTemporaryLinkArg.path:
+        The path to the file you want a temporary link to.
     """
 
     __slots__ = [
@@ -3083,16 +3148,17 @@ class GetTemporaryLinkError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.GetTemporaryLinkError.email_not_verified: This user's email
-        address is not verified. This functionality is only available on
-        accounts with a verified email address. Users can verify their email
-        address `here <https://www.dropbox.com/help/317>`_.
-    :ivar files.GetTemporaryLinkError.unsupported_file: Cannot get temporary
-        link to this file type; use
+    :ivar GetTemporaryLinkError.email_not_verified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
+    :ivar GetTemporaryLinkError.unsupported_file:
+        Cannot get temporary link to this file type; use
         :meth:`dropbox.dropbox_client.Dropbox.files_export` instead.
-    :ivar files.GetTemporaryLinkError.not_allowed: The user is not allowed to
-        request a temporary link to the specified file. For example, this can
-        occur if the file is restricted or if the user's links are `banned
+    :ivar GetTemporaryLinkError.not_allowed:
+        The user is not allowed to request a temporary link to the specified
+        file. For example, this can occur if the file is restricted or if the
+        user's links are `banned
         <https://help.dropbox.com/files-folders/share/banned-links>`_.
     """
 
@@ -3174,9 +3240,10 @@ GetTemporaryLinkError_validator = bv.Union(GetTemporaryLinkError)
 
 class GetTemporaryLinkResult(bb.Struct):
     """
-    :ivar files.GetTemporaryLinkResult.metadata: Metadata of the file.
-    :ivar files.GetTemporaryLinkResult.link: The temporary link which can be
-        used to stream content the file.
+    :ivar GetTemporaryLinkResult.metadata:
+        Metadata of the file.
+    :ivar GetTemporaryLinkResult.link:
+        The temporary link which can be used to stream content the file.
     """
 
     __slots__ = [
@@ -3209,13 +3276,14 @@ GetTemporaryLinkResult_validator = bv.Struct(GetTemporaryLinkResult)
 
 class GetTemporaryUploadLinkArg(bb.Struct):
     """
-    :ivar files.GetTemporaryUploadLinkArg.commit_info: Contains the path and
-        other optional modifiers for the future upload commit. Equivalent to the
-        parameters provided to
+    :ivar GetTemporaryUploadLinkArg.commit_info:
+        Contains the path and other optional modifiers for the future upload
+        commit. Equivalent to the parameters provided to
         :meth:`dropbox.dropbox_client.Dropbox.files_upload`.
-    :ivar files.GetTemporaryUploadLinkArg.duration: How long before this link
-        expires, in seconds. Attempting to start an upload with this link longer
-        than this period of time after link creation will result in an error.
+    :ivar GetTemporaryUploadLinkArg.duration:
+        How long before this link expires, in seconds. Attempting to start an
+        upload with this link longer than this period of time after link
+        creation will result in an error.
     """
 
     __slots__ = [
@@ -3248,8 +3316,9 @@ GetTemporaryUploadLinkArg_validator = bv.Struct(GetTemporaryUploadLinkArg)
 
 class GetTemporaryUploadLinkResult(bb.Struct):
     """
-    :ivar files.GetTemporaryUploadLinkResult.link: The temporary link which can
-        be used to stream a file to a Dropbox location.
+    :ivar GetTemporaryUploadLinkResult.link:
+        The temporary link which can be used to stream a file to a Dropbox
+        location.
     """
 
     __slots__ = [
@@ -3277,7 +3346,8 @@ class GetThumbnailBatchArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.files_get_thumbnail_batch`.
 
-    :ivar files.GetThumbnailBatchArg.entries: List of files to get thumbnails.
+    :ivar GetThumbnailBatchArg.entries:
+        List of files to get thumbnails.
     """
 
     __slots__ = [
@@ -3306,8 +3376,8 @@ class GetThumbnailBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.GetThumbnailBatchError.too_many_files: The operation involves
-        more than 25 files.
+    :ivar GetThumbnailBatchError.too_many_files:
+        The operation involves more than 25 files.
     """
 
     _catch_all = 'other'
@@ -3339,8 +3409,8 @@ GetThumbnailBatchError_validator = bv.Union(GetThumbnailBatchError)
 
 class GetThumbnailBatchResult(bb.Struct):
     """
-    :ivar files.GetThumbnailBatchResult.entries: List of files and their
-        thumbnails.
+    :ivar GetThumbnailBatchResult.entries:
+        List of files and their thumbnails.
     """
 
     __slots__ = [
@@ -3365,8 +3435,8 @@ GetThumbnailBatchResult_validator = bv.Struct(GetThumbnailBatchResult)
 
 class GetThumbnailBatchResultData(bb.Struct):
     """
-    :ivar files.GetThumbnailBatchResultData.thumbnail: A string containing the
-        base64-encoded thumbnail data for this file.
+    :ivar GetThumbnailBatchResultData.thumbnail:
+        A string containing the base64-encoded thumbnail data for this file.
     """
 
     __slots__ = [
@@ -3403,8 +3473,9 @@ class GetThumbnailBatchResultEntry(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar ThumbnailError GetThumbnailBatchResultEntry.failure: The result for
-        this file if it was an error.
+    :ivar GetThumbnailBatchResultEntry.failure:
+        The result for this file if it was an error.
+    :vartype GetThumbnailBatchResultEntry.failure: ThumbnailError
     """
 
     _catch_all = 'other'
@@ -3488,8 +3559,10 @@ class GpsCoordinates(bb.Struct):
     """
     GPS coordinates for a photo or video.
 
-    :ivar files.GpsCoordinates.latitude: Latitude of the GPS coordinates.
-    :ivar files.GpsCoordinates.longitude: Longitude of the GPS coordinates.
+    :ivar GpsCoordinates.latitude:
+        Latitude of the GPS coordinates.
+    :ivar GpsCoordinates.longitude:
+        Longitude of the GPS coordinates.
     """
 
     __slots__ = [
@@ -3522,10 +3595,10 @@ GpsCoordinates_validator = bv.Struct(GpsCoordinates)
 
 class HighlightSpan(bb.Struct):
     """
-    :ivar files.HighlightSpan.highlight_str: String to be determined whether it
-        should be highlighted or not.
-    :ivar files.HighlightSpan.is_highlighted: The string should be highlighted
-        or not.
+    :ivar HighlightSpan.highlight_str:
+        String to be determined whether it should be highlighted or not.
+    :ivar HighlightSpan.is_highlighted:
+        The string should be highlighted or not.
     """
 
     __slots__ = [
@@ -3564,12 +3637,12 @@ class ImportFormat(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ImportFormat.html: The provided data is interpreted as standard
-        HTML.
-    :ivar files.ImportFormat.markdown: The provided data is interpreted as
-        markdown.
-    :ivar files.ImportFormat.plain_text: The provided data is interpreted as
-        plain text.
+    :ivar ImportFormat.html:
+        The provided data is interpreted as standard HTML.
+    :ivar ImportFormat.markdown:
+        The provided data is interpreted as markdown.
+    :ivar ImportFormat.plain_text:
+        The provided data is interpreted as plain text.
     """
 
     _catch_all = 'other'
@@ -3621,41 +3694,47 @@ ImportFormat_validator = bv.Union(ImportFormat)
 
 class ListFolderArg(bb.Struct):
     """
-    :ivar files.ListFolderArg.path: A unique identifier for the file.
-    :ivar files.ListFolderArg.recursive: If true, the list folder operation will
-        be applied recursively to all subfolders and the response will contain
-        contents of all subfolders. In some cases, setting
-        ``ListFolderArg.recursive`` to ``True`` may lead to performance issues
-        or errors, especially when traversing folder structures with a large
-        number of items. A workaround for such cases is to set
-        ``ListFolderArg.recursive`` to ``False`` and traverse subfolders one at
-        a time.
-    :ivar files.ListFolderArg.include_media_info: Field is deprecated. If true,
-        ``FileMetadata.media_info`` is set for photo and video. This parameter
-        will no longer have an effect starting December 2, 2019.
-    :ivar files.ListFolderArg.include_deleted: If true, the results will include
-        entries for files and folders that used to exist but were deleted.
-    :ivar files.ListFolderArg.include_has_explicit_shared_members: If true, the
-        results will include a flag for each file indicating whether or not that
-        file has any explicit members.
-    :ivar files.ListFolderArg.include_mounted_folders: If true, the results will
-        include entries under mounted folders which includes app folder, shared
-        folder and team folder.
-    :ivar files.ListFolderArg.limit: The maximum number of results to return per
-        request. Note: This is an approximate number and there can be slightly
-        more entries returned in some cases.
-    :ivar files.ListFolderArg.shared_link: A shared link to list the contents
-        of. If the link is password-protected, the password must be provided. If
-        this field is present, ``ListFolderArg.path`` will be relative to root
-        of the shared link. Only non-recursive mode is supported for shared
-        link.
-    :ivar files.ListFolderArg.include_property_groups: If set to a valid list of
-        template IDs, ``FileMetadata.property_groups`` is set if there exists
-        property data associated with the file and each of the listed templates.
-    :ivar files.ListFolderArg.include_non_downloadable_files: If true, include
-        files that are not downloadable, i.e. Google Docs.
-    :ivar files.ListFolderArg.include_restorable_info: If true, each returned
-        deleted entry will include whether that entry can be restored.
+    :ivar ListFolderArg.path:
+        A unique identifier for the file.
+    :ivar ListFolderArg.recursive:
+        If true, the list folder operation will be applied recursively to all
+        subfolders and the response will contain contents of all subfolders. In
+        some cases, setting ``ListFolderArg.recursive`` to ``True`` may lead to
+        performance issues or errors, especially when traversing folder
+        structures with a large number of items. A workaround for such cases is
+        to set ``ListFolderArg.recursive`` to ``False`` and traverse subfolders
+        one at a time.
+    :ivar ListFolderArg.include_media_info:
+        Field is deprecated. If true, ``FileMetadata.media_info`` is set for
+        photo and video. This parameter will no longer have an effect starting
+        December 2, 2019.
+    :ivar ListFolderArg.include_deleted:
+        If true, the results will include entries for files and folders that
+        used to exist but were deleted.
+    :ivar ListFolderArg.include_has_explicit_shared_members:
+        If true, the results will include a flag for each file indicating
+        whether or not that file has any explicit members.
+    :ivar ListFolderArg.include_mounted_folders:
+        If true, the results will include entries under mounted folders which
+        includes app folder, shared folder and team folder.
+    :ivar ListFolderArg.limit:
+        The maximum number of results to return per request. Note: This is an
+        approximate number and there can be slightly more entries returned in
+        some cases.
+    :ivar ListFolderArg.shared_link:
+        A shared link to list the contents of. If the link is
+        password-protected, the password must be provided. If this field is
+        present, ``ListFolderArg.path`` will be relative to root of the shared
+        link. Only non-recursive mode is supported for shared link.
+    :ivar ListFolderArg.include_property_groups:
+        If set to a valid list of template IDs, ``FileMetadata.property_groups``
+        is set if there exists property data associated with the file and each
+        of the listed templates.
+    :ivar ListFolderArg.include_non_downloadable_files:
+        If true, include files that are not downloadable, i.e. Google Docs.
+    :ivar ListFolderArg.include_restorable_info:
+        If true, each returned deleted entry will include whether that entry can
+        be restored.
     """
 
     __slots__ = [
@@ -3760,8 +3839,9 @@ ListFolderArg_validator = bv.Struct(ListFolderArg)
 
 class ListFolderContinueArg(bb.Struct):
     """
-    :ivar files.ListFolderContinueArg.cursor: The cursor returned by your last
-        call to :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` or
+    :ivar ListFolderContinueArg.cursor:
+        The cursor returned by your last call to
+        :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` or
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue`.
     """
 
@@ -3791,8 +3871,8 @@ class ListFolderContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ListFolderContinueError.reset: Indicates that the cursor has
-        been invalidated. Call
+    :ivar ListFolderContinueError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` to obtain a new
         cursor.
     """
@@ -3937,7 +4017,8 @@ ListFolderError_validator = bv.Union(ListFolderError)
 
 class ListFolderGetLatestCursorResult(bb.Struct):
     """
-    :ivar files.ListFolderGetLatestCursorResult.cursor: Pass the cursor into
+    :ivar ListFolderGetLatestCursorResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue` to see
         what's changed in the folder since your previous query.
     """
@@ -3964,16 +4045,17 @@ ListFolderGetLatestCursorResult_validator = bv.Struct(ListFolderGetLatestCursorR
 
 class ListFolderLongpollArg(bb.Struct):
     """
-    :ivar files.ListFolderLongpollArg.cursor: A cursor as returned by
+    :ivar ListFolderLongpollArg.cursor:
+        A cursor as returned by
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` or
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue`.
         Cursors retrieved by setting ``ListFolderArg.include_media_info`` to
         ``True`` are not supported.
-    :ivar files.ListFolderLongpollArg.timeout: A timeout in seconds. The request
-        will block for at most this length of time, plus up to 90 seconds of
-        random jitter added to avoid the thundering herd problem. Care should be
-        taken when using this parameter, as some network infrastructure does not
-        support long timeouts.
+    :ivar ListFolderLongpollArg.timeout:
+        A timeout in seconds. The request will block for at most this length of
+        time, plus up to 90 seconds of random jitter added to avoid the
+        thundering herd problem. Care should be taken when using this parameter,
+        as some network infrastructure does not support long timeouts.
     """
 
     __slots__ = [
@@ -4010,8 +4092,8 @@ class ListFolderLongpollError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ListFolderLongpollError.reset: Indicates that the cursor has
-        been invalidated. Call
+    :ivar ListFolderLongpollError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder` to obtain a new
         cursor.
     """
@@ -4045,12 +4127,12 @@ ListFolderLongpollError_validator = bv.Union(ListFolderLongpollError)
 
 class ListFolderLongpollResult(bb.Struct):
     """
-    :ivar files.ListFolderLongpollResult.changes: Indicates whether new changes
-        are available. If true, call
+    :ivar ListFolderLongpollResult.changes:
+        Indicates whether new changes are available. If true, call
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue` to
         retrieve the changes.
-    :ivar files.ListFolderLongpollResult.backoff: If present, backoff for at
-        least this many seconds before calling
+    :ivar ListFolderLongpollResult.backoff:
+        If present, backoff for at least this many seconds before calling
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_longpoll` again.
     """
 
@@ -4084,13 +4166,14 @@ ListFolderLongpollResult_validator = bv.Struct(ListFolderLongpollResult)
 
 class ListFolderResult(bb.Struct):
     """
-    :ivar files.ListFolderResult.entries: The files and (direct) subfolders in
-        the folder.
-    :ivar files.ListFolderResult.cursor: Pass the cursor into
+    :ivar ListFolderResult.entries:
+        The files and (direct) subfolders in the folder.
+    :ivar ListFolderResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue` to see
         what's changed in the folder since your previous query.
-    :ivar files.ListFolderResult.has_more: If true, then there are more entries
-        available. Pass the cursor to
+    :ivar ListFolderResult.has_more:
+        If true, then there are more entries available. Pass the cursor to
         :meth:`dropbox.dropbox_client.Dropbox.files_list_folder_continue` to
         retrieve the rest.
     """
@@ -4133,18 +4216,21 @@ ListFolderResult_validator = bv.Struct(ListFolderResult)
 
 class ListRevisionsArg(bb.Struct):
     """
-    :ivar files.ListRevisionsArg.path: The path to the file you want to see the
-        revisions of.
-    :ivar files.ListRevisionsArg.mode: Determines the behavior of the API in
-        listing the revisions for a given file path or id.
-    :ivar files.ListRevisionsArg.limit: The maximum number of revision entries
-        returned.
-    :ivar files.ListRevisionsArg.before_rev: If set, ListRevisions will only
-        return revisions prior to before_rev. Can be set using the last revision
-        from a previous call to list_revisions to fetch the next page of
-        revisions. Only supported in path mode.
-    :ivar files.ListRevisionsArg.include_restorable_info: If true, each returned
-        revision will include whether that revision can be restored.
+    :ivar ListRevisionsArg.path:
+        The path to the file you want to see the revisions of.
+    :ivar ListRevisionsArg.mode:
+        Determines the behavior of the API in listing the revisions for a given
+        file path or id.
+    :ivar ListRevisionsArg.limit:
+        The maximum number of revision entries returned.
+    :ivar ListRevisionsArg.before_rev:
+        If set, ListRevisions will only return revisions prior to before_rev.
+        Can be set using the last revision from a previous call to
+        list_revisions to fetch the next page of revisions. Only supported in
+        path mode.
+    :ivar ListRevisionsArg.include_restorable_info:
+        If true, each returned revision will include whether that revision can
+        be restored.
     """
 
     __slots__ = [
@@ -4205,10 +4291,10 @@ class ListRevisionsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ListRevisionsError.invalid_before_rev: The revision in
-        before_rev is invalid.
-    :ivar files.ListRevisionsError.before_rev_not_supported: The before_rev
-        argument is only supported in path mode.
+    :ivar ListRevisionsError.invalid_before_rev:
+        The revision in before_rev is invalid.
+    :ivar ListRevisionsError.before_rev_not_supported:
+        The before_rev argument is only supported in path mode.
     """
 
     _catch_all = 'other'
@@ -4283,11 +4369,12 @@ class ListRevisionsMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ListRevisionsMode.path: Returns revisions with the same file
-        path as identified by the latest file entry at the given file path or
-        id.
-    :ivar files.ListRevisionsMode.id: Returns revisions with the same file id as
-        identified by the latest file entry at the given file path or id.
+    :ivar ListRevisionsMode.path:
+        Returns revisions with the same file path as identified by the latest
+        file entry at the given file path or id.
+    :ivar ListRevisionsMode.id:
+        Returns revisions with the same file id as identified by the latest file
+        entry at the given file path or id.
     """
 
     _catch_all = 'other'
@@ -4329,17 +4416,19 @@ ListRevisionsMode_validator = bv.Union(ListRevisionsMode)
 
 class ListRevisionsResult(bb.Struct):
     """
-    :ivar files.ListRevisionsResult.is_deleted: If the file identified by the
-        latest revision in the response is either deleted or moved. If
-        before_rev is set, this refers to the latest revision of the file older
-        than before_rev.
-    :ivar files.ListRevisionsResult.server_deleted: The time of deletion if the
-        file was deleted.
-    :ivar files.ListRevisionsResult.entries: The revisions for the file. Only
-        revisions that are not deleted will show up here.
-    :ivar files.ListRevisionsResult.has_more: If true, then there are more
-        entries available. Call list_revisions again with before_rev equal to
-        the revision of the last returned entry to retrieve the rest.
+    :ivar ListRevisionsResult.is_deleted:
+        If the file identified by the latest revision in the response is either
+        deleted or moved. If before_rev is set, this refers to the latest
+        revision of the file older than before_rev.
+    :ivar ListRevisionsResult.server_deleted:
+        The time of deletion if the file was deleted.
+    :ivar ListRevisionsResult.entries:
+        The revisions for the file. Only revisions that are not deleted will
+        show up here.
+    :ivar ListRevisionsResult.has_more:
+        If true, then there are more entries available. Call list_revisions
+        again with before_rev equal to the revision of the last returned entry
+        to retrieve the rest.
     """
 
     __slots__ = [
@@ -4388,7 +4477,8 @@ ListRevisionsResult_validator = bv.Struct(ListRevisionsResult)
 
 class LockConflictError(bb.Struct):
     """
-    :ivar files.LockConflictError.lock: The lock that caused the conflict.
+    :ivar LockConflictError.lock:
+        The lock that caused the conflict.
     """
 
     __slots__ = [
@@ -4413,7 +4503,8 @@ LockConflictError_validator = bv.Struct(LockConflictError)
 
 class LockFileArg(bb.Struct):
     """
-    :ivar files.LockFileArg.path: Path in the user's Dropbox to a file.
+    :ivar LockFileArg.path:
+        Path in the user's Dropbox to a file.
     """
 
     __slots__ = [
@@ -4438,9 +4529,10 @@ LockFileArg_validator = bv.Struct(LockFileArg)
 
 class LockFileBatchArg(bb.Struct):
     """
-    :ivar files.LockFileBatchArg.entries: List of 'entries'. Each 'entry'
-        contains a path of the file which will be locked or queried. Duplicate
-        path arguments in the batch are considered only once.
+    :ivar LockFileBatchArg.entries:
+        List of 'entries'. Each 'entry' contains a path of the file which will
+        be locked or queried. Duplicate path arguments in the batch are
+        considered only once.
     """
 
     __slots__ = [
@@ -4465,9 +4557,10 @@ LockFileBatchArg_validator = bv.Struct(LockFileBatchArg)
 
 class LockFileBatchResult(FileOpsResult):
     """
-    :ivar files.LockFileBatchResult.entries: Each Entry in the 'entries' will
-        have '.tag' with the operation status (e.g. success), the metadata for
-        the file and the lock state after the operation.
+    :ivar LockFileBatchResult.entries:
+        Each Entry in the 'entries' will have '.tag' with the operation status
+        (e.g. success), the metadata for the file and the lock state after the
+        operation.
     """
 
     __slots__ = [
@@ -4497,23 +4590,28 @@ class LockFileError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar LookupError LockFileError.path_lookup: Could not find the specified
-        resource.
-    :ivar files.LockFileError.too_many_write_operations: There are too many
-        write operations in user's Dropbox. Please retry this request.
-    :ivar files.LockFileError.too_many_files: There are too many files in one
-        request. Please retry with fewer files.
-    :ivar files.LockFileError.no_write_permission: The user does not have
-        permissions to change the lock state or access the file.
-    :ivar files.LockFileError.cannot_be_locked: Item is a type that cannot be
-        locked.
-    :ivar files.LockFileError.file_not_shared: Requested file is not currently
-        shared.
-    :ivar LockConflictError LockFileError.lock_conflict: The user action
-        conflicts with an existing lock on the file.
-    :ivar files.LockFileError.internal_error: Something went wrong with the job
-        on Dropbox's end. You'll need to verify that the action you were taking
-        succeeded, and if not, try again. This should happen very rarely.
+    :ivar LockFileError.path_lookup:
+        Could not find the specified resource.
+    :vartype LockFileError.path_lookup: LookupError
+    :ivar LockFileError.too_many_write_operations:
+        There are too many write operations in user's Dropbox. Please retry this
+        request.
+    :ivar LockFileError.too_many_files:
+        There are too many files in one request. Please retry with fewer files.
+    :ivar LockFileError.no_write_permission:
+        The user does not have permissions to change the lock state or access
+        the file.
+    :ivar LockFileError.cannot_be_locked:
+        Item is a type that cannot be locked.
+    :ivar LockFileError.file_not_shared:
+        Requested file is not currently shared.
+    :ivar LockFileError.lock_conflict:
+        The user action conflicts with an existing lock on the file.
+    :vartype LockFileError.lock_conflict: LockConflictError
+    :ivar LockFileError.internal_error:
+        Something went wrong with the job on Dropbox's end. You'll need to
+        verify that the action you were taking succeeded, and if not, try again.
+        This should happen very rarely.
     """
 
     _catch_all = 'other'
@@ -4657,9 +4755,10 @@ LockFileError_validator = bv.Union(LockFileError)
 
 class LockFileResult(bb.Struct):
     """
-    :ivar files.LockFileResult.metadata: Metadata of the file.
-    :ivar files.LockFileResult.lock: Field is deprecated. The file lock state
-        after the operation.
+    :ivar LockFileResult.metadata:
+        Metadata of the file.
+    :ivar LockFileResult.lock:
+        Field is deprecated. The file lock state after the operation.
     """
 
     __slots__ = [
@@ -4768,22 +4867,27 @@ class LookupError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar Optional[str] files.LookupError.malformed_path: The given path does
-        not satisfy the required path format. Please refer to the :link:`Path
-        formats documentation
-        https://www.dropbox.com/developers/documentation/http/documentation#path-formats`
+    :ivar LookupError.malformed_path:
+        The given path does not satisfy the required path format. Please refer
+        to the `Path formats documentation
+        <https://www.dropbox.com/developers/documentation/http/documentation#path-formats>`_
         for more information.
-    :ivar files.LookupError.not_found: There is nothing at the given path.
-    :ivar files.LookupError.not_file: We were expecting a file, but the given
-        path refers to something that isn't a file.
-    :ivar files.LookupError.not_folder: We were expecting a folder, but the
-        given path refers to something that isn't a folder.
-    :ivar files.LookupError.restricted_content: The file cannot be transferred
-        because the content is restricted. For example, we might restrict a file
-        due to legal requirements.
-    :ivar files.LookupError.unsupported_content_type: This operation is not
-        supported for this content type.
-    :ivar files.LookupError.locked: The given path is locked.
+    :vartype LookupError.malformed_path: Optional[str]
+    :ivar LookupError.not_found:
+        There is nothing at the given path.
+    :ivar LookupError.not_file:
+        We were expecting a file, but the given path refers to something that
+        isn't a file.
+    :ivar LookupError.not_folder:
+        We were expecting a folder, but the given path refers to something that
+        isn't a folder.
+    :ivar LookupError.restricted_content:
+        The file cannot be transferred because the content is restricted. For
+        example, we might restrict a file due to legal requirements.
+    :ivar LookupError.unsupported_content_type:
+        This operation is not supported for this content type.
+    :ivar LookupError.locked:
+        The given path is locked.
     """
 
     _catch_all = 'other'
@@ -4903,11 +5007,13 @@ class MediaInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.MediaInfo.pending: Indicate the photo/video is still under
-        processing and metadata is not available yet.
-    :ivar MediaMetadata MediaInfo.metadata: The metadata for the photo/video.
-        Uses MediaMetadataAbstract to preserve photo/video subtypes (e.g.
-        VideoMetadata.duration).
+    :ivar MediaInfo.pending:
+        Indicate the photo/video is still under processing and metadata is not
+        available yet.
+    :ivar MediaInfo.metadata:
+        The metadata for the photo/video. Uses MediaMetadataAbstract to preserve
+        photo/video subtypes (e.g. VideoMetadata.duration).
+    :vartype MediaInfo.metadata: MediaMetadata
     """
 
     _catch_all = None
@@ -4963,10 +5069,12 @@ class MediaMetadata(bb.Struct):
     """
     Metadata for a photo or video.
 
-    :ivar files.MediaMetadata.dimensions: Dimension of the photo/video.
-    :ivar files.MediaMetadata.location: The GPS coordinate of the photo/video.
-    :ivar files.MediaMetadata.time_taken: The timestamp when the photo/video is
-        taken.
+    :ivar MediaMetadata.dimensions:
+        Dimension of the photo/video.
+    :ivar MediaMetadata.location:
+        The GPS coordinate of the photo/video.
+    :ivar MediaMetadata.time_taken:
+        The timestamp when the photo/video is taken.
     """
 
     __slots__ = [
@@ -5062,15 +5170,18 @@ MetadataV2_validator = bv.Union(MetadataV2)
 
 class MinimalFileLinkMetadata(bb.Struct):
     """
-    :ivar files.MinimalFileLinkMetadata.url: URL of the shared link.
-    :ivar files.MinimalFileLinkMetadata.id: Unique identifier for the linked
-        file.
-    :ivar files.MinimalFileLinkMetadata.path: Full path in the user's Dropbox.
-        This always starts with a slash. This field will only be present only if
-        the linked file is in the authenticated user's Dropbox.
-    :ivar files.MinimalFileLinkMetadata.rev: A unique identifier for the current
-        revision of a file. This field is the same rev as elsewhere in the API
-        and can be used to detect changes and avoid conflicts.
+    :ivar MinimalFileLinkMetadata.url:
+        URL of the shared link.
+    :ivar MinimalFileLinkMetadata.id:
+        Unique identifier for the linked file.
+    :ivar MinimalFileLinkMetadata.path:
+        Full path in the user's Dropbox. This always starts with a slash. This
+        field will only be present only if the linked file is in the
+        authenticated user's Dropbox.
+    :ivar MinimalFileLinkMetadata.rev:
+        A unique identifier for the current revision of a file. This field is
+        the same rev as elsewhere in the API and can be used to detect changes
+        and avoid conflicts.
     """
 
     __slots__ = [
@@ -5119,11 +5230,12 @@ MinimalFileLinkMetadata_validator = bv.Struct(MinimalFileLinkMetadata)
 
 class RelocationBatchArgBase(bb.Struct):
     """
-    :ivar files.RelocationBatchArgBase.entries: List of entries to be moved or
-        copied. Each entry is :class:`RelocationPath`.
-    :ivar files.RelocationBatchArgBase.autorename: If there's a conflict with
-        any file, have the Dropbox server try to autorename that file to avoid
-        the conflict.
+    :ivar RelocationBatchArgBase.entries:
+        List of entries to be moved or copied. Each entry is
+        :class:`RelocationPath`.
+    :ivar RelocationBatchArgBase.autorename:
+        If there's a conflict with any file, have the Dropbox server try to
+        autorename that file to avoid the conflict.
     """
 
     __slots__ = [
@@ -5156,9 +5268,9 @@ RelocationBatchArgBase_validator = bv.Struct(RelocationBatchArgBase)
 
 class MoveBatchArg(RelocationBatchArgBase):
     """
-    :ivar files.MoveBatchArg.allow_ownership_transfer: Allow moves by owner even
-        if it would result in an ownership transfer for the content being moved.
-        This does not apply to copies.
+    :ivar MoveBatchArg.allow_ownership_transfer:
+        Allow moves by owner even if it would result in an ownership transfer
+        for the content being moved. This does not apply to copies.
     """
 
     __slots__ = [
@@ -5191,8 +5303,8 @@ class MoveIntoFamilyError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.MoveIntoFamilyError.is_shared_folder: Moving shared folder into
-        Family Room folder is not allowed.
+    :ivar MoveIntoFamilyError.is_shared_folder:
+        Moving shared folder into Family Room folder is not allowed.
     """
 
     _catch_all = 'other'
@@ -5228,8 +5340,8 @@ class MoveIntoVaultError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.MoveIntoVaultError.is_shared_folder: Moving shared folder into
-        Vault is not allowed.
+    :ivar MoveIntoVaultError.is_shared_folder:
+        Moving shared folder into Vault is not allowed.
     """
 
     _catch_all = 'other'
@@ -5265,15 +5377,15 @@ class PaperContentError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.PaperContentError.insufficient_permissions: Your account does
-        not have permissions to edit Paper docs.
-    :ivar files.PaperContentError.content_malformed: The provided content was
-        malformed and cannot be imported to Paper.
-    :ivar files.PaperContentError.doc_length_exceeded: The Paper doc would be
-        too large, split the content into multiple docs.
-    :ivar files.PaperContentError.image_size_exceeded: The imported document
-        contains an image that is too large. The current limit is 1MB. This only
-        applies to HTML with data URI.
+    :ivar PaperContentError.insufficient_permissions:
+        Your account does not have permissions to edit Paper docs.
+    :ivar PaperContentError.content_malformed:
+        The provided content was malformed and cannot be imported to Paper.
+    :ivar PaperContentError.doc_length_exceeded:
+        The Paper doc would be too large, split the content into multiple docs.
+    :ivar PaperContentError.image_size_exceeded:
+        The imported document contains an image that is too large. The current
+        limit is 1MB. This only applies to HTML with data URI.
     """
 
     _catch_all = 'other'
@@ -5335,10 +5447,12 @@ PaperContentError_validator = bv.Union(PaperContentError)
 
 class PaperCreateArg(bb.Struct):
     """
-    :ivar files.PaperCreateArg.path: The fully qualified path to the location in
-        the user's Dropbox where the Paper Doc should be created. This should
-        include the document's title and end with .paper.
-    :ivar files.PaperCreateArg.import_format: The format of the provided data.
+    :ivar PaperCreateArg.path:
+        The fully qualified path to the location in the user's Dropbox where the
+        Paper Doc should be created. This should include the document's title
+        and end with .paper.
+    :ivar PaperCreateArg.import_format:
+        The format of the provided data.
     """
 
     __slots__ = [
@@ -5375,14 +5489,14 @@ class PaperCreateError(PaperContentError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.PaperCreateError.invalid_path: The file could not be saved to
-        the specified location.
-    :ivar files.PaperCreateError.email_unverified: The user's email must be
-        verified to create Paper docs.
-    :ivar files.PaperCreateError.invalid_file_extension: The file path must end
-        in .paper.
-    :ivar files.PaperCreateError.paper_disabled: Paper is disabled for your
-        team.
+    :ivar PaperCreateError.invalid_path:
+        The file could not be saved to the specified location.
+    :ivar PaperCreateError.email_unverified:
+        The user's email must be verified to create Paper docs.
+    :ivar PaperCreateError.invalid_file_extension:
+        The file path must end in .paper.
+    :ivar PaperCreateError.paper_disabled:
+        Paper is disabled for your team.
     """
 
     # Attribute is overwritten below the class definition
@@ -5433,12 +5547,14 @@ PaperCreateError_validator = bv.Union(PaperCreateError)
 
 class PaperCreateResult(bb.Struct):
     """
-    :ivar files.PaperCreateResult.url: URL to open the Paper Doc.
-    :ivar files.PaperCreateResult.result_path: The fully qualified path the
-        Paper Doc was actually created at.
-    :ivar files.PaperCreateResult.file_id: The id to use in Dropbox APIs when
-        referencing the Paper Doc.
-    :ivar files.PaperCreateResult.paper_revision: The current doc revision.
+    :ivar PaperCreateResult.url:
+        URL to open the Paper Doc.
+    :ivar PaperCreateResult.result_path:
+        The fully qualified path the Paper Doc was actually created at.
+    :ivar PaperCreateResult.file_id:
+        The id to use in Dropbox APIs when referencing the Paper Doc.
+    :ivar PaperCreateResult.paper_revision:
+        The current doc revision.
     """
 
     __slots__ = [
@@ -5491,15 +5607,19 @@ class PaperDocUpdatePolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.PaperDocUpdatePolicy.update: Sets the doc content to the
-        provided content if the provided paper_revision matches the latest doc
-        revision. Otherwise, returns an error.
-    :ivar files.PaperDocUpdatePolicy.overwrite: Sets the doc content to the
-        provided content without checking paper_revision.
-    :ivar files.PaperDocUpdatePolicy.prepend: Adds the provided content to the
-        beginning of the doc without checking paper_revision.
-    :ivar files.PaperDocUpdatePolicy.append: Adds the provided content to the
-        end of the doc without checking paper_revision.
+    :ivar PaperDocUpdatePolicy.update:
+        Sets the doc content to the provided content if the provided
+        paper_revision matches the latest doc revision. Otherwise, returns an
+        error.
+    :ivar PaperDocUpdatePolicy.overwrite:
+        Sets the doc content to the provided content without checking
+        paper_revision.
+    :ivar PaperDocUpdatePolicy.prepend:
+        Adds the provided content to the beginning of the doc without checking
+        paper_revision.
+    :ivar PaperDocUpdatePolicy.append:
+        Adds the provided content to the end of the doc without checking
+        paper_revision.
     """
 
     _catch_all = 'other'
@@ -5561,14 +5681,17 @@ PaperDocUpdatePolicy_validator = bv.Union(PaperDocUpdatePolicy)
 
 class PaperUpdateArg(bb.Struct):
     """
-    :ivar files.PaperUpdateArg.path: Path in the user's Dropbox to update. The
-        path must correspond to a Paper doc or an error will be returned.
-    :ivar files.PaperUpdateArg.import_format: The format of the provided data.
-    :ivar files.PaperUpdateArg.doc_update_policy: How the provided content
-        should be applied to the doc.
-    :ivar files.PaperUpdateArg.paper_revision: The latest doc revision. Required
-        when doc_update_policy is update. This value must match the current
-        revision of the doc or error revision_mismatch will be returned.
+    :ivar PaperUpdateArg.path:
+        Path in the user's Dropbox to update. The path must correspond to a
+        Paper doc or an error will be returned.
+    :ivar PaperUpdateArg.import_format:
+        The format of the provided data.
+    :ivar PaperUpdateArg.doc_update_policy:
+        How the provided content should be applied to the doc.
+    :ivar PaperUpdateArg.paper_revision:
+        The latest doc revision. Required when doc_update_policy is update. This
+        value must match the current revision of the doc or error
+        revision_mismatch will be returned.
     """
 
     __slots__ = [
@@ -5621,12 +5744,12 @@ class PaperUpdateError(PaperContentError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.PaperUpdateError.revision_mismatch: The provided revision does
-        not match the document head.
-    :ivar files.PaperUpdateError.doc_archived: This operation is not allowed on
-        archived Paper docs.
-    :ivar files.PaperUpdateError.doc_deleted: This operation is not allowed on
-        deleted Paper docs.
+    :ivar PaperUpdateError.revision_mismatch:
+        The provided revision does not match the document head.
+    :ivar PaperUpdateError.doc_archived:
+        This operation is not allowed on archived Paper docs.
+    :ivar PaperUpdateError.doc_deleted:
+        This operation is not allowed on deleted Paper docs.
     """
 
     # Attribute is overwritten below the class definition
@@ -5696,7 +5819,8 @@ PaperUpdateError_validator = bv.Union(PaperUpdateError)
 
 class PaperUpdateResult(bb.Struct):
     """
-    :ivar files.PaperUpdateResult.paper_revision: The current doc revision.
+    :ivar PaperUpdateResult.paper_revision:
+        The current doc revision.
     """
 
     __slots__ = [
@@ -5803,8 +5927,10 @@ PathOrLink_validator = bv.Union(PathOrLink)
 
 class PathToTags(bb.Struct):
     """
-    :ivar files.PathToTags.path: Path of the item.
-    :ivar files.PathToTags.tags: Tags assigned to this item.
+    :ivar PathToTags.path:
+        Path of the item.
+    :ivar PathToTags.tags:
+        Tags assigned to this item.
     """
 
     __slots__ = [
@@ -5860,9 +5986,10 @@ PhotoMetadata_validator = bv.Struct(PhotoMetadata)
 
 class PreviewArg(bb.Struct):
     """
-    :ivar files.PreviewArg.path: The path of the file to preview.
-    :ivar files.PreviewArg.rev: Field is deprecated. Please specify revision in
-        ``path`` instead.
+    :ivar PreviewArg.path:
+        The path of the file to preview.
+    :ivar PreviewArg.rev:
+        Field is deprecated. Please specify revision in ``path`` instead.
     """
 
     __slots__ = [
@@ -5899,14 +6026,16 @@ class PreviewError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar LookupError PreviewError.path: An error occurs when downloading
-        metadata for the file.
-    :ivar files.PreviewError.in_progress: This preview generation is still in
-        progress and the file is not ready for preview yet.
-    :ivar files.PreviewError.unsupported_extension: The file extension is not
-        supported preview generation.
-    :ivar files.PreviewError.unsupported_content: The file content is not
-        supported for preview generation.
+    :ivar PreviewError.path:
+        An error occurs when downloading metadata for the file.
+    :vartype PreviewError.path: LookupError
+    :ivar PreviewError.in_progress:
+        This preview generation is still in progress and the file is not ready
+        for preview yet.
+    :ivar PreviewError.unsupported_extension:
+        The file extension is not supported preview generation.
+    :ivar PreviewError.unsupported_content:
+        The file content is not supported for preview generation.
     """
 
     _catch_all = None
@@ -5979,12 +6108,13 @@ PreviewError_validator = bv.Union(PreviewError)
 
 class PreviewResult(bb.Struct):
     """
-    :ivar files.PreviewResult.file_metadata: Metadata corresponding to the file
-        received as an argument. Will be populated if the endpoint is called
-        with a path (ReadPath).
-    :ivar files.PreviewResult.link_metadata: Minimal metadata corresponding to
-        the file received as an argument. Will be populated if the endpoint is
-        called using a shared link (SharedLinkFileInfo).
+    :ivar PreviewResult.file_metadata:
+        Metadata corresponding to the file received as an argument. Will be
+        populated if the endpoint is called with a path (ReadPath).
+    :ivar PreviewResult.link_metadata:
+        Minimal metadata corresponding to the file received as an argument. Will
+        be populated if the endpoint is called using a shared link
+        (SharedLinkFileInfo).
     """
 
     __slots__ = [
@@ -6017,10 +6147,10 @@ PreviewResult_validator = bv.Struct(PreviewResult)
 
 class RelocationPath(bb.Struct):
     """
-    :ivar files.RelocationPath.from_path: Path in the user's Dropbox to be
-        copied or moved.
-    :ivar files.RelocationPath.to_path: Path in the user's Dropbox that is the
-        destination.
+    :ivar RelocationPath.from_path:
+        Path in the user's Dropbox to be copied or moved.
+    :ivar RelocationPath.to_path:
+        Path in the user's Dropbox that is the destination.
     """
 
     __slots__ = [
@@ -6053,13 +6183,14 @@ RelocationPath_validator = bv.Struct(RelocationPath)
 
 class RelocationArg(RelocationPath):
     """
-    :ivar files.RelocationArg.allow_shared_folder: Field is deprecated. This
-        flag has no effect.
-    :ivar files.RelocationArg.autorename: If there's a conflict, have the
-        Dropbox server try to autorename the file to avoid the conflict.
-    :ivar files.RelocationArg.allow_ownership_transfer: Allow moves by owner
-        even if it would result in an ownership transfer for the content being
-        moved. This does not apply to copies.
+    :ivar RelocationArg.allow_shared_folder:
+        Field is deprecated. This flag has no effect.
+    :ivar RelocationArg.autorename:
+        If there's a conflict, have the Dropbox server try to autorename the
+        file to avoid the conflict.
+    :ivar RelocationArg.allow_ownership_transfer:
+        Allow moves by owner even if it would result in an ownership transfer
+        for the content being moved. This does not apply to copies.
     """
 
     __slots__ = [
@@ -6104,11 +6235,11 @@ RelocationArg_validator = bv.Struct(RelocationArg)
 
 class RelocationBatchArg(RelocationBatchArgBase):
     """
-    :ivar files.RelocationBatchArg.allow_shared_folder: Field is deprecated.
-        This flag has no effect.
-    :ivar files.RelocationBatchArg.allow_ownership_transfer: Allow moves by
-        owner even if it would result in an ownership transfer for the content
-        being moved. This does not apply to copies.
+    :ivar RelocationBatchArg.allow_shared_folder:
+        Field is deprecated. This flag has no effect.
+    :ivar RelocationBatchArg.allow_ownership_transfer:
+        Allow moves by owner even if it would result in an ownership transfer
+        for the content being moved. This does not apply to copies.
     """
 
     __slots__ = [
@@ -6149,33 +6280,38 @@ class RelocationError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.RelocationError.cant_copy_shared_folder: Shared folders can't be
-        copied.
-    :ivar files.RelocationError.cant_nest_shared_folder: Your move operation
-        would result in nested shared folders.  This is not allowed.
-    :ivar files.RelocationError.cant_move_folder_into_itself: You cannot move a
-        folder into itself.
-    :ivar files.RelocationError.too_many_files: The operation would involve more
-        than 10,000 files and folders.
-    :ivar files.RelocationError.duplicated_or_nested_paths: There are
-        duplicated/nested paths among ``RelocationArg.from_path`` and
+    :ivar RelocationError.cant_copy_shared_folder:
+        Shared folders can't be copied.
+    :ivar RelocationError.cant_nest_shared_folder:
+        Your move operation would result in nested shared folders.  This is not
+        allowed.
+    :ivar RelocationError.cant_move_folder_into_itself:
+        You cannot move a folder into itself.
+    :ivar RelocationError.too_many_files:
+        The operation would involve more than 10,000 files and folders.
+    :ivar RelocationError.duplicated_or_nested_paths:
+        There are duplicated/nested paths among ``RelocationArg.from_path`` and
         ``RelocationArg.to_path``.
-    :ivar files.RelocationError.cant_transfer_ownership: Your move operation
-        would result in an ownership transfer. You may reissue the request with
-        the field ``RelocationArg.allow_ownership_transfer`` to true.
-    :ivar files.RelocationError.insufficient_quota: The current user does not
-        have enough space to move or copy the files.
-    :ivar files.RelocationError.internal_error: Something went wrong with the
-        job on Dropbox's end. You'll need to verify that the action you were
-        taking succeeded, and if not, try again. This should happen very rarely.
-    :ivar files.RelocationError.cant_move_shared_folder: Can't move the shared
-        folder to the given destination.
-    :ivar MoveIntoVaultError RelocationError.cant_move_into_vault: Some content
-        cannot be moved into Vault under certain circumstances, see detailed
-        error.
-    :ivar MoveIntoFamilyError RelocationError.cant_move_into_family: Some
-        content cannot be moved into the Family Room folder under certain
+    :ivar RelocationError.cant_transfer_ownership:
+        Your move operation would result in an ownership transfer. You may
+        reissue the request with the field
+        ``RelocationArg.allow_ownership_transfer`` to true.
+    :ivar RelocationError.insufficient_quota:
+        The current user does not have enough space to move or copy the files.
+    :ivar RelocationError.internal_error:
+        Something went wrong with the job on Dropbox's end. You'll need to
+        verify that the action you were taking succeeded, and if not, try again.
+        This should happen very rarely.
+    :ivar RelocationError.cant_move_shared_folder:
+        Can't move the shared folder to the given destination.
+    :ivar RelocationError.cant_move_into_vault:
+        Some content cannot be moved into Vault under certain circumstances, see
+        detailed error.
+    :vartype RelocationError.cant_move_into_vault: MoveIntoVaultError
+    :ivar RelocationError.cant_move_into_family:
+        Some content cannot be moved into the Family Room folder under certain
         circumstances, see detailed error.
+    :vartype RelocationError.cant_move_into_family: MoveIntoFamilyError
     """
 
     _catch_all = 'other'
@@ -6442,8 +6578,9 @@ class RelocationBatchError(RelocationError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.RelocationBatchError.too_many_write_operations: There are too
-        many write operations in user's Dropbox. Please retry this request.
+    :ivar RelocationBatchError.too_many_write_operations:
+        There are too many write operations in user's Dropbox. Please retry this
+        request.
     """
 
     # Attribute is overwritten below the class definition
@@ -6468,14 +6605,16 @@ class RelocationBatchErrorEntry(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar RelocationError RelocationBatchErrorEntry.relocation_error: User
-        errors that retry won't help.
-    :ivar files.RelocationBatchErrorEntry.internal_error: Something went wrong
-        with the job on Dropbox's end. You'll need to verify that the action you
-        were taking succeeded, and if not, try again. This should happen very
-        rarely.
-    :ivar files.RelocationBatchErrorEntry.too_many_write_operations: There are
-        too many write operations in user's Dropbox. Please retry this request.
+    :ivar RelocationBatchErrorEntry.relocation_error:
+        User errors that retry won't help.
+    :vartype RelocationBatchErrorEntry.relocation_error: RelocationError
+    :ivar RelocationBatchErrorEntry.internal_error:
+        Something went wrong with the job on Dropbox's end. You'll need to
+        verify that the action you were taking succeeded, and if not, try again.
+        This should happen very rarely.
+    :ivar RelocationBatchErrorEntry.too_many_write_operations:
+        There are too many write operations in user's Dropbox. Please retry this
+        request.
     """
 
     _catch_all = 'other'
@@ -6552,10 +6691,12 @@ class RelocationBatchJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar RelocationBatchResult RelocationBatchJobStatus.complete: The copy or
-        move batch job has finished.
-    :ivar RelocationBatchError RelocationBatchJobStatus.failed: The copy or move
-        batch job has failed with exception.
+    :ivar RelocationBatchJobStatus.complete:
+        The copy or move batch job has finished.
+    :vartype RelocationBatchJobStatus.complete: RelocationBatchResult
+    :ivar RelocationBatchJobStatus.failed:
+        The copy or move batch job has failed with exception.
+    :vartype RelocationBatchJobStatus.failed: RelocationBatchError
     """
 
     @classmethod
@@ -6707,8 +6848,8 @@ RelocationBatchResult_validator = bv.Struct(RelocationBatchResult)
 
 class RelocationBatchResultData(bb.Struct):
     """
-    :ivar files.RelocationBatchResultData.metadata: Metadata of the relocated
-        object.
+    :ivar RelocationBatchResultData.metadata:
+        Metadata of the relocated object.
     """
 
     __slots__ = [
@@ -6824,8 +6965,9 @@ class RelocationBatchV2JobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar RelocationBatchV2Result RelocationBatchV2JobStatus.complete: The copy
-        or move batch job has finished.
+    :ivar RelocationBatchV2JobStatus.complete:
+        The copy or move batch job has finished.
+    :vartype RelocationBatchV2JobStatus.complete: RelocationBatchV2Result
     """
 
     @classmethod
@@ -6911,9 +7053,9 @@ RelocationBatchV2Launch_validator = bv.Union(RelocationBatchV2Launch)
 
 class RelocationBatchV2Result(FileOpsResult):
     """
-    :ivar files.RelocationBatchV2Result.entries: Each entry in
-        CopyBatchArg.entries or ``MoveBatchArg.entries`` will appear at the same
-        position inside ``RelocationBatchV2Result.entries``.
+    :ivar RelocationBatchV2Result.entries:
+        Each entry in CopyBatchArg.entries or ``MoveBatchArg.entries`` will
+        appear at the same position inside ``RelocationBatchV2Result.entries``.
     """
 
     __slots__ = [
@@ -6939,7 +7081,8 @@ RelocationBatchV2Result_validator = bv.Struct(RelocationBatchV2Result)
 
 class RelocationResult(FileOpsResult):
     """
-    :ivar files.RelocationResult.metadata: Metadata of the relocated object.
+    :ivar RelocationResult.metadata:
+        Metadata of the relocated object.
     """
 
     __slots__ = [
@@ -6965,9 +7108,10 @@ RelocationResult_validator = bv.Struct(RelocationResult)
 
 class RemoveTagArg(bb.Struct):
     """
-    :ivar files.RemoveTagArg.path: Path to the item to tag.
-    :ivar files.RemoveTagArg.tag_text: The tag to remove. Will be automatically
-        converted to lowercase letters.
+    :ivar RemoveTagArg.path:
+        Path to the item to tag.
+    :ivar RemoveTagArg.tag_text:
+        The tag to remove. Will be automatically converted to lowercase letters.
     """
 
     __slots__ = [
@@ -7004,8 +7148,8 @@ class RemoveTagError(BaseTagError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.RemoveTagError.tag_not_present: That tag doesn't exist at this
-        path.
+    :ivar RemoveTagError.tag_not_present:
+        That tag doesn't exist at this path.
     """
 
     # Attribute is overwritten below the class definition
@@ -7026,8 +7170,10 @@ RemoveTagError_validator = bv.Union(RemoveTagError)
 
 class RestoreArg(bb.Struct):
     """
-    :ivar files.RestoreArg.path: The path to save the restored file.
-    :ivar files.RestoreArg.rev: The revision to restore.
+    :ivar RestoreArg.path:
+        The path to save the restored file.
+    :ivar RestoreArg.rev:
+        The revision to restore.
     """
 
     __slots__ = [
@@ -7064,14 +7210,17 @@ class RestoreError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar LookupError RestoreError.path_lookup: An error occurs when downloading
-        metadata for the file.
-    :ivar WriteError RestoreError.path_write: An error occurs when trying to
-        restore the file to that path.
-    :ivar files.RestoreError.invalid_revision: The revision is invalid. It may
-        not exist or may point to a deleted file.
-    :ivar files.RestoreError.in_progress: The restore is currently executing,
-        but has not yet completed.
+    :ivar RestoreError.path_lookup:
+        An error occurs when downloading metadata for the file.
+    :vartype RestoreError.path_lookup: LookupError
+    :ivar RestoreError.path_write:
+        An error occurs when trying to restore the file to that path.
+    :vartype RestoreError.path_write: WriteError
+    :ivar RestoreError.invalid_revision:
+        The revision is invalid. It may not exist or may point to a deleted
+        file.
+    :ivar RestoreError.in_progress:
+        The restore is currently executing, but has not yet completed.
     """
 
     _catch_all = 'other'
@@ -7175,10 +7324,11 @@ RestoreError_validator = bv.Union(RestoreError)
 
 class SaveCopyReferenceArg(bb.Struct):
     """
-    :ivar files.SaveCopyReferenceArg.copy_reference: A copy reference returned
-        by :meth:`dropbox.dropbox_client.Dropbox.files_copy_reference_get`.
-    :ivar files.SaveCopyReferenceArg.path: Path in the user's Dropbox that is
-        the destination.
+    :ivar SaveCopyReferenceArg.copy_reference:
+        A copy reference returned by
+        :meth:`dropbox.dropbox_client.Dropbox.files_copy_reference_get`.
+    :ivar SaveCopyReferenceArg.path:
+        Path in the user's Dropbox that is the destination.
     """
 
     __slots__ = [
@@ -7215,16 +7365,16 @@ class SaveCopyReferenceError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SaveCopyReferenceError.invalid_copy_reference: The copy
-        reference is invalid.
-    :ivar files.SaveCopyReferenceError.no_permission: You don't have permission
-        to save the given copy reference. Please make sure this app is same app
-        which created the copy reference and the source user is still linked to
-        the app.
-    :ivar files.SaveCopyReferenceError.not_found: The file referenced by the
-        copy reference cannot be found.
-    :ivar files.SaveCopyReferenceError.too_many_files: The operation would
-        involve more than 10,000 files and folders.
+    :ivar SaveCopyReferenceError.invalid_copy_reference:
+        The copy reference is invalid.
+    :ivar SaveCopyReferenceError.no_permission:
+        You don't have permission to save the given copy reference. Please make
+        sure this app is same app which created the copy reference and the
+        source user is still linked to the app.
+    :ivar SaveCopyReferenceError.not_found:
+        The file referenced by the copy reference cannot be found.
+    :ivar SaveCopyReferenceError.too_many_files:
+        The operation would involve more than 10,000 files and folders.
     """
 
     _catch_all = 'other'
@@ -7315,8 +7465,8 @@ SaveCopyReferenceError_validator = bv.Union(SaveCopyReferenceError)
 
 class SaveCopyReferenceResult(bb.Struct):
     """
-    :ivar files.SaveCopyReferenceResult.metadata: The metadata of the saved file
-        or folder in the user's Dropbox.
+    :ivar SaveCopyReferenceResult.metadata:
+        The metadata of the saved file or folder in the user's Dropbox.
     """
 
     __slots__ = [
@@ -7341,9 +7491,10 @@ SaveCopyReferenceResult_validator = bv.Struct(SaveCopyReferenceResult)
 
 class SaveUrlArg(bb.Struct):
     """
-    :ivar files.SaveUrlArg.path: The path in Dropbox where the URL will be saved
-        to.
-    :ivar files.SaveUrlArg.url: The URL to be saved.
+    :ivar SaveUrlArg.path:
+        The path in Dropbox where the URL will be saved to.
+    :ivar SaveUrlArg.url:
+        The URL to be saved.
     """
 
     __slots__ = [
@@ -7380,12 +7531,13 @@ class SaveUrlError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SaveUrlError.download_failed: Failed downloading the given URL.
-        The URL may be password-protected and the password provided was
-        incorrect, or the link may be disabled.
-    :ivar files.SaveUrlError.invalid_url: The given URL is invalid.
-    :ivar files.SaveUrlError.not_found: The file where the URL is saved to no
-        longer exists.
+    :ivar SaveUrlError.download_failed:
+        Failed downloading the given URL. The URL may be password-protected and
+        the password provided was incorrect, or the link may be disabled.
+    :ivar SaveUrlError.invalid_url:
+        The given URL is invalid.
+    :ivar SaveUrlError.not_found:
+        The file where the URL is saved to no longer exists.
     """
 
     _catch_all = 'other'
@@ -7470,8 +7622,9 @@ class SaveUrlJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar FileMetadata SaveUrlJobStatus.complete: Metadata of the file where the
-        URL is saved to.
+    :ivar SaveUrlJobStatus.complete:
+        Metadata of the file where the URL is saved to.
+    :vartype SaveUrlJobStatus.complete: FileMetadata
     """
 
     @classmethod
@@ -7545,8 +7698,9 @@ class SaveUrlResult(async_.LaunchResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar FileMetadata SaveUrlResult.complete: Metadata of the file where the
-        URL is saved to.
+    :ivar SaveUrlResult.complete:
+        Metadata of the file where the URL is saved to.
+    :vartype SaveUrlResult.complete: FileMetadata
     """
 
     @classmethod
@@ -7587,20 +7741,21 @@ SaveUrlResult_validator = bv.Union(SaveUrlResult)
 
 class SearchArg(bb.Struct):
     """
-    :ivar files.SearchArg.path: The path in the user's Dropbox to search. Should
-        probably be a folder.
-    :ivar files.SearchArg.query: The string to search for. Query string may be
-        rewritten to improve relevance of results. The string is split on spaces
-        into multiple tokens. For file name searching, the last token is used
-        for prefix matching (i.e. "bat c" matches "bat cave" but not "batman
-        car").
-    :ivar files.SearchArg.start: The starting index within the search results
-        (used for paging).
-    :ivar files.SearchArg.max_results: The maximum number of search results to
-        return.
-    :ivar files.SearchArg.mode: The search mode (filename, filename_and_content,
-        or deleted_filename). Note that searching file content is only available
-        for Dropbox Business accounts.
+    :ivar SearchArg.path:
+        The path in the user's Dropbox to search. Should probably be a folder.
+    :ivar SearchArg.query:
+        The string to search for. Query string may be rewritten to improve
+        relevance of results. The string is split on spaces into multiple
+        tokens. For file name searching, the last token is used for prefix
+        matching (i.e. "bat c" matches "bat cave" but not "batman car").
+    :ivar SearchArg.start:
+        The starting index within the search results (used for paging).
+    :ivar SearchArg.max_results:
+        The maximum number of search results to return.
+    :ivar SearchArg.mode:
+        The search mode (filename, filename_and_content, or deleted_filename).
+        Note that searching file content is only available for Dropbox Business
+        accounts.
     """
 
     __slots__ = [
@@ -7661,8 +7816,8 @@ class SearchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SearchError.internal_error: Something went wrong, please try
-        again.
+    :ivar SearchError.internal_error:
+        Something went wrong, please try again.
     """
 
     _catch_all = 'other'
@@ -7752,9 +7907,10 @@ SearchError_validator = bv.Union(SearchError)
 
 class SearchMatch(bb.Struct):
     """
-    :ivar files.SearchMatch.match_type: The type of the match.
-    :ivar files.SearchMatch.metadata: The metadata for the matched file or
-        folder.
+    :ivar SearchMatch.match_type:
+        The type of the match.
+    :ivar SearchMatch.metadata:
+        The metadata for the matched file or folder.
     """
 
     __slots__ = [
@@ -7787,8 +7943,8 @@ SearchMatch_validator = bv.Struct(SearchMatch)
 
 class SearchMatchFieldOptions(bb.Struct):
     """
-    :ivar files.SearchMatchFieldOptions.include_highlights: Whether to include
-        highlight span from file title.
+    :ivar SearchMatchFieldOptions.include_highlights:
+        Whether to include highlight span from file title.
     """
 
     __slots__ = [
@@ -7819,12 +7975,12 @@ class SearchMatchType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SearchMatchType.filename: This item was matched on its file or
-        folder name.
-    :ivar files.SearchMatchType.content: This item was matched based on its file
-        contents.
-    :ivar files.SearchMatchType.both: This item was matched based on both its
-        contents and its file name.
+    :ivar SearchMatchType.filename:
+        This item was matched on its file or folder name.
+    :ivar SearchMatchType.content:
+        This item was matched based on its file contents.
+    :ivar SearchMatchType.both:
+        This item was matched based on both its contents and its file name.
     """
 
     _catch_all = None
@@ -7872,16 +8028,16 @@ class SearchMatchTypeV2(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SearchMatchTypeV2.filename: This item was matched on its file or
-        folder name.
-    :ivar files.SearchMatchTypeV2.file_content: This item was matched based on
-        its file contents.
-    :ivar files.SearchMatchTypeV2.filename_and_content: This item was matched
-        based on both its contents and its file name.
-    :ivar files.SearchMatchTypeV2.image_content: This item was matched on image
-        content.
-    :ivar files.SearchMatchTypeV2.metadata: This item was matched based on its
-        metadata.
+    :ivar SearchMatchTypeV2.filename:
+        This item was matched on its file or folder name.
+    :ivar SearchMatchTypeV2.file_content:
+        This item was matched based on its file contents.
+    :ivar SearchMatchTypeV2.filename_and_content:
+        This item was matched based on both its contents and its file name.
+    :ivar SearchMatchTypeV2.image_content:
+        This item was matched on image content.
+    :ivar SearchMatchTypeV2.metadata:
+        This item was matched based on its metadata.
     """
 
     _catch_all = 'other'
@@ -7953,11 +8109,13 @@ SearchMatchTypeV2_validator = bv.Union(SearchMatchTypeV2)
 
 class SearchMatchV2(bb.Struct):
     """
-    :ivar files.SearchMatchV2.metadata: The metadata for the matched file or
-        folder.
-    :ivar files.SearchMatchV2.match_type: The type of the match.
-    :ivar files.SearchMatchV2.highlight_spans: The list of HighlightSpan
-        determines which parts of the file title should be highlighted.
+    :ivar SearchMatchV2.metadata:
+        The metadata for the matched file or folder.
+    :ivar SearchMatchV2.match_type:
+        The type of the match.
+    :ivar SearchMatchV2.highlight_spans:
+        The list of HighlightSpan determines which parts of the file title
+        should be highlighted.
     """
 
     __slots__ = [
@@ -8002,11 +8160,12 @@ class SearchMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SearchMode.filename: Search file and folder names.
-    :ivar files.SearchMode.filename_and_content: Search file and folder names as
-        well as file contents.
-    :ivar files.SearchMode.deleted_filename: Search for deleted file and folder
-        names.
+    :ivar SearchMode.filename:
+        Search file and folder names.
+    :ivar SearchMode.filename_and_content:
+        Search file and folder names as well as file contents.
+    :ivar SearchMode.deleted_filename:
+        Search for deleted file and folder names.
     """
 
     _catch_all = None
@@ -8048,22 +8207,26 @@ SearchMode_validator = bv.Union(SearchMode)
 
 class SearchOptions(bb.Struct):
     """
-    :ivar files.SearchOptions.path: Scopes the search to a path in the user's
-        Dropbox. Searches the entire Dropbox if not specified.
-    :ivar files.SearchOptions.max_results: The maximum number of search results
-        to return.
-    :ivar files.SearchOptions.order_by: Specified property of the order of
-        search results. By default, results are sorted by relevance.
-    :ivar files.SearchOptions.file_status: Restricts search to the given file
-        status.
-    :ivar files.SearchOptions.filename_only: Restricts search to only match on
-        filenames.
-    :ivar files.SearchOptions.file_extensions: Restricts search to only the
-        extensions specified. Only supported for active file search.
-    :ivar files.SearchOptions.file_categories: Restricts search to only the file
-        categories specified. Only supported for active file search.
-    :ivar files.SearchOptions.account_id: Restricts results to the given account
-        id.
+    :ivar SearchOptions.path:
+        Scopes the search to a path in the user's Dropbox. Searches the entire
+        Dropbox if not specified.
+    :ivar SearchOptions.max_results:
+        The maximum number of search results to return.
+    :ivar SearchOptions.order_by:
+        Specified property of the order of search results. By default, results
+        are sorted by relevance.
+    :ivar SearchOptions.file_status:
+        Restricts search to the given file status.
+    :ivar SearchOptions.filename_only:
+        Restricts search to only match on filenames.
+    :ivar SearchOptions.file_extensions:
+        Restricts search to only the extensions specified. Only supported for
+        active file search.
+    :ivar SearchOptions.file_categories:
+        Restricts search to only the file categories specified. Only supported
+        for active file search.
+    :ivar SearchOptions.account_id:
+        Restricts results to the given account id.
     """
 
     __slots__ = [
@@ -8188,13 +8351,14 @@ SearchOrderBy_validator = bv.Union(SearchOrderBy)
 
 class SearchResult(bb.Struct):
     """
-    :ivar files.SearchResult.matches: A list (possibly empty) of matches for the
-        query.
-    :ivar files.SearchResult.more: Used for paging. If true, indicates there is
-        another page of results available that can be fetched by calling
+    :ivar SearchResult.matches:
+        A list (possibly empty) of matches for the query.
+    :ivar SearchResult.more:
+        Used for paging. If true, indicates there is another page of results
+        available that can be fetched by calling
         :meth:`dropbox.dropbox_client.Dropbox.files_search` again.
-    :ivar files.SearchResult.start: Used for paging. Value to set the start
-        argument to when calling
+    :ivar SearchResult.start:
+        Used for paging. Value to set the start argument to when calling
         :meth:`dropbox.dropbox_client.Dropbox.files_search` to fetch the next
         page of results.
     """
@@ -8237,13 +8401,16 @@ SearchResult_validator = bv.Struct(SearchResult)
 
 class SearchV2Arg(bb.Struct):
     """
-    :ivar files.SearchV2Arg.query: The string to search for. May match across
-        multiple fields based on the request arguments.
-    :ivar files.SearchV2Arg.options: Options for more targeted search results.
-    :ivar files.SearchV2Arg.match_field_options: Options for search results
-        match fields.
-    :ivar files.SearchV2Arg.include_highlights: Field is deprecated. Deprecated
-        and moved this option to SearchMatchFieldOptions.
+    :ivar SearchV2Arg.query:
+        The string to search for. May match across multiple fields based on the
+        request arguments.
+    :ivar SearchV2Arg.options:
+        Options for more targeted search results.
+    :ivar SearchV2Arg.match_field_options:
+        Options for search results match fields.
+    :ivar SearchV2Arg.include_highlights:
+        Field is deprecated. Deprecated and moved this option to
+        SearchMatchFieldOptions.
     """
 
     __slots__ = [
@@ -8292,9 +8459,10 @@ SearchV2Arg_validator = bv.Struct(SearchV2Arg)
 
 class SearchV2ContinueArg(bb.Struct):
     """
-    :ivar files.SearchV2ContinueArg.cursor: The cursor returned by your last
-        call to :meth:`dropbox.dropbox_client.Dropbox.files_search`. Used to
-        fetch the next page of results.
+    :ivar SearchV2ContinueArg.cursor:
+        The cursor returned by your last call to
+        :meth:`dropbox.dropbox_client.Dropbox.files_search`. Used to fetch the
+        next page of results.
     """
 
     __slots__ = [
@@ -8319,13 +8487,15 @@ SearchV2ContinueArg_validator = bv.Struct(SearchV2ContinueArg)
 
 class SearchV2Result(bb.Struct):
     """
-    :ivar files.SearchV2Result.matches: A list (possibly empty) of matches for
-        the query.
-    :ivar files.SearchV2Result.has_more: Used for paging. If true, indicates
-        there is another page of results available that can be fetched by
-        calling :meth:`dropbox.dropbox_client.Dropbox.files_search_continue`
-        with the cursor.
-    :ivar files.SearchV2Result.cursor: Pass the cursor into
+    :ivar SearchV2Result.matches:
+        A list (possibly empty) of matches for the query.
+    :ivar SearchV2Result.has_more:
+        Used for paging. If true, indicates there is another page of results
+        available that can be fetched by calling
+        :meth:`dropbox.dropbox_client.Dropbox.files_search_continue` with the
+        cursor.
+    :ivar SearchV2Result.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.files_search_continue` to fetch
         the next page of results.
     """
@@ -8368,8 +8538,10 @@ SearchV2Result_validator = bv.Struct(SearchV2Result)
 
 class SharedLink(bb.Struct):
     """
-    :ivar files.SharedLink.url: Shared link url.
-    :ivar files.SharedLink.password: Password for the shared link.
+    :ivar SharedLink.url:
+        Shared link url.
+    :ivar SharedLink.password:
+        Password for the shared link.
     """
 
     __slots__ = [
@@ -8402,15 +8574,16 @@ SharedLink_validator = bv.Struct(SharedLink)
 
 class SharedLinkFileInfo(bb.Struct):
     """
-    :ivar files.SharedLinkFileInfo.url: The shared link corresponding to either
-        a file or shared link to a folder. If it is for a folder shared link, we
-        use the path param to determine for which file in the folder the view is
-        for.
-    :ivar files.SharedLinkFileInfo.path: The path corresponding to a file in a
-        shared link to a folder. Required for shared links to folders.
-    :ivar files.SharedLinkFileInfo.password: Password for the shared link.
-        Required for password-protected shared links to files unless it can be
-        read from a cookie.
+    :ivar SharedLinkFileInfo.url:
+        The shared link corresponding to either a file or shared link to a
+        folder. If it is for a folder shared link, we use the path param to
+        determine for which file in the folder the view is for.
+    :ivar SharedLinkFileInfo.path:
+        The path corresponding to a file in a shared link to a folder. Required
+        for shared links to folders.
+    :ivar SharedLinkFileInfo.password:
+        Password for the shared link. Required for password-protected shared
+        links to files unless it can be read from a cookie.
     """
 
     __slots__ = [
@@ -8451,11 +8624,12 @@ SharedLinkFileInfo_validator = bv.Struct(SharedLinkFileInfo)
 
 class SingleUserLock(bb.Struct):
     """
-    :ivar files.SingleUserLock.created: The time the lock was created.
-    :ivar files.SingleUserLock.lock_holder_account_id: The account ID of the
-        lock holder if known.
-    :ivar files.SingleUserLock.lock_holder_team_id: The id of the team of the
-        account holder if it exists.
+    :ivar SingleUserLock.created:
+        The time the lock was created.
+    :ivar SingleUserLock.lock_holder_account_id:
+        The account ID of the lock holder if known.
+    :ivar SingleUserLock.lock_holder_team_id:
+        The id of the team of the account holder if it exists.
     """
 
     __slots__ = [
@@ -8496,7 +8670,8 @@ SingleUserLock_validator = bv.Struct(SingleUserLock)
 
 class SymlinkInfo(bb.Struct):
     """
-    :ivar files.SymlinkInfo.target: The target this symlink points to.
+    :ivar SymlinkInfo.target:
+        The target this symlink points to.
     """
 
     __slots__ = [
@@ -8525,14 +8700,16 @@ class SyncSetting(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SyncSetting.default: On first sync to members' computers, the
-        specified folder will follow its parent folder's setting or otherwise
-        follow default sync behavior.
-    :ivar files.SyncSetting.not_synced: On first sync to members' computers, the
-        specified folder will be set to not sync with selective sync.
-    :ivar files.SyncSetting.not_synced_inactive: The specified folder's
-        not_synced setting is inactive due to its location or other
-        configuration changes. It will follow its parent folder's setting.
+    :ivar SyncSetting.default:
+        On first sync to members' computers, the specified folder will follow
+        its parent folder's setting or otherwise follow default sync behavior.
+    :ivar SyncSetting.not_synced:
+        On first sync to members' computers, the specified folder will be set to
+        not sync with selective sync.
+    :ivar SyncSetting.not_synced_inactive:
+        The specified folder's not_synced setting is inactive due to its
+        location or other configuration changes. It will follow its parent
+        folder's setting.
     """
 
     _catch_all = 'other'
@@ -8588,11 +8765,12 @@ class SyncSettingArg(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SyncSettingArg.default: On first sync to members' computers, the
-        specified folder will follow its parent folder's setting or otherwise
-        follow default sync behavior.
-    :ivar files.SyncSettingArg.not_synced: On first sync to members' computers,
-        the specified folder will be set to not sync with selective sync.
+    :ivar SyncSettingArg.default:
+        On first sync to members' computers, the specified folder will follow
+        its parent folder's setting or otherwise follow default sync behavior.
+    :ivar SyncSettingArg.not_synced:
+        On first sync to members' computers, the specified folder will be set to
+        not sync with selective sync.
     """
 
     _catch_all = 'other'
@@ -8638,10 +8816,11 @@ class SyncSettingsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.SyncSettingsError.unsupported_combination: Setting this
-        combination of sync settings simultaneously is not supported.
-    :ivar files.SyncSettingsError.unsupported_configuration: The specified
-        configuration is not supported.
+    :ivar SyncSettingsError.unsupported_combination:
+        Setting this combination of sync settings simultaneously is not
+        supported.
+    :ivar SyncSettingsError.unsupported_configuration:
+        The specified configuration is not supported.
     """
 
     _catch_all = 'other'
@@ -8718,7 +8897,9 @@ class Tag(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserGeneratedTag Tag.user_generated_tag: Tag generated by the user.
+    :ivar Tag.user_generated_tag:
+        Tag generated by the user.
+    :vartype Tag.user_generated_tag: UserGeneratedTag
     """
 
     _catch_all = 'other'
@@ -8771,21 +8952,23 @@ Tag_validator = bv.Union(Tag)
 
 class ThumbnailArg(bb.Struct):
     """
-    :ivar files.ThumbnailArg.path: The path to the image file you want to
-        thumbnail.
-    :ivar files.ThumbnailArg.format: The format for the thumbnail image, jpeg
-        (default), png, or webp. For images that are photos, jpeg should be
-        preferred, while png is better for screenshots and digital arts, and web
-        for compression.
-    :ivar files.ThumbnailArg.size: The size for the thumbnail image.
-    :ivar files.ThumbnailArg.mode: How to resize and crop the image to achieve
-        the desired size.
-    :ivar files.ThumbnailArg.quality: Field is only returned for "internal"
-        callers. Quality of the thumbnail image.
-    :ivar files.ThumbnailArg.exclude_media_info: Normally,
-        ``FileMetadata.media_info`` is set for photo and video. When this flag
-        is true, ``FileMetadata.media_info`` is not populated. This improves
-        latency for use cases where `media_info` is not needed.
+    :ivar ThumbnailArg.path:
+        The path to the image file you want to thumbnail.
+    :ivar ThumbnailArg.format:
+        The format for the thumbnail image, jpeg (default), png, or webp. For
+        images that are photos, jpeg should be preferred, while png is better
+        for screenshots and digital arts, and web for compression.
+    :ivar ThumbnailArg.size:
+        The size for the thumbnail image.
+    :ivar ThumbnailArg.mode:
+        How to resize and crop the image to achieve the desired size.
+    :ivar ThumbnailArg.quality:
+        Field is only returned for "internal" callers. Quality of the thumbnail
+        image.
+    :ivar ThumbnailArg.exclude_media_info:
+        Normally, ``FileMetadata.media_info`` is set for photo and video. When
+        this flag is true, ``FileMetadata.media_info`` is not populated. This
+        improves latency for use cases where `media_info` is not needed.
     """
 
     __slots__ = [
@@ -8854,16 +9037,17 @@ class ThumbnailError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar LookupError ThumbnailError.path: An error occurs when downloading
-        metadata for the image.
-    :ivar files.ThumbnailError.unsupported_extension: The file extension doesn't
-        allow conversion to a thumbnail.
-    :ivar files.ThumbnailError.unsupported_image: The image cannot be converted
-        to a thumbnail.
-    :ivar files.ThumbnailError.encrypted_content: Encrypted content cannot be
-        converted to a thumbnail.
-    :ivar files.ThumbnailError.conversion_error: An error occurs during
-        thumbnail conversion.
+    :ivar ThumbnailError.path:
+        An error occurs when downloading metadata for the image.
+    :vartype ThumbnailError.path: LookupError
+    :ivar ThumbnailError.unsupported_extension:
+        The file extension doesn't allow conversion to a thumbnail.
+    :ivar ThumbnailError.unsupported_image:
+        The image cannot be converted to a thumbnail.
+    :ivar ThumbnailError.encrypted_content:
+        Encrypted content cannot be converted to a thumbnail.
+    :ivar ThumbnailError.conversion_error:
+        An error occurs during thumbnail conversion.
     """
 
     _catch_all = None
@@ -8994,13 +9178,15 @@ class ThumbnailMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ThumbnailMode.strict: Scale down the image to fit within the
-        given size.
-    :ivar files.ThumbnailMode.bestfit: Scale down the image to fit within the
-        given size or its transpose.
-    :ivar files.ThumbnailMode.fitone_bestfit: Scale down the image to completely
-        cover the given size or its transpose.
-    :ivar files.ThumbnailMode.original: Don't resize the image at all.
+    :ivar ThumbnailMode.strict:
+        Scale down the image to fit within the given size.
+    :ivar ThumbnailMode.bestfit:
+        Scale down the image to fit within the given size or its transpose.
+    :ivar ThumbnailMode.fitone_bestfit:
+        Scale down the image to completely cover the given size or its
+        transpose.
+    :ivar ThumbnailMode.original:
+        Don't resize the image at all.
     """
 
     _catch_all = None
@@ -9056,8 +9242,10 @@ class ThumbnailQuality(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ThumbnailQuality.quality_80: default thumbnail quality.
-    :ivar files.ThumbnailQuality.quality_90: high thumbnail quality.
+    :ivar ThumbnailQuality.quality_80:
+        default thumbnail quality.
+    :ivar ThumbnailQuality.quality_90:
+        high thumbnail quality.
     """
 
     _catch_all = None
@@ -9093,17 +9281,26 @@ class ThumbnailSize(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.ThumbnailSize.w32h32: 32 by 32 px.
-    :ivar files.ThumbnailSize.w64h64: 64 by 64 px.
-    :ivar files.ThumbnailSize.w128h128: 128 by 128 px.
-    :ivar files.ThumbnailSize.w256h256: 256 by 256 px.
-    :ivar files.ThumbnailSize.w480h320: 480 by 320 px.
-    :ivar files.ThumbnailSize.w640h480: 640 by 480 px.
-    :ivar files.ThumbnailSize.w960h640: 960 by 640 px.
-    :ivar files.ThumbnailSize.w1024h768: 1024 by 768 px.
-    :ivar files.ThumbnailSize.w2048h1536: 2048 by 1536 px.
-    :ivar files.ThumbnailSize.w3200h2400: Field is only returned for "internal"
-        callers. 3200 by 2400 px.
+    :ivar ThumbnailSize.w32h32:
+        32 by 32 px.
+    :ivar ThumbnailSize.w64h64:
+        64 by 64 px.
+    :ivar ThumbnailSize.w128h128:
+        128 by 128 px.
+    :ivar ThumbnailSize.w256h256:
+        256 by 256 px.
+    :ivar ThumbnailSize.w480h320:
+        480 by 320 px.
+    :ivar ThumbnailSize.w640h480:
+        640 by 480 px.
+    :ivar ThumbnailSize.w960h640:
+        960 by 640 px.
+    :ivar ThumbnailSize.w1024h768:
+        1024 by 768 px.
+    :ivar ThumbnailSize.w2048h1536:
+        2048 by 1536 px.
+    :ivar ThumbnailSize.w3200h2400:
+        Field is only returned for "internal" callers. 3200 by 2400 px.
     """
 
     _catch_all = None
@@ -9215,22 +9412,25 @@ ThumbnailSize_validator = bv.Union(ThumbnailSize)
 
 class ThumbnailV2Arg(bb.Struct):
     """
-    :ivar files.ThumbnailV2Arg.resource: Information specifying which file to
-        preview. This could be a path to a file, a shared link pointing to a
-        file, or a shared link pointing to a folder, with a relative path.
-    :ivar files.ThumbnailV2Arg.format: The format for the thumbnail image, jpeg
-        (default), png, or webp. For images that are photos, jpeg should be
-        preferred, while png is better for screenshots and digital arts, and web
-        for compression.
-    :ivar files.ThumbnailV2Arg.size: The size for the thumbnail image.
-    :ivar files.ThumbnailV2Arg.mode: How to resize and crop the image to achieve
-        the desired size.
-    :ivar files.ThumbnailV2Arg.quality: Field is only returned for "internal"
-        callers. Quality of the thumbnail image.
-    :ivar files.ThumbnailV2Arg.exclude_media_info: Normally,
-        ``FileMetadata.media_info`` is set for photo and video. When this flag
-        is true, ``FileMetadata.media_info`` is not populated. This improves
-        latency for use cases where `media_info` is not needed.
+    :ivar ThumbnailV2Arg.resource:
+        Information specifying which file to preview. This could be a path to a
+        file, a shared link pointing to a file, or a shared link pointing to a
+        folder, with a relative path.
+    :ivar ThumbnailV2Arg.format:
+        The format for the thumbnail image, jpeg (default), png, or webp. For
+        images that are photos, jpeg should be preferred, while png is better
+        for screenshots and digital arts, and web for compression.
+    :ivar ThumbnailV2Arg.size:
+        The size for the thumbnail image.
+    :ivar ThumbnailV2Arg.mode:
+        How to resize and crop the image to achieve the desired size.
+    :ivar ThumbnailV2Arg.quality:
+        Field is only returned for "internal" callers. Quality of the thumbnail
+        image.
+    :ivar ThumbnailV2Arg.exclude_media_info:
+        Normally, ``FileMetadata.media_info`` is set for photo and video. When
+        this flag is true, ``FileMetadata.media_info`` is not populated. This
+        improves latency for use cases where `media_info` is not needed.
     """
 
     __slots__ = [
@@ -9299,19 +9499,21 @@ class ThumbnailV2Error(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar LookupError ThumbnailV2Error.path: An error occurred when downloading
-        metadata for the image.
-    :ivar files.ThumbnailV2Error.unsupported_extension: The file extension
-        doesn't allow conversion to a thumbnail.
-    :ivar files.ThumbnailV2Error.unsupported_image: The image cannot be
-        converted to a thumbnail.
-    :ivar files.ThumbnailV2Error.encrypted_content: Encrypted content cannot be
-        converted to a thumbnail.
-    :ivar files.ThumbnailV2Error.conversion_error: An error occurred during
-        thumbnail conversion.
-    :ivar files.ThumbnailV2Error.access_denied: Access to this shared link is
-        forbidden.
-    :ivar files.ThumbnailV2Error.not_found: The shared link does not exist.
+    :ivar ThumbnailV2Error.path:
+        An error occurred when downloading metadata for the image.
+    :vartype ThumbnailV2Error.path: LookupError
+    :ivar ThumbnailV2Error.unsupported_extension:
+        The file extension doesn't allow conversion to a thumbnail.
+    :ivar ThumbnailV2Error.unsupported_image:
+        The image cannot be converted to a thumbnail.
+    :ivar ThumbnailV2Error.encrypted_content:
+        Encrypted content cannot be converted to a thumbnail.
+    :ivar ThumbnailV2Error.conversion_error:
+        An error occurred during thumbnail conversion.
+    :ivar ThumbnailV2Error.access_denied:
+        Access to this shared link is forbidden.
+    :ivar ThumbnailV2Error.not_found:
+        The shared link does not exist.
     """
 
     _catch_all = 'other'
@@ -9424,7 +9626,8 @@ ThumbnailV2Error_validator = bv.Union(ThumbnailV2Error)
 
 class UnlockFileArg(bb.Struct):
     """
-    :ivar files.UnlockFileArg.path: Path in the user's Dropbox to a file.
+    :ivar UnlockFileArg.path:
+        Path in the user's Dropbox to a file.
     """
 
     __slots__ = [
@@ -9449,9 +9652,10 @@ UnlockFileArg_validator = bv.Struct(UnlockFileArg)
 
 class UnlockFileBatchArg(bb.Struct):
     """
-    :ivar files.UnlockFileBatchArg.entries: List of 'entries'. Each 'entry'
-        contains a path of the file which will be unlocked. Duplicate path
-        arguments in the batch are considered only once.
+    :ivar UnlockFileBatchArg.entries:
+        List of 'entries'. Each 'entry' contains a path of the file which will
+        be unlocked. Duplicate path arguments in the batch are considered only
+        once.
     """
 
     __slots__ = [
@@ -9476,10 +9680,11 @@ UnlockFileBatchArg_validator = bv.Struct(UnlockFileBatchArg)
 
 class UploadArg(CommitInfo):
     """
-    :ivar files.UploadArg.content_hash: A hash of the file content uploaded in
-        this call. If provided and the uploaded content does not match this
-        hash, an error will be returned. For more information see our `Content
-        hash <https://www.dropbox.com/developers/reference/content-hash>`_ page.
+    :ivar UploadArg.content_hash:
+        A hash of the file content uploaded in this call. If provided and the
+        uploaded content does not match this hash, an error will be returned.
+        For more information see our `Content hash
+        <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
     __slots__ = [
@@ -9522,17 +9727,21 @@ class UploadError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UploadWriteFailed UploadError.path: Unable to save the uploaded
-        contents to a file.
-    :ivar InvalidPropertyGroupError UploadError.properties_error: The supplied
-        property group is invalid. The file has uploaded without property
-        groups.
-    :ivar files.UploadError.payload_too_large: The request payload must be at
-        most 150 MiB.
-    :ivar files.UploadError.content_hash_mismatch: The content received by the
-        Dropbox server in this call does not match the provided content hash.
-    :ivar files.UploadError.encryption_not_supported: The file is required to be
-        encrypted, which is not supported in our public API.
+    :ivar UploadError.path:
+        Unable to save the uploaded contents to a file.
+    :vartype UploadError.path: UploadWriteFailed
+    :ivar UploadError.properties_error:
+        The supplied property group is invalid. The file has uploaded without
+        property groups.
+    :vartype UploadError.properties_error: file_properties.InvalidPropertyGroupError
+    :ivar UploadError.payload_too_large:
+        The request payload must be at most 150 MiB.
+    :ivar UploadError.content_hash_mismatch:
+        The content received by the Dropbox server in this call does not match
+        the provided content hash.
+    :ivar UploadError.encryption_not_supported:
+        The file is required to be encrypted, which is not supported in our
+        public API.
     """
 
     _catch_all = 'other'
@@ -9647,16 +9856,17 @@ UploadError_validator = bv.Union(UploadError)
 
 class UploadSessionAppendArg(bb.Struct):
     """
-    :ivar files.UploadSessionAppendArg.cursor: Contains the upload session ID
-        and the offset.
-    :ivar files.UploadSessionAppendArg.close: If true, the current session will
-        be closed, at which point you won't be able to call
+    :ivar UploadSessionAppendArg.cursor:
+        Contains the upload session ID and the offset.
+    :ivar UploadSessionAppendArg.close:
+        If true, the current session will be closed, at which point you won't be
+        able to call
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_append`
         anymore with the current session.
-    :ivar files.UploadSessionAppendArg.content_hash: A hash of the file content
-        uploaded in this call. If provided and the uploaded content does not
-        match this hash, an error will be returned. For more information see our
-        `Content hash
+    :ivar UploadSessionAppendArg.content_hash:
+        A hash of the file content uploaded in this call. If provided and the
+        uploaded content does not match this hash, an error will be returned.
+        For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
@@ -9698,13 +9908,13 @@ UploadSessionAppendArg_validator = bv.Struct(UploadSessionAppendArg)
 
 class UploadSessionAppendBatchArg(bb.Struct):
     """
-    :ivar files.UploadSessionAppendBatchArg.entries: Append information for each
-        file in the batch.
-    :ivar files.UploadSessionAppendBatchArg.content_hash: A hash of the entire
-        request body which is all the concatenated pieces of file content that
-        were uploaded in this call. If provided and the uploaded content does
-        not match this hash, an error will be returned. For more information see
-        our `Content hash
+    :ivar UploadSessionAppendBatchArg.entries:
+        Append information for each file in the batch.
+    :ivar UploadSessionAppendBatchArg.content_hash:
+        A hash of the entire request body which is all the concatenated pieces
+        of file content that were uploaded in this call. If provided and the
+        uploaded content does not match this hash, an error will be returned.
+        For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
@@ -9738,13 +9948,14 @@ UploadSessionAppendBatchArg_validator = bv.Struct(UploadSessionAppendBatchArg)
 
 class UploadSessionAppendBatchArgEntry(bb.Struct):
     """
-    :ivar files.UploadSessionAppendBatchArgEntry.cursor: Contains the upload
-        session ID and the offset.
-    :ivar files.UploadSessionAppendBatchArgEntry.length: Length in bytes of the
-        data that should be appended for this session. Used to split the batched
-        upload data for multiple upload sessions.
-    :ivar files.UploadSessionAppendBatchArgEntry.close: If true, the current
-        session will be closed, at which point you won't be able to call
+    :ivar UploadSessionAppendBatchArgEntry.cursor:
+        Contains the upload session ID and the offset.
+    :ivar UploadSessionAppendBatchArgEntry.length:
+        Length in bytes of the data that should be appended for this session.
+        Used to split the batched upload data for multiple upload sessions.
+    :ivar UploadSessionAppendBatchArgEntry.close:
+        If true, the current session will be closed, at which point you won't be
+        able to call
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_append_batch`
         anymore with the current session.
     """
@@ -9791,26 +10002,26 @@ class UploadSessionAppendBatchEntryError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionAppendBatchEntryError.not_found: The upload session
-        ID was not found or has expired. Upload sessions are valid for 7 days.
-    :ivar UploadSessionOffsetError
-        UploadSessionAppendBatchEntryError.incorrect_offset: The specified
-        offset was incorrect. See the value for the correct offset. This error
-        may occur when a previous request was received and processed
-        successfully but the client did not receive the response, e.g. due to a
-        network error.
-    :ivar files.UploadSessionAppendBatchEntryError.closed: You are attempting to
-        append data to an upload session that has already been closed (i.e.
-        committed).
-    :ivar files.UploadSessionAppendBatchEntryError.too_large: You can not append
-        to the upload session because the size of a file should not exceed the
-        max file size limit (i.e. 2^41 - 2^22 or 2,199,019,061,248 bytes).
-    :ivar
-        files.UploadSessionAppendBatchEntryError.concurrent_session_invalid_offset:
+    :ivar UploadSessionAppendBatchEntryError.not_found:
+        The upload session ID was not found or has expired. Upload sessions are
+        valid for 7 days.
+    :ivar UploadSessionAppendBatchEntryError.incorrect_offset:
+        The specified offset was incorrect. See the value for the correct
+        offset. This error may occur when a previous request was received and
+        processed successfully but the client did not receive the response, e.g.
+        due to a network error.
+    :vartype UploadSessionAppendBatchEntryError.incorrect_offset: UploadSessionOffsetError
+    :ivar UploadSessionAppendBatchEntryError.closed:
+        You are attempting to append data to an upload session that has already
+        been closed (i.e. committed).
+    :ivar UploadSessionAppendBatchEntryError.too_large:
+        You can not append to the upload session because the size of a file
+        should not exceed the max file size limit (i.e. 2^41 - 2^22 or
+        2,199,019,061,248 bytes).
+    :ivar UploadSessionAppendBatchEntryError.concurrent_session_invalid_offset:
         For concurrent upload sessions, offset needs to be multiple of 2^22
         (4,194,304) bytes.
-    :ivar
-        files.UploadSessionAppendBatchEntryError.concurrent_session_invalid_data_size:
+    :ivar UploadSessionAppendBatchEntryError.concurrent_session_invalid_data_size:
         For concurrent upload sessions, only chunks with size multiple of 2^22
         (4,194,304) bytes can be uploaded.
     """
@@ -9922,14 +10133,15 @@ class UploadSessionAppendBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionAppendBatchError.payload_too_large: The request
-        payload must be at most 150 MiB.
-    :ivar files.UploadSessionAppendBatchError.content_hash_mismatch: The content
-        received by the Dropbox server in this call does not match the provided
-        content hash.
-    :ivar files.UploadSessionAppendBatchError.length_mismatch: The total length
-        of the content received by the Dropbox server in this call does not
-        match the total of the provided lengths in the batch arguments.
+    :ivar UploadSessionAppendBatchError.payload_too_large:
+        The request payload must be at most 150 MiB.
+    :ivar UploadSessionAppendBatchError.content_hash_mismatch:
+        The content received by the Dropbox server in this call does not match
+        the provided content hash.
+    :ivar UploadSessionAppendBatchError.length_mismatch:
+        The total length of the content received by the Dropbox server in this
+        call does not match the total of the provided lengths in the batch
+        arguments.
     """
 
     _catch_all = 'other'
@@ -9981,9 +10193,9 @@ UploadSessionAppendBatchError_validator = bv.Union(UploadSessionAppendBatchError
 
 class UploadSessionAppendBatchResult(bb.Struct):
     """
-    :ivar files.UploadSessionAppendBatchResult.entries: Each entry in
-        ``UploadSessionAppendBatchArg.entries`` will appear at the same position
-        inside ``UploadSessionAppendBatchResult.entries``.
+    :ivar UploadSessionAppendBatchResult.entries:
+        Each entry in ``UploadSessionAppendBatchArg.entries`` will appear at the
+        same position inside ``UploadSessionAppendBatchResult.entries``.
     """
 
     __slots__ = [
@@ -10065,29 +10277,33 @@ class UploadSessionAppendError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionAppendError.not_found: The upload session ID was
-        not found or has expired. Upload sessions are valid for 7 days.
-    :ivar UploadSessionOffsetError UploadSessionAppendError.incorrect_offset:
+    :ivar UploadSessionAppendError.not_found:
+        The upload session ID was not found or has expired. Upload sessions are
+        valid for 7 days.
+    :ivar UploadSessionAppendError.incorrect_offset:
         The specified offset was incorrect. See the value for the correct
         offset. This error may occur when a previous request was received and
         processed successfully but the client did not receive the response, e.g.
         due to a network error.
-    :ivar files.UploadSessionAppendError.closed: You are attempting to append
-        data to an upload session that has already been closed (i.e. committed).
-    :ivar files.UploadSessionAppendError.too_large: You can not append to the
-        upload session because the size of a file should not exceed the max file
-        size limit (i.e. 2^41 - 2^22 or 2,199,019,061,248 bytes).
-    :ivar files.UploadSessionAppendError.concurrent_session_invalid_offset: For
-        concurrent upload sessions, offset needs to be multiple of 2^22
+    :vartype UploadSessionAppendError.incorrect_offset: UploadSessionOffsetError
+    :ivar UploadSessionAppendError.closed:
+        You are attempting to append data to an upload session that has already
+        been closed (i.e. committed).
+    :ivar UploadSessionAppendError.too_large:
+        You can not append to the upload session because the size of a file
+        should not exceed the max file size limit (i.e. 2^41 - 2^22 or
+        2,199,019,061,248 bytes).
+    :ivar UploadSessionAppendError.concurrent_session_invalid_offset:
+        For concurrent upload sessions, offset needs to be multiple of 2^22
         (4,194,304) bytes.
-    :ivar files.UploadSessionAppendError.concurrent_session_invalid_data_size:
+    :ivar UploadSessionAppendError.concurrent_session_invalid_data_size:
         For concurrent upload sessions, only chunks with size multiple of 2^22
         (4,194,304) bytes can be uploaded.
-    :ivar files.UploadSessionAppendError.payload_too_large: The request payload
-        must be at most 150 MiB.
-    :ivar files.UploadSessionAppendError.content_hash_mismatch: The content
-        received by the Dropbox server in this call does not match the provided
-        content hash.
+    :ivar UploadSessionAppendError.payload_too_large:
+        The request payload must be at most 150 MiB.
+    :ivar UploadSessionAppendError.content_hash_mismatch:
+        The content received by the Dropbox server in this call does not match
+        the provided content hash.
     """
 
     _catch_all = 'other'
@@ -10213,11 +10429,13 @@ UploadSessionAppendError_validator = bv.Union(UploadSessionAppendError)
 
 class UploadSessionCursor(bb.Struct):
     """
-    :ivar files.UploadSessionCursor.session_id: The upload session ID (returned
-        by :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_start`).
-    :ivar files.UploadSessionCursor.offset: Offset in bytes at which data should
-        be appended. We use this to make sure upload data isn't lost or
-        duplicated in the event of a network error.
+    :ivar UploadSessionCursor.session_id:
+        The upload session ID (returned by
+        :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_start`).
+    :ivar UploadSessionCursor.offset:
+        Offset in bytes at which data should be appended. We use this to make
+        sure upload data isn't lost or duplicated in the event of a network
+        error.
     """
 
     __slots__ = [
@@ -10250,14 +10468,14 @@ UploadSessionCursor_validator = bv.Struct(UploadSessionCursor)
 
 class UploadSessionFinishArg(bb.Struct):
     """
-    :ivar files.UploadSessionFinishArg.cursor: Contains the upload session ID
-        and the offset.
-    :ivar files.UploadSessionFinishArg.commit: Contains the path and other
-        optional modifiers for the commit.
-    :ivar files.UploadSessionFinishArg.content_hash: A hash of the file content
-        uploaded in this call. If provided and the uploaded content does not
-        match this hash, an error will be returned. For more information see our
-        `Content hash
+    :ivar UploadSessionFinishArg.cursor:
+        Contains the upload session ID and the offset.
+    :ivar UploadSessionFinishArg.commit:
+        Contains the path and other optional modifiers for the commit.
+    :ivar UploadSessionFinishArg.content_hash:
+        A hash of the file content uploaded in this call. If provided and the
+        uploaded content does not match this hash, an error will be returned.
+        For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
@@ -10299,8 +10517,8 @@ UploadSessionFinishArg_validator = bv.Struct(UploadSessionFinishArg)
 
 class UploadSessionFinishBatchArg(bb.Struct):
     """
-    :ivar files.UploadSessionFinishBatchArg.entries: Commit information for each
-        file in the batch.
+    :ivar UploadSessionFinishBatchArg.entries:
+        Commit information for each file in the batch.
     """
 
     __slots__ = [
@@ -10329,10 +10547,11 @@ class UploadSessionFinishBatchJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UploadSessionFinishBatchResult
-        UploadSessionFinishBatchJobStatus.complete: The
+    :ivar UploadSessionFinishBatchJobStatus.complete:
+        The
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_finish_batch`
         has finished.
+    :vartype UploadSessionFinishBatchJobStatus.complete: UploadSessionFinishBatchResult
     """
 
     @classmethod
@@ -10432,9 +10651,9 @@ UploadSessionFinishBatchLaunch_validator = bv.Union(UploadSessionFinishBatchLaun
 
 class UploadSessionFinishBatchResult(bb.Struct):
     """
-    :ivar files.UploadSessionFinishBatchResult.entries: Each entry in
-        ``UploadSessionFinishBatchArg.entries`` will appear at the same position
-        inside ``UploadSessionFinishBatchResult.entries``.
+    :ivar UploadSessionFinishBatchResult.entries:
+        Each entry in ``UploadSessionFinishBatchArg.entries`` will appear at the
+        same position inside ``UploadSessionFinishBatchResult.entries``.
     """
 
     __slots__ = [
@@ -10535,34 +10754,40 @@ class UploadSessionFinishError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UploadSessionLookupError UploadSessionFinishError.lookup_failed: The
-        session arguments are incorrect; the value explains the reason.
-    :ivar WriteError UploadSessionFinishError.path: Unable to save the uploaded
-        contents to a file. Data has already been appended to the upload
-        session. Please retry with empty data body and updated offset.
-    :ivar InvalidPropertyGroupError UploadSessionFinishError.properties_error:
+    :ivar UploadSessionFinishError.lookup_failed:
+        The session arguments are incorrect; the value explains the reason.
+    :vartype UploadSessionFinishError.lookup_failed: UploadSessionLookupError
+    :ivar UploadSessionFinishError.path:
+        Unable to save the uploaded contents to a file. Data has already been
+        appended to the upload session. Please retry with empty data body and
+        updated offset.
+    :vartype UploadSessionFinishError.path: WriteError
+    :ivar UploadSessionFinishError.properties_error:
         The supplied property group is invalid. The file has uploaded without
         property groups.
-    :ivar files.UploadSessionFinishError.too_many_shared_folder_targets: Field
-        is deprecated. The batch request commits files into too many different
-        shared folders. Please limit your batch request to files contained in a
-        single shared folder.
-    :ivar files.UploadSessionFinishError.too_many_write_operations: There are
-        too many write operations happening in the user's Dropbox. You should
-        retry uploading this file.
-    :ivar files.UploadSessionFinishError.concurrent_session_data_not_allowed:
+    :vartype UploadSessionFinishError.properties_error: file_properties.InvalidPropertyGroupError
+    :ivar UploadSessionFinishError.too_many_shared_folder_targets:
+        Field is deprecated. The batch request commits files into too many
+        different shared folders. Please limit your batch request to files
+        contained in a single shared folder.
+    :ivar UploadSessionFinishError.too_many_write_operations:
+        There are too many write operations happening in the user's Dropbox. You
+        should retry uploading this file.
+    :ivar UploadSessionFinishError.concurrent_session_data_not_allowed:
         Uploading data not allowed when finishing concurrent upload session.
-    :ivar files.UploadSessionFinishError.concurrent_session_not_closed:
+    :ivar UploadSessionFinishError.concurrent_session_not_closed:
         Concurrent upload sessions need to be closed before finishing.
-    :ivar files.UploadSessionFinishError.concurrent_session_missing_data: Not
-        all pieces of data were uploaded before trying to finish the session.
-    :ivar files.UploadSessionFinishError.payload_too_large: The request payload
-        must be at most 150 MiB.
-    :ivar files.UploadSessionFinishError.content_hash_mismatch: The content
-        received by the Dropbox server in this call does not match the provided
-        content hash.
-    :ivar files.UploadSessionFinishError.encryption_not_supported: The file is
-        required to be encrypted, which is not supported in our public API.
+    :ivar UploadSessionFinishError.concurrent_session_missing_data:
+        Not all pieces of data were uploaded before trying to finish the
+        session.
+    :ivar UploadSessionFinishError.payload_too_large:
+        The request payload must be at most 150 MiB.
+    :ivar UploadSessionFinishError.content_hash_mismatch:
+        The content received by the Dropbox server in this call does not match
+        the provided content hash.
+    :ivar UploadSessionFinishError.encryption_not_supported:
+        The file is required to be encrypted, which is not supported in our
+        public API.
     """
 
     _catch_all = 'other'
@@ -10764,28 +10989,32 @@ class UploadSessionLookupError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionLookupError.not_found: The upload session ID was
-        not found or has expired. Upload sessions are valid for 7 days.
-    :ivar UploadSessionOffsetError UploadSessionLookupError.incorrect_offset:
+    :ivar UploadSessionLookupError.not_found:
+        The upload session ID was not found or has expired. Upload sessions are
+        valid for 7 days.
+    :ivar UploadSessionLookupError.incorrect_offset:
         The specified offset was incorrect. See the value for the correct
         offset. This error may occur when a previous request was received and
         processed successfully but the client did not receive the response, e.g.
         due to a network error.
-    :ivar files.UploadSessionLookupError.closed: You are attempting to append
-        data to an upload session that has already been closed (i.e. committed).
-    :ivar files.UploadSessionLookupError.not_closed: The session must be closed
-        before calling upload_session/finish_batch.
-    :ivar files.UploadSessionLookupError.too_large: You can not append to the
-        upload session because the size of a file should not exceed the max file
-        size limit (i.e. 2^41 - 2^22 or 2,199,019,061,248 bytes).
-    :ivar files.UploadSessionLookupError.concurrent_session_invalid_offset: For
-        concurrent upload sessions, offset needs to be multiple of 2^22
+    :vartype UploadSessionLookupError.incorrect_offset: UploadSessionOffsetError
+    :ivar UploadSessionLookupError.closed:
+        You are attempting to append data to an upload session that has already
+        been closed (i.e. committed).
+    :ivar UploadSessionLookupError.not_closed:
+        The session must be closed before calling upload_session/finish_batch.
+    :ivar UploadSessionLookupError.too_large:
+        You can not append to the upload session because the size of a file
+        should not exceed the max file size limit (i.e. 2^41 - 2^22 or
+        2,199,019,061,248 bytes).
+    :ivar UploadSessionLookupError.concurrent_session_invalid_offset:
+        For concurrent upload sessions, offset needs to be multiple of 2^22
         (4,194,304) bytes.
-    :ivar files.UploadSessionLookupError.concurrent_session_invalid_data_size:
+    :ivar UploadSessionLookupError.concurrent_session_invalid_data_size:
         For concurrent upload sessions, only chunks with size multiple of 2^22
         (4,194,304) bytes can be uploaded.
-    :ivar files.UploadSessionLookupError.payload_too_large: The request payload
-        must be at most 150 MiB.
+    :ivar UploadSessionLookupError.payload_too_large:
+        The request payload must be at most 150 MiB.
     """
 
     _catch_all = 'other'
@@ -10911,8 +11140,8 @@ UploadSessionLookupError_validator = bv.Union(UploadSessionLookupError)
 
 class UploadSessionOffsetError(bb.Struct):
     """
-    :ivar files.UploadSessionOffsetError.correct_offset: The offset up to which
-        data has been collected.
+    :ivar UploadSessionOffsetError.correct_offset:
+        The offset up to which data has been collected.
     """
 
     __slots__ = [
@@ -10937,17 +11166,18 @@ UploadSessionOffsetError_validator = bv.Struct(UploadSessionOffsetError)
 
 class UploadSessionStartArg(bb.Struct):
     """
-    :ivar files.UploadSessionStartArg.close: If true, the current session will
-        be closed, at which point you won't be able to call
+    :ivar UploadSessionStartArg.close:
+        If true, the current session will be closed, at which point you won't be
+        able to call
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_append`
         anymore with the current session.
-    :ivar files.UploadSessionStartArg.session_type: Type of upload session you
-        want to start. If not specified, default is
+    :ivar UploadSessionStartArg.session_type:
+        Type of upload session you want to start. If not specified, default is
         ``UploadSessionType.sequential``.
-    :ivar files.UploadSessionStartArg.content_hash: A hash of the file content
-        uploaded in this call. If provided and the uploaded content does not
-        match this hash, an error will be returned. For more information see our
-        `Content hash
+    :ivar UploadSessionStartArg.content_hash:
+        A hash of the file content uploaded in this call. If provided and the
+        uploaded content does not match this hash, an error will be returned.
+        For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
@@ -10989,11 +11219,11 @@ UploadSessionStartArg_validator = bv.Struct(UploadSessionStartArg)
 
 class UploadSessionStartBatchArg(bb.Struct):
     """
-    :ivar files.UploadSessionStartBatchArg.session_type: Type of upload session
-        you want to start. If not specified, default is
+    :ivar UploadSessionStartBatchArg.session_type:
+        Type of upload session you want to start. If not specified, default is
         ``UploadSessionType.sequential``.
-    :ivar files.UploadSessionStartBatchArg.num_sessions: The number of upload
-        sessions to start.
+    :ivar UploadSessionStartBatchArg.num_sessions:
+        The number of upload sessions to start.
     """
 
     __slots__ = [
@@ -11026,8 +11256,9 @@ UploadSessionStartBatchArg_validator = bv.Struct(UploadSessionStartBatchArg)
 
 class UploadSessionStartBatchResult(bb.Struct):
     """
-    :ivar files.UploadSessionStartBatchResult.session_ids: A List of unique
-        identifiers for the upload session. Pass each session_id to
+    :ivar UploadSessionStartBatchResult.session_ids:
+        A List of unique identifiers for the upload session. Pass each
+        session_id to
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_append` and
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_finish`.
     """
@@ -11058,15 +11289,15 @@ class UploadSessionStartError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionStartError.concurrent_session_data_not_allowed:
+    :ivar UploadSessionStartError.concurrent_session_data_not_allowed:
         Uploading data not allowed when starting concurrent upload session.
-    :ivar files.UploadSessionStartError.concurrent_session_close_not_allowed:
+    :ivar UploadSessionStartError.concurrent_session_close_not_allowed:
         Can not start a closed concurrent upload session.
-    :ivar files.UploadSessionStartError.payload_too_large: The request payload
-        must be at most 150 MiB.
-    :ivar files.UploadSessionStartError.content_hash_mismatch: The content
-        received by the Dropbox server in this call does not match the provided
-        content hash.
+    :ivar UploadSessionStartError.payload_too_large:
+        The request payload must be at most 150 MiB.
+    :ivar UploadSessionStartError.content_hash_mismatch:
+        The content received by the Dropbox server in this call does not match
+        the provided content hash.
     """
 
     _catch_all = 'other'
@@ -11128,8 +11359,8 @@ UploadSessionStartError_validator = bv.Union(UploadSessionStartError)
 
 class UploadSessionStartResult(bb.Struct):
     """
-    :ivar files.UploadSessionStartResult.session_id: A unique identifier for the
-        upload session. Pass this to
+    :ivar UploadSessionStartResult.session_id:
+        A unique identifier for the upload session. Pass this to
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_append` and
         :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_finish`.
     """
@@ -11160,10 +11391,11 @@ class UploadSessionType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.UploadSessionType.sequential: Pieces of data are uploaded
-        sequentially one after another. This is the default behavior.
-    :ivar files.UploadSessionType.concurrent: Pieces of data can be uploaded in
-        concurrent RPCs in any order.
+    :ivar UploadSessionType.sequential:
+        Pieces of data are uploaded sequentially one after another. This is the
+        default behavior.
+    :ivar UploadSessionType.concurrent:
+        Pieces of data can be uploaded in concurrent RPCs in any order.
     """
 
     _catch_all = 'other'
@@ -11205,12 +11437,12 @@ UploadSessionType_validator = bv.Union(UploadSessionType)
 
 class UploadWriteFailed(bb.Struct):
     """
-    :ivar files.UploadWriteFailed.reason: The reason why the file couldn't be
-        saved.
-    :ivar files.UploadWriteFailed.upload_session_id: The upload session ID; data
-        has already been uploaded to the corresponding upload session and this
-        ID may be used to retry the commit with
-        :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_finish`.
+    :ivar UploadWriteFailed.reason:
+        The reason why the file couldn't be saved.
+    :ivar UploadWriteFailed.upload_session_id:
+        The upload session ID; data has already been uploaded to the
+        corresponding upload session and this ID may be used to retry the commit
+        with :meth:`dropbox.dropbox_client.Dropbox.files_upload_session_finish`.
     """
 
     __slots__ = [
@@ -11267,8 +11499,8 @@ class VideoMetadata(MediaMetadata):
     """
     Metadata for a video.
 
-    :ivar files.VideoMetadata.duration: The duration of the video in
-        milliseconds.
+    :ivar VideoMetadata.duration:
+        The duration of the video in milliseconds.
     """
 
     __slots__ = [
@@ -11303,10 +11535,13 @@ class WriteConflictError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.WriteConflictError.file: There's a file in the way.
-    :ivar files.WriteConflictError.folder: There's a folder in the way.
-    :ivar files.WriteConflictError.file_ancestor: There's a file at an ancestor
-        path, so we couldn't create the required parent folders.
+    :ivar WriteConflictError.file:
+        There's a file in the way.
+    :ivar WriteConflictError.folder:
+        There's a folder in the way.
+    :ivar WriteConflictError.file_ancestor:
+        There's a file at an ancestor path, so we couldn't create the required
+        parent folders.
     """
 
     _catch_all = 'other'
@@ -11362,27 +11597,32 @@ class WriteError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar Optional[str] files.WriteError.malformed_path: The given path does not
-        satisfy the required path format. Please refer to the :link:`Path
-        formats documentation
-        https://www.dropbox.com/developers/documentation/http/documentation#path-formats`
+    :ivar WriteError.malformed_path:
+        The given path does not satisfy the required path format. Please refer
+        to the `Path formats documentation
+        <https://www.dropbox.com/developers/documentation/http/documentation#path-formats>`_
         for more information.
-    :ivar WriteConflictError WriteError.conflict: Couldn't write to the target
-        path because there was something in the way.
-    :ivar files.WriteError.no_write_permission: The user doesn't have
-        permissions to write to the target location.
-    :ivar files.WriteError.insufficient_space: The user doesn't have enough
-        available space (bytes) to write more data.
-    :ivar files.WriteError.disallowed_name: Dropbox will not save the file or
-        folder because of its name.
-    :ivar files.WriteError.team_folder: This endpoint cannot move or delete team
-        folders.
-    :ivar files.WriteError.operation_suppressed: This file operation is not
-        allowed at this path.
-    :ivar files.WriteError.too_many_write_operations: There are too many write
-        operations in user's Dropbox. Please retry this request.
-    :ivar files.WriteError.access_restricted: The user doesn't have permission
-        to perform the action due to restrictions set by a team administrator
+    :vartype WriteError.malformed_path: Optional[str]
+    :ivar WriteError.conflict:
+        Couldn't write to the target path because there was something in the
+        way.
+    :vartype WriteError.conflict: WriteConflictError
+    :ivar WriteError.no_write_permission:
+        The user doesn't have permissions to write to the target location.
+    :ivar WriteError.insufficient_space:
+        The user doesn't have enough available space (bytes) to write more data.
+    :ivar WriteError.disallowed_name:
+        Dropbox will not save the file or folder because of its name.
+    :ivar WriteError.team_folder:
+        This endpoint cannot move or delete team folders.
+    :ivar WriteError.operation_suppressed:
+        This file operation is not allowed at this path.
+    :ivar WriteError.too_many_write_operations:
+        There are too many write operations in user's Dropbox. Please retry this
+        request.
+    :ivar WriteError.access_restricted:
+        The user doesn't have permission to perform the action due to
+        restrictions set by a team administrator
     """
 
     _catch_all = 'other'
@@ -11554,20 +11794,24 @@ class WriteMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar files.WriteMode.add: Do not overwrite an existing file if there is a
-        conflict. The autorename strategy is to append a number to the file
-        name. For example, "document.txt" might become "document (2).txt".
-    :ivar files.WriteMode.overwrite: Always overwrite the existing file. The
-        autorename strategy is the same as it is for ``add``.
-    :ivar str files.WriteMode.update: Overwrite if the given "rev" matches the
-        existing file's "rev". The supplied value should be the latest known
-        "rev" of the file, for example, from :type:`FileMetadata`, from when the
-        file was last downloaded by the app. This will cause the file on the
-        Dropbox servers to be overwritten if the given "rev" matches the
-        existing file's current "rev" on the Dropbox servers. The autorename
-        strategy is to append the string "conflicted copy" to the file name. For
-        example, "document.txt" might become "document (conflicted copy).txt" or
-        "document (Panda's conflicted copy).txt".
+    :ivar WriteMode.add:
+        Do not overwrite an existing file if there is a conflict. The autorename
+        strategy is to append a number to the file name. For example,
+        "document.txt" might become "document (2).txt".
+    :ivar WriteMode.overwrite:
+        Always overwrite the existing file. The autorename strategy is the same
+        as it is for ``add``.
+    :ivar WriteMode.update:
+        Overwrite if the given "rev" matches the existing file's "rev". The
+        supplied value should be the latest known "rev" of the file, for
+        example, from :class:`FileMetadata`, from when the file was last
+        downloaded by the app. This will cause the file on the Dropbox servers
+        to be overwritten if the given "rev" matches the existing file's current
+        "rev" on the Dropbox servers. The autorename strategy is to append the
+        string "conflicted copy" to the file name. For example, "document.txt"
+        might become "document (conflicted copy).txt" or "document (Panda's
+        conflicted copy).txt".
+    :vartype WriteMode.update: str
     """
 
     _catch_all = None

--- a/dropbox/openid.py
+++ b/dropbox/openid.py
@@ -13,8 +13,8 @@ class OpenIdError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar openid.OpenIdError.incorrect_openid_scopes: Missing openid claims for
-        the associated access token.
+    :ivar OpenIdError.incorrect_openid_scopes:
+        Missing openid claims for the associated access token.
     """
 
     _catch_all = 'other'
@@ -117,14 +117,19 @@ UserInfoError_validator = bv.Union(UserInfoError)
 
 class UserInfoResult(bb.Struct):
     """
-    :ivar openid.UserInfoResult.family_name: Last name of user.
-    :ivar openid.UserInfoResult.given_name: First name of user.
-    :ivar openid.UserInfoResult.email: Email address of user.
-    :ivar openid.UserInfoResult.email_verified: If user is email verified.
-    :ivar openid.UserInfoResult.iss: Issuer of token (in this case Dropbox).
-    :ivar openid.UserInfoResult.sub: An identifier for the user. This is the
-        Dropbox account_id, a string value such as
-        dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc.
+    :ivar UserInfoResult.family_name:
+        Last name of user.
+    :ivar UserInfoResult.given_name:
+        First name of user.
+    :ivar UserInfoResult.email:
+        Email address of user.
+    :ivar UserInfoResult.email_verified:
+        If user is email verified.
+    :ivar UserInfoResult.iss:
+        Issuer of token (in this case Dropbox).
+    :ivar UserInfoResult.sub:
+        An identifier for the user. This is the Dropbox account_id, a string
+        value such as dbid:AAH4f99T0taONIb-OurWxbNQ6ywGRopQngc.
     """
 
     __slots__ = [

--- a/dropbox/paper.py
+++ b/dropbox/paper.py
@@ -18,9 +18,11 @@ from dropbox import sharing
 
 class AddMember(bb.Struct):
     """
-    :ivar paper.AddMember.permission_level: Permission for the user.
-    :ivar paper.AddMember.member: User which should be added to the Paper doc.
-        Specify only email address or Dropbox account ID.
+    :ivar AddMember.permission_level:
+        Permission for the user.
+    :ivar AddMember.member:
+        User which should be added to the Paper doc. Specify only email address
+        or Dropbox account ID.
     """
 
     __slots__ = [
@@ -53,7 +55,8 @@ AddMember_validator = bv.Struct(AddMember)
 
 class RefPaperDoc(bb.Struct):
     """
-    :ivar paper.RefPaperDoc.doc_id: The Paper doc ID.
+    :ivar RefPaperDoc.doc_id:
+        The Paper doc ID.
     """
 
     __slots__ = [
@@ -78,12 +81,15 @@ RefPaperDoc_validator = bv.Struct(RefPaperDoc)
 
 class AddPaperDocUser(RefPaperDoc):
     """
-    :ivar paper.AddPaperDocUser.members: User which should be added to the Paper
-        doc. Specify only email address or Dropbox account ID.
-    :ivar paper.AddPaperDocUser.custom_message: A personal message that will be
-        emailed to each successfully added member.
-    :ivar paper.AddPaperDocUser.quiet: Clients should set this to true if no
-        email message shall be sent to added users.
+    :ivar AddPaperDocUser.members:
+        User which should be added to the Paper doc. Specify only email address
+        or Dropbox account ID.
+    :ivar AddPaperDocUser.custom_message:
+        A personal message that will be emailed to each successfully added
+        member.
+    :ivar AddPaperDocUser.quiet:
+        Clients should set this to true if no email message shall be sent to
+        added users.
     """
 
     __slots__ = [
@@ -129,10 +135,10 @@ class AddPaperDocUserMemberResult(bb.Struct):
     Per-member result for
     :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_add`.
 
-    :ivar paper.AddPaperDocUserMemberResult.member: One of specified input
-        members.
-    :ivar paper.AddPaperDocUserMemberResult.result: The outcome of the action on
-        this member.
+    :ivar AddPaperDocUserMemberResult.member:
+        One of specified input members.
+    :ivar AddPaperDocUserMemberResult.result:
+        The outcome of the action on this member.
     """
 
     __slots__ = [
@@ -169,20 +175,22 @@ class AddPaperDocUserResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.AddPaperDocUserResult.success: User was successfully added to
-        the Paper doc.
-    :ivar paper.AddPaperDocUserResult.unknown_error: Something unexpected
-        happened when trying to add the user to the Paper doc.
-    :ivar paper.AddPaperDocUserResult.sharing_outside_team_disabled: The Paper
-        doc can be shared only with team members.
-    :ivar paper.AddPaperDocUserResult.daily_limit_reached: The daily limit of
-        how many users can be added to the Paper doc was reached.
-    :ivar paper.AddPaperDocUserResult.user_is_owner: Owner's permissions cannot
-        be changed.
-    :ivar paper.AddPaperDocUserResult.failed_user_data_retrieval: User data
-        could not be retrieved. Clients should retry.
-    :ivar paper.AddPaperDocUserResult.permission_already_granted: This user
-        already has the correct permission to the Paper doc.
+    :ivar AddPaperDocUserResult.success:
+        User was successfully added to the Paper doc.
+    :ivar AddPaperDocUserResult.unknown_error:
+        Something unexpected happened when trying to add the user to the Paper
+        doc.
+    :ivar AddPaperDocUserResult.sharing_outside_team_disabled:
+        The Paper doc can be shared only with team members.
+    :ivar AddPaperDocUserResult.daily_limit_reached:
+        The daily limit of how many users can be added to the Paper doc was
+        reached.
+    :ivar AddPaperDocUserResult.user_is_owner:
+        Owner's permissions cannot be changed.
+    :ivar AddPaperDocUserResult.failed_user_data_retrieval:
+        User data could not be retrieved. Clients should retry.
+    :ivar AddPaperDocUserResult.permission_already_granted:
+        This user already has the correct permission to the Paper doc.
     """
 
     _catch_all = 'other'
@@ -274,20 +282,22 @@ AddPaperDocUserResult_validator = bv.Union(AddPaperDocUserResult)
 
 class Cursor(bb.Struct):
     """
-    :ivar paper.Cursor.value: The actual cursor value.
-    :ivar paper.Cursor.expiration: Expiration time of ``value``. Some cursors
-        might have expiration time assigned. This is a UTC value after which the
-        cursor is no longer valid and the API starts returning an error. If
-        cursor expires a new one needs to be obtained and pagination needs to be
-        restarted. Some cursors might be short-lived some cursors might be
-        long-lived. This really depends on the sorting type and order, e.g.: 1.
-        on one hand, listing docs created by the user, sorted by the created
-        time ascending will have undefinite expiration because the results
-        cannot change while the iteration is happening. This cursor would be
-        suitable for long term polling. 2. on the other hand, listing docs
-        sorted by the last modified time will have a very short expiration as
-        docs do get modified very often and the modified time can be changed
-        while the iteration is happening thus altering the results.
+    :ivar Cursor.value:
+        The actual cursor value.
+    :ivar Cursor.expiration:
+        Expiration time of ``value``. Some cursors might have expiration time
+        assigned. This is a UTC value after which the cursor is no longer valid
+        and the API starts returning an error. If cursor expires a new one needs
+        to be obtained and pagination needs to be restarted. Some cursors might
+        be short-lived some cursors might be long-lived. This really depends on
+        the sorting type and order, e.g.: 1. on one hand, listing docs created
+        by the user, sorted by the created time ascending will have undefinite
+        expiration because the results cannot change while the iteration is
+        happening. This cursor would be suitable for long term polling. 2. on
+        the other hand, listing docs sorted by the last modified time will have
+        a very short expiration as docs do get modified very often and the
+        modified time can be changed while the iteration is happening thus
+        altering the results.
     """
 
     __slots__ = [
@@ -324,10 +334,10 @@ class PaperApiBaseError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperApiBaseError.insufficient_permissions: Your account does
-        not have permissions to perform this action. This may be due to it only
-        having access to Paper as files in the Dropbox filesystem. For more
-        information, refer to the `Paper Migration Guide
+    :ivar PaperApiBaseError.insufficient_permissions:
+        Your account does not have permissions to perform this action. This may
+        be due to it only having access to Paper as files in the Dropbox
+        filesystem. For more information, refer to the `Paper Migration Guide
         <https://www.dropbox.com/lp/developers/reference/paper-migration-guide>`_.
     """
 
@@ -364,7 +374,8 @@ class DocLookupError(PaperApiBaseError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.DocLookupError.doc_not_found: The required doc was not found.
+    :ivar DocLookupError.doc_not_found:
+        The required doc was not found.
     """
 
     # Attribute is overwritten below the class definition
@@ -391,14 +402,17 @@ class DocSubscriptionLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.DocSubscriptionLevel.default: No change email messages unless
-        you're the creator.
-    :ivar paper.DocSubscriptionLevel.ignore: Ignored: Not shown in pad lists or
-        activity and no email message is sent.
-    :ivar paper.DocSubscriptionLevel.every: Subscribed: Shown in pad lists and
-        activity and change email messages are sent.
-    :ivar paper.DocSubscriptionLevel.no_email: Unsubscribed: Shown in pad lists,
-        but not in activity and no change email messages are sent.
+    :ivar DocSubscriptionLevel.default:
+        No change email messages unless you're the creator.
+    :ivar DocSubscriptionLevel.ignore:
+        Ignored: Not shown in pad lists or activity and no email message is
+        sent.
+    :ivar DocSubscriptionLevel.every:
+        Subscribed: Shown in pad lists and activity and change email messages
+        are sent.
+    :ivar DocSubscriptionLevel.no_email:
+        Unsubscribed: Shown in pad lists, but not in activity and no change
+        email messages are sent.
     """
 
     _catch_all = None
@@ -456,9 +470,12 @@ class ExportFormat(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ExportFormat.html: The HTML export format.
-    :ivar paper.ExportFormat.markdown: The markdown export format.
-    :ivar paper.ExportFormat.json: Doc metadata JSON export format.
+    :ivar ExportFormat.html:
+        The HTML export format.
+    :ivar ExportFormat.markdown:
+        The markdown export format.
+    :ivar ExportFormat.json:
+        Doc metadata JSON export format.
     """
 
     _catch_all = 'other'
@@ -512,9 +529,10 @@ class Folder(bb.Struct):
     """
     Data structure representing a Paper folder.
 
-    :ivar paper.Folder.id: Paper folder ID. This ID uniquely identifies the
-        folder.
-    :ivar paper.Folder.name: Paper folder name.
+    :ivar Folder.id:
+        Paper folder ID. This ID uniquely identifies the folder.
+    :ivar Folder.name:
+        Paper folder name.
     """
 
     __slots__ = [
@@ -554,10 +572,11 @@ class FolderSharingPolicyType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.FolderSharingPolicyType.team: Everyone in your team and anyone
-        directly invited can access this folder.
-    :ivar paper.FolderSharingPolicyType.invite_only: Only people directly
-        invited can access this folder.
+    :ivar FolderSharingPolicyType.team:
+        Everyone in your team and anyone directly invited can access this
+        folder.
+    :ivar FolderSharingPolicyType.invite_only:
+        Only people directly invited can access this folder.
     """
 
     _catch_all = None
@@ -595,14 +614,14 @@ class FolderSubscriptionLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.FolderSubscriptionLevel.none: Not shown in activity, no email
-        messages.
-    :ivar paper.FolderSubscriptionLevel.activity_only: Shown in activity, no
-        email messages.
-    :ivar paper.FolderSubscriptionLevel.daily_emails: Shown in activity, daily
-        email messages.
-    :ivar paper.FolderSubscriptionLevel.weekly_emails: Shown in activity, weekly
-        email messages.
+    :ivar FolderSubscriptionLevel.none:
+        Not shown in activity, no email messages.
+    :ivar FolderSubscriptionLevel.activity_only:
+        Shown in activity, no email messages.
+    :ivar FolderSubscriptionLevel.daily_emails:
+        Shown in activity, daily email messages.
+    :ivar FolderSubscriptionLevel.weekly_emails:
+        Shown in activity, weekly email messages.
     """
 
     _catch_all = None
@@ -656,10 +675,10 @@ class FoldersContainingPaperDoc(bb.Struct):
     """
     Metadata about Paper folders containing the specififed Paper doc.
 
-    :ivar paper.FoldersContainingPaperDoc.folder_sharing_policy_type: The
-        sharing policy of the folder containing the Paper doc.
-    :ivar paper.FoldersContainingPaperDoc.folders: The folder path. If present
-        the first folder is the root folder.
+    :ivar FoldersContainingPaperDoc.folder_sharing_policy_type:
+        The sharing policy of the folder containing the Paper doc.
+    :ivar FoldersContainingPaperDoc.folders:
+        The folder path. If present the first folder is the root folder.
     """
 
     __slots__ = [
@@ -695,9 +714,10 @@ class GetDocMetadataArg(bb.Struct):
     Argument for retrieving Paper doc metadata. Accepts either a legacy Paper
     doc ID or a Cloud Doc file ID.
 
-    :ivar paper.GetDocMetadataArg.doc_id: Legacy Paper doc identifier.
-    :ivar paper.GetDocMetadataArg.file_id: Dropbox file ID for Cloud Docs
-        (post-PiFS migration).
+    :ivar GetDocMetadataArg.doc_id:
+        Legacy Paper doc identifier.
+    :ivar GetDocMetadataArg.file_id:
+        Dropbox file ID for Cloud Docs (post-PiFS migration).
     """
 
     __slots__ = [
@@ -736,14 +756,14 @@ class ImportFormat(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ImportFormat.html: The provided data is interpreted as standard
-        HTML.
-    :ivar paper.ImportFormat.markdown: The provided data is interpreted as
-        markdown. The first line of the provided document will be used as the
-        doc title.
-    :ivar paper.ImportFormat.plain_text: The provided data is interpreted as
-        plain text. The first line of the provided document will be used as the
-        doc title.
+    :ivar ImportFormat.html:
+        The provided data is interpreted as standard HTML.
+    :ivar ImportFormat.markdown:
+        The provided data is interpreted as markdown. The first line of the
+        provided document will be used as the doc title.
+    :ivar ImportFormat.plain_text:
+        The provided data is interpreted as plain text. The first line of the
+        provided document will be used as the doc title.
     """
 
     _catch_all = 'other'
@@ -795,10 +815,10 @@ ImportFormat_validator = bv.Union(ImportFormat)
 
 class InviteeInfoWithPermissionLevel(bb.Struct):
     """
-    :ivar paper.InviteeInfoWithPermissionLevel.invitee: Email address invited to
-        the Paper doc.
-    :ivar paper.InviteeInfoWithPermissionLevel.permission_level: Permission
-        level for the invitee.
+    :ivar InviteeInfoWithPermissionLevel.invitee:
+        Email address invited to the Paper doc.
+    :ivar InviteeInfoWithPermissionLevel.permission_level:
+        Permission level for the invitee.
     """
 
     __slots__ = [
@@ -884,17 +904,17 @@ ListDocsCursorError_validator = bv.Union(ListDocsCursorError)
 
 class ListPaperDocsArgs(bb.Struct):
     """
-    :ivar paper.ListPaperDocsArgs.filter_by: Allows user to specify how the
-        Paper docs should be filtered.
-    :ivar paper.ListPaperDocsArgs.sort_by: Allows user to specify how the Paper
-        docs should be sorted.
-    :ivar paper.ListPaperDocsArgs.sort_order: Allows user to specify the sort
-        order of the result.
-    :ivar paper.ListPaperDocsArgs.limit: Size limit per batch. The maximum
-        number of docs that can be retrieved per batch is 1000. Higher value
-        results in invalid arguments error.
-    :ivar paper.ListPaperDocsArgs.stop_at_date: Do not return results beyond
-        this date. Behavior depends on sort order.
+    :ivar ListPaperDocsArgs.filter_by:
+        Allows user to specify how the Paper docs should be filtered.
+    :ivar ListPaperDocsArgs.sort_by:
+        Allows user to specify how the Paper docs should be sorted.
+    :ivar ListPaperDocsArgs.sort_order:
+        Allows user to specify the sort order of the result.
+    :ivar ListPaperDocsArgs.limit:
+        Size limit per batch. The maximum number of docs that can be retrieved
+        per batch is 1000. Higher value results in invalid arguments error.
+    :ivar ListPaperDocsArgs.stop_at_date:
+        Do not return results beyond this date. Behavior depends on sort order.
     """
 
     __slots__ = [
@@ -951,7 +971,8 @@ ListPaperDocsArgs_validator = bv.Struct(ListPaperDocsArgs)
 
 class ListPaperDocsContinueArgs(bb.Struct):
     """
-    :ivar paper.ListPaperDocsContinueArgs.cursor: The cursor obtained from
+    :ivar ListPaperDocsContinueArgs.cursor:
+        The cursor obtained from
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list` or
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list_continue`. Allows
         for pagination.
@@ -983,10 +1004,10 @@ class ListPaperDocsFilterBy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ListPaperDocsFilterBy.docs_accessed: Fetches all Paper doc IDs
-        that the user has ever accessed.
-    :ivar paper.ListPaperDocsFilterBy.docs_created: Fetches only the Paper doc
-        IDs that the user has created.
+    :ivar ListPaperDocsFilterBy.docs_accessed:
+        Fetches all Paper doc IDs that the user has ever accessed.
+    :ivar ListPaperDocsFilterBy.docs_created:
+        Fetches only the Paper doc IDs that the user has created.
     """
 
     _catch_all = 'other'
@@ -1028,17 +1049,19 @@ ListPaperDocsFilterBy_validator = bv.Union(ListPaperDocsFilterBy)
 
 class ListPaperDocsResponse(bb.Struct):
     """
-    :ivar paper.ListPaperDocsResponse.doc_ids: The list of Paper doc IDs that
-        can be used to access the given Paper docs or supplied to other API
-        methods. The list is sorted in the order specified by the initial call
-        to :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list`.
-    :ivar paper.ListPaperDocsResponse.cursor: Pass the cursor into
+    :ivar ListPaperDocsResponse.doc_ids:
+        The list of Paper doc IDs that can be used to access the given Paper
+        docs or supplied to other API methods. The list is sorted in the order
+        specified by the initial call to
+        :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list`.
+    :ivar ListPaperDocsResponse.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list_continue` to
         paginate through all files. The cursor preserves all properties as
         specified in the original call to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list`.
-    :ivar paper.ListPaperDocsResponse.has_more: Will be set to True if a
-        subsequent call with the provided cursor to
+    :ivar ListPaperDocsResponse.has_more:
+        Will be set to True if a subsequent call with the provided cursor to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_list_continue` returns
         immediately with some results. If set to False please allow some delay
         before making another call to
@@ -1087,12 +1110,12 @@ class ListPaperDocsSortBy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ListPaperDocsSortBy.accessed: Sorts the Paper docs by the time
-        they were last accessed.
-    :ivar paper.ListPaperDocsSortBy.modified: Sorts the Paper docs by the time
-        they were last modified.
-    :ivar paper.ListPaperDocsSortBy.created: Sorts the Paper docs by the
-        creation time.
+    :ivar ListPaperDocsSortBy.accessed:
+        Sorts the Paper docs by the time they were last accessed.
+    :ivar ListPaperDocsSortBy.modified:
+        Sorts the Paper docs by the time they were last modified.
+    :ivar ListPaperDocsSortBy.created:
+        Sorts the Paper docs by the creation time.
     """
 
     _catch_all = 'other'
@@ -1148,10 +1171,10 @@ class ListPaperDocsSortOrder(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ListPaperDocsSortOrder.ascending: Sorts the search result in
-        ascending order.
-    :ivar paper.ListPaperDocsSortOrder.descending: Sorts the search result in
-        descending order.
+    :ivar ListPaperDocsSortOrder.ascending:
+        Sorts the search result in ascending order.
+    :ivar ListPaperDocsSortOrder.descending:
+        Sorts the search result in descending order.
     """
 
     _catch_all = 'other'
@@ -1197,8 +1220,8 @@ class ListUsersCursorError(PaperApiBaseError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.ListUsersCursorError.doc_not_found: The required doc was not
-        found.
+    :ivar ListUsersCursorError.doc_not_found:
+        The required doc was not found.
     """
 
     # Attribute is overwritten below the class definition
@@ -1248,9 +1271,9 @@ ListUsersCursorError_validator = bv.Union(ListUsersCursorError)
 
 class ListUsersOnFolderArgs(RefPaperDoc):
     """
-    :ivar paper.ListUsersOnFolderArgs.limit: Size limit per batch. The maximum
-        number of users that can be retrieved per batch is 1000. Higher value
-        results in invalid arguments error.
+    :ivar ListUsersOnFolderArgs.limit:
+        Size limit per batch. The maximum number of users that can be retrieved
+        per batch is 1000. Higher value results in invalid arguments error.
     """
 
     __slots__ = [
@@ -1277,7 +1300,8 @@ ListUsersOnFolderArgs_validator = bv.Struct(ListUsersOnFolderArgs)
 
 class ListUsersOnFolderContinueArgs(RefPaperDoc):
     """
-    :ivar paper.ListUsersOnFolderContinueArgs.cursor: The cursor obtained from
+    :ivar ListUsersOnFolderContinueArgs.cursor:
+        The cursor obtained from
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_folder_users_list` or
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_folder_users_list_continue`.
         Allows for pagination.
@@ -1307,17 +1331,18 @@ ListUsersOnFolderContinueArgs_validator = bv.Struct(ListUsersOnFolderContinueArg
 
 class ListUsersOnFolderResponse(bb.Struct):
     """
-    :ivar paper.ListUsersOnFolderResponse.invitees: List of email addresses that
-        are invited on the Paper folder.
-    :ivar paper.ListUsersOnFolderResponse.users: List of users that are invited
-        on the Paper folder.
-    :ivar paper.ListUsersOnFolderResponse.cursor: Pass the cursor into
+    :ivar ListUsersOnFolderResponse.invitees:
+        List of email addresses that are invited on the Paper folder.
+    :ivar ListUsersOnFolderResponse.users:
+        List of users that are invited on the Paper folder.
+    :ivar ListUsersOnFolderResponse.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_folder_users_list_continue`
         to paginate through all users. The cursor preserves all properties as
         specified in the original call to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_folder_users_list`.
-    :ivar paper.ListUsersOnFolderResponse.has_more: Will be set to True if a
-        subsequent call with the provided cursor to
+    :ivar ListUsersOnFolderResponse.has_more:
+        Will be set to True if a subsequent call with the provided cursor to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_folder_users_list_continue`
         returns immediately with some results. If set to False please allow some
         delay before making another call to
@@ -1370,11 +1395,12 @@ ListUsersOnFolderResponse_validator = bv.Struct(ListUsersOnFolderResponse)
 
 class ListUsersOnPaperDocArgs(RefPaperDoc):
     """
-    :ivar paper.ListUsersOnPaperDocArgs.limit: Size limit per batch. The maximum
-        number of users that can be retrieved per batch is 1000. Higher value
-        results in invalid arguments error.
-    :ivar paper.ListUsersOnPaperDocArgs.filter_by: Specify this attribute if you
-        want to obtain users that have already accessed the Paper doc.
+    :ivar ListUsersOnPaperDocArgs.limit:
+        Size limit per batch. The maximum number of users that can be retrieved
+        per batch is 1000. Higher value results in invalid arguments error.
+    :ivar ListUsersOnPaperDocArgs.filter_by:
+        Specify this attribute if you want to obtain users that have already
+        accessed the Paper doc.
     """
 
     __slots__ = [
@@ -1409,7 +1435,8 @@ ListUsersOnPaperDocArgs_validator = bv.Struct(ListUsersOnPaperDocArgs)
 
 class ListUsersOnPaperDocContinueArgs(RefPaperDoc):
     """
-    :ivar paper.ListUsersOnPaperDocContinueArgs.cursor: The cursor obtained from
+    :ivar ListUsersOnPaperDocContinueArgs.cursor:
+        The cursor obtained from
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_list` or
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_list_continue`.
         Allows for pagination.
@@ -1439,20 +1466,22 @@ ListUsersOnPaperDocContinueArgs_validator = bv.Struct(ListUsersOnPaperDocContinu
 
 class ListUsersOnPaperDocResponse(bb.Struct):
     """
-    :ivar paper.ListUsersOnPaperDocResponse.invitees: List of email addresses
-        with their respective permission levels that are invited on the Paper
-        doc.
-    :ivar paper.ListUsersOnPaperDocResponse.users: List of users with their
-        respective permission levels that are invited on the Paper folder.
-    :ivar paper.ListUsersOnPaperDocResponse.doc_owner: The Paper doc owner. This
-        field is populated on every single response.
-    :ivar paper.ListUsersOnPaperDocResponse.cursor: Pass the cursor into
+    :ivar ListUsersOnPaperDocResponse.invitees:
+        List of email addresses with their respective permission levels that are
+        invited on the Paper doc.
+    :ivar ListUsersOnPaperDocResponse.users:
+        List of users with their respective permission levels that are invited
+        on the Paper folder.
+    :ivar ListUsersOnPaperDocResponse.doc_owner:
+        The Paper doc owner. This field is populated on every single response.
+    :ivar ListUsersOnPaperDocResponse.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_list_continue` to
         paginate through all users. The cursor preserves all properties as
         specified in the original call to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_list`.
-    :ivar paper.ListUsersOnPaperDocResponse.has_more: Will be set to True if a
-        subsequent call with the provided cursor to
+    :ivar ListUsersOnPaperDocResponse.has_more:
+        Will be set to True if a subsequent call with the provided cursor to
         :meth:`dropbox.dropbox_client.Dropbox.paper_docs_users_list_continue`
         returns immediately with some results. If set to False please allow some
         delay before making another call to
@@ -1517,15 +1546,15 @@ class PaperApiCursorError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperApiCursorError.expired_cursor: The provided cursor is
-        expired.
-    :ivar paper.PaperApiCursorError.invalid_cursor: The provided cursor is
-        invalid.
-    :ivar paper.PaperApiCursorError.wrong_user_in_cursor: The provided cursor
-        contains invalid user.
-    :ivar paper.PaperApiCursorError.reset: Indicates that the cursor has been
-        invalidated. Call the corresponding non-continue endpoint to obtain a
-        new cursor.
+    :ivar PaperApiCursorError.expired_cursor:
+        The provided cursor is expired.
+    :ivar PaperApiCursorError.invalid_cursor:
+        The provided cursor is invalid.
+    :ivar PaperApiCursorError.wrong_user_in_cursor:
+        The provided cursor contains invalid user.
+    :ivar PaperApiCursorError.reset:
+        Indicates that the cursor has been invalidated. Call the corresponding
+        non-continue endpoint to obtain a new cursor.
     """
 
     _catch_all = 'other'
@@ -1587,10 +1616,11 @@ PaperApiCursorError_validator = bv.Union(PaperApiCursorError)
 
 class PaperDocCreateArgs(bb.Struct):
     """
-    :ivar paper.PaperDocCreateArgs.parent_folder_id: The Paper folder ID where
-        the Paper document should be created. The API user has to have write
-        access to this folder or error is thrown.
-    :ivar paper.PaperDocCreateArgs.import_format: The format of provided data.
+    :ivar PaperDocCreateArgs.parent_folder_id:
+        The Paper folder ID where the Paper document should be created. The API
+        user has to have write access to this folder or error is thrown.
+    :ivar PaperDocCreateArgs.import_format:
+        The format of provided data.
     """
 
     __slots__ = [
@@ -1627,15 +1657,16 @@ class PaperDocCreateError(PaperApiBaseError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperDocCreateError.content_malformed: The provided content was
-        malformed and cannot be imported to Paper.
-    :ivar paper.PaperDocCreateError.folder_not_found: The specified Paper folder
-        is cannot be found.
-    :ivar paper.PaperDocCreateError.doc_length_exceeded: The newly created Paper
-        doc would be too large. Please split the content into multiple docs.
-    :ivar paper.PaperDocCreateError.image_size_exceeded: The imported document
-        contains an image that is too large. The current limit is 1MB. This only
-        applies to HTML with data URI.
+    :ivar PaperDocCreateError.content_malformed:
+        The provided content was malformed and cannot be imported to Paper.
+    :ivar PaperDocCreateError.folder_not_found:
+        The specified Paper folder is cannot be found.
+    :ivar PaperDocCreateError.doc_length_exceeded:
+        The newly created Paper doc would be too large. Please split the content
+        into multiple docs.
+    :ivar PaperDocCreateError.image_size_exceeded:
+        The imported document contains an image that is too large. The current
+        limit is 1MB. This only applies to HTML with data URI.
     """
 
     # Attribute is overwritten below the class definition
@@ -1686,11 +1717,12 @@ PaperDocCreateError_validator = bv.Union(PaperDocCreateError)
 
 class PaperDocCreateUpdateResult(bb.Struct):
     """
-    :ivar paper.PaperDocCreateUpdateResult.doc_id: Doc ID of the newly created
-        doc.
-    :ivar paper.PaperDocCreateUpdateResult.revision: The Paper doc revision.
-        Simply an ever increasing number.
-    :ivar paper.PaperDocCreateUpdateResult.title: The Paper doc title.
+    :ivar PaperDocCreateUpdateResult.doc_id:
+        Doc ID of the newly created doc.
+    :ivar PaperDocCreateUpdateResult.revision:
+        The Paper doc revision. Simply an ever increasing number.
+    :ivar PaperDocCreateUpdateResult.title:
+        The Paper doc title.
     """
 
     __slots__ = [
@@ -1731,11 +1763,11 @@ PaperDocCreateUpdateResult_validator = bv.Struct(PaperDocCreateUpdateResult)
 
 class PaperDocExport(RefPaperDoc):
     """
-    :ivar paper.PaperDocExport.include_comments: When true, export includes
-        comment threads (e.g. markdown footnotes). When false or omitted, body
-        only. Other formats may adopt this later; currently only markdown uses
-        it. Plain bool (not optional): protoc-gen-godbx does not support proto3
-        optional yet.
+    :ivar PaperDocExport.include_comments:
+        When true, export includes comment threads (e.g. markdown footnotes).
+        When false or omitted, body only. Other formats may adopt this later;
+        currently only markdown uses it. Plain bool (not optional):
+        protoc-gen-godbx does not support proto3 optional yet.
     """
 
     __slots__ = [
@@ -1770,12 +1802,15 @@ PaperDocExport_validator = bv.Struct(PaperDocExport)
 
 class PaperDocExportResult(bb.Struct):
     """
-    :ivar paper.PaperDocExportResult.owner: The Paper doc owner's email address.
-    :ivar paper.PaperDocExportResult.title: The Paper doc title.
-    :ivar paper.PaperDocExportResult.revision: The Paper doc revision. Simply an
-        ever increasing number.
-    :ivar paper.PaperDocExportResult.mime_type: MIME type of the export. This
-        corresponds to :class:`ExportFormat` specified in the request.
+    :ivar PaperDocExportResult.owner:
+        The Paper doc owner's email address.
+    :ivar PaperDocExportResult.title:
+        The Paper doc title.
+    :ivar PaperDocExportResult.revision:
+        The Paper doc revision. Simply an ever increasing number.
+    :ivar PaperDocExportResult.mime_type:
+        MIME type of the export. This corresponds to :class:`ExportFormat`
+        specified in the request.
     """
 
     __slots__ = [
@@ -1826,19 +1861,22 @@ class PaperDocGetMetadataResult(bb.Struct):
     """
     Metadata returned by docs/get_metadata.
 
-    :ivar paper.PaperDocGetMetadataResult.doc_id: The Paper doc ID.
-    :ivar paper.PaperDocGetMetadataResult.owner: The Paper doc owner's email
-        address.
-    :ivar paper.PaperDocGetMetadataResult.title: The Paper doc title.
-    :ivar paper.PaperDocGetMetadataResult.created_date: The Paper doc creation
-        date.
-    :ivar paper.PaperDocGetMetadataResult.status: The Paper doc status.
-    :ivar paper.PaperDocGetMetadataResult.revision: The Paper doc revision.
-        Simply an ever increasing number.
-    :ivar paper.PaperDocGetMetadataResult.last_updated_date: The date when the
-        Paper doc was last edited.
-    :ivar paper.PaperDocGetMetadataResult.last_editor: The email address of the
-        last editor of the Paper doc.
+    :ivar PaperDocGetMetadataResult.doc_id:
+        The Paper doc ID.
+    :ivar PaperDocGetMetadataResult.owner:
+        The Paper doc owner's email address.
+    :ivar PaperDocGetMetadataResult.title:
+        The Paper doc title.
+    :ivar PaperDocGetMetadataResult.created_date:
+        The Paper doc creation date.
+    :ivar PaperDocGetMetadataResult.status:
+        The Paper doc status.
+    :ivar PaperDocGetMetadataResult.revision:
+        The Paper doc revision. Simply an ever increasing number.
+    :ivar PaperDocGetMetadataResult.last_updated_date:
+        The date when the Paper doc was last edited.
+    :ivar PaperDocGetMetadataResult.last_editor:
+        The email address of the last editor of the Paper doc.
     """
 
     __slots__ = [
@@ -1923,10 +1961,10 @@ class PaperDocPermissionLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperDocPermissionLevel.edit: User will be granted edit
-        permissions.
-    :ivar paper.PaperDocPermissionLevel.view_and_comment: User will be granted
-        view and comment permissions.
+    :ivar PaperDocPermissionLevel.edit:
+        User will be granted edit permissions.
+    :ivar PaperDocPermissionLevel.view_and_comment:
+        User will be granted view and comment permissions.
     """
 
     _catch_all = 'other'
@@ -1968,8 +2006,8 @@ PaperDocPermissionLevel_validator = bv.Union(PaperDocPermissionLevel)
 
 class PaperDocSharingPolicy(RefPaperDoc):
     """
-    :ivar paper.PaperDocSharingPolicy.sharing_policy: The default sharing policy
-        to be set for the Paper doc.
+    :ivar PaperDocSharingPolicy.sharing_policy:
+        The default sharing policy to be set for the Paper doc.
     """
 
     __slots__ = [
@@ -2002,8 +2040,10 @@ class PaperDocStatus(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperDocStatus.active: The Paper doc is active.
-    :ivar paper.PaperDocStatus.deleted: The Paper doc is deleted.
+    :ivar PaperDocStatus.active:
+        The Paper doc is active.
+    :ivar PaperDocStatus.deleted:
+        The Paper doc is deleted.
     """
 
     _catch_all = 'other'
@@ -2045,12 +2085,13 @@ PaperDocStatus_validator = bv.Union(PaperDocStatus)
 
 class PaperDocUpdateArgs(RefPaperDoc):
     """
-    :ivar paper.PaperDocUpdateArgs.doc_update_policy: The policy used for the
-        current update call.
-    :ivar paper.PaperDocUpdateArgs.revision: The latest doc revision. This value
-        must match the head revision or an error code will be returned. This is
-        to prevent colliding writes.
-    :ivar paper.PaperDocUpdateArgs.import_format: The format of provided data.
+    :ivar PaperDocUpdateArgs.doc_update_policy:
+        The policy used for the current update call.
+    :ivar PaperDocUpdateArgs.revision:
+        The latest doc revision. This value must match the head revision or an
+        error code will be returned. This is to prevent colliding writes.
+    :ivar PaperDocUpdateArgs.import_format:
+        The format of provided data.
     """
 
     __slots__ = [
@@ -2097,19 +2138,20 @@ class PaperDocUpdateError(DocLookupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperDocUpdateError.content_malformed: The provided content was
-        malformed and cannot be imported to Paper.
-    :ivar paper.PaperDocUpdateError.revision_mismatch: The provided revision
-        does not match the document head.
-    :ivar paper.PaperDocUpdateError.doc_length_exceeded: The newly created Paper
-        doc would be too large, split the content into multiple docs.
-    :ivar paper.PaperDocUpdateError.image_size_exceeded: The imported document
-        contains an image that is too large. The current limit is 1MB. This only
-        applies to HTML with data URI.
-    :ivar paper.PaperDocUpdateError.doc_archived: This operation is not allowed
-        on archived Paper docs.
-    :ivar paper.PaperDocUpdateError.doc_deleted: This operation is not allowed
-        on deleted Paper docs.
+    :ivar PaperDocUpdateError.content_malformed:
+        The provided content was malformed and cannot be imported to Paper.
+    :ivar PaperDocUpdateError.revision_mismatch:
+        The provided revision does not match the document head.
+    :ivar PaperDocUpdateError.doc_length_exceeded:
+        The newly created Paper doc would be too large, split the content into
+        multiple docs.
+    :ivar PaperDocUpdateError.image_size_exceeded:
+        The imported document contains an image that is too large. The current
+        limit is 1MB. This only applies to HTML with data URI.
+    :ivar PaperDocUpdateError.doc_archived:
+        This operation is not allowed on archived Paper docs.
+    :ivar PaperDocUpdateError.doc_deleted:
+        This operation is not allowed on deleted Paper docs.
     """
 
     # Attribute is overwritten below the class definition
@@ -2184,12 +2226,13 @@ class PaperDocUpdatePolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperDocUpdatePolicy.append: The content will be appended to the
-        doc.
-    :ivar paper.PaperDocUpdatePolicy.prepend: The content will be prepended to
-        the doc. The doc title will not be affected.
-    :ivar paper.PaperDocUpdatePolicy.overwrite_all: The document will be
-        overwitten at the head with the provided content.
+    :ivar PaperDocUpdatePolicy.append:
+        The content will be appended to the doc.
+    :ivar PaperDocUpdatePolicy.prepend:
+        The content will be prepended to the doc. The doc title will not be
+        affected.
+    :ivar PaperDocUpdatePolicy.overwrite_all:
+        The document will be overwitten at the head with the provided content.
     """
 
     _catch_all = 'other'
@@ -2241,17 +2284,18 @@ PaperDocUpdatePolicy_validator = bv.Union(PaperDocUpdatePolicy)
 
 class PaperFolderCreateArg(bb.Struct):
     """
-    :ivar paper.PaperFolderCreateArg.name: The name of the new Paper folder.
-    :ivar paper.PaperFolderCreateArg.parent_folder_id: The encrypted Paper
-        folder Id where the new Paper folder should be created. The API user has
-        to have write access to this folder or error is thrown. If not supplied,
-        the new folder will be created at top level.
-    :ivar paper.PaperFolderCreateArg.is_team_folder: Whether the folder to be
-        created should be a team folder. This value will be ignored if
-        parent_folder_id is supplied, as the new folder will inherit the type
-        (private or team folder) from its parent. We will by default create a
-        top-level private folder if both parent_folder_id and is_team_folder are
-        not supplied.
+    :ivar PaperFolderCreateArg.name:
+        The name of the new Paper folder.
+    :ivar PaperFolderCreateArg.parent_folder_id:
+        The encrypted Paper folder Id where the new Paper folder should be
+        created. The API user has to have write access to this folder or error
+        is thrown. If not supplied, the new folder will be created at top level.
+    :ivar PaperFolderCreateArg.is_team_folder:
+        Whether the folder to be created should be a team folder. This value
+        will be ignored if parent_folder_id is supplied, as the new folder will
+        inherit the type (private or team folder) from its parent. We will by
+        default create a top-level private folder if both parent_folder_id and
+        is_team_folder are not supplied.
     """
 
     __slots__ = [
@@ -2296,10 +2340,10 @@ class PaperFolderCreateError(PaperApiBaseError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.PaperFolderCreateError.folder_not_found: The specified parent
-        Paper folder cannot be found.
-    :ivar paper.PaperFolderCreateError.invalid_folder_id: The folder id cannot
-        be decrypted to valid folder id.
+    :ivar PaperFolderCreateError.folder_not_found:
+        The specified parent Paper folder cannot be found.
+    :ivar PaperFolderCreateError.invalid_folder_id:
+        The folder id cannot be decrypted to valid folder id.
     """
 
     # Attribute is overwritten below the class definition
@@ -2330,8 +2374,8 @@ PaperFolderCreateError_validator = bv.Union(PaperFolderCreateError)
 
 class PaperFolderCreateResult(bb.Struct):
     """
-    :ivar paper.PaperFolderCreateResult.folder_id: Folder ID of the newly
-        created folder.
+    :ivar PaperFolderCreateResult.folder_id:
+        Folder ID of the newly created folder.
     """
 
     __slots__ = [
@@ -2356,8 +2400,9 @@ PaperFolderCreateResult_validator = bv.Struct(PaperFolderCreateResult)
 
 class RemovePaperDocUser(RefPaperDoc):
     """
-    :ivar paper.RemovePaperDocUser.member: User which should be removed from the
-        Paper doc. Specify only email address or Dropbox account ID.
+    :ivar RemovePaperDocUser.member:
+        User which should be removed from the Paper doc. Specify only email
+        address or Dropbox account ID.
     """
 
     __slots__ = [
@@ -2386,10 +2431,11 @@ class SharingPolicy(bb.Struct):
     """
     Sharing policy of Paper doc.
 
-    :ivar paper.SharingPolicy.public_sharing_policy: This value applies to the
-        non-team members.
-    :ivar paper.SharingPolicy.team_sharing_policy: This value applies to the
-        team members only. The value is null for all personal accounts.
+    :ivar SharingPolicy.public_sharing_policy:
+        This value applies to the non-team members.
+    :ivar SharingPolicy.team_sharing_policy:
+        This value applies to the team members only. The value is null for all
+        personal accounts.
     """
 
     __slots__ = [
@@ -2428,12 +2474,12 @@ class SharingTeamPolicyType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.SharingTeamPolicyType.people_with_link_can_edit: Users who have
-        a link to this doc can edit it.
-    :ivar paper.SharingTeamPolicyType.people_with_link_can_view_and_comment:
+    :ivar SharingTeamPolicyType.people_with_link_can_edit:
+        Users who have a link to this doc can edit it.
+    :ivar SharingTeamPolicyType.people_with_link_can_view_and_comment:
         Users who have a link to this doc can view and comment on it.
-    :ivar paper.SharingTeamPolicyType.invite_only: Users must be explicitly
-        invited to this doc.
+    :ivar SharingTeamPolicyType.invite_only:
+        Users must be explicitly invited to this doc.
     """
 
     _catch_all = None
@@ -2479,8 +2525,8 @@ class SharingPublicPolicyType(SharingTeamPolicyType):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.SharingPublicPolicyType.disabled: Value used to indicate that
-        doc sharing is enabled only within team.
+    :ivar SharingPublicPolicyType.disabled:
+        Value used to indicate that doc sharing is enabled only within team.
     """
 
     # Attribute is overwritten below the class definition
@@ -2501,9 +2547,10 @@ SharingPublicPolicyType_validator = bv.Union(SharingPublicPolicyType)
 
 class UserInfoWithPermissionLevel(bb.Struct):
     """
-    :ivar paper.UserInfoWithPermissionLevel.user: User shared on the Paper doc.
-    :ivar paper.UserInfoWithPermissionLevel.permission_level: Permission level
-        for the user.
+    :ivar UserInfoWithPermissionLevel.user:
+        User shared on the Paper doc.
+    :ivar UserInfoWithPermissionLevel.permission_level:
+        Permission level for the user.
     """
 
     __slots__ = [
@@ -2540,11 +2587,11 @@ class UserOnPaperDocFilter(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar paper.UserOnPaperDocFilter.visited: all users who have visited the
-        Paper doc.
-    :ivar paper.UserOnPaperDocFilter.shared: All uses who are shared on the
-        Paper doc. This includes all users who have visited the Paper doc as
-        well as those who have not.
+    :ivar UserOnPaperDocFilter.visited:
+        all users who have visited the Paper doc.
+    :ivar UserOnPaperDocFilter.shared:
+        All uses who are shared on the Paper doc. This includes all users who
+        have visited the Paper doc as well as those who have not.
     """
 
     _catch_all = 'other'

--- a/dropbox/riviera.py
+++ b/dropbox/riviera.py
@@ -15,13 +15,14 @@ class ApiExifGpsMetadata(bb.Struct):
     populated on a best-effort basis and may be empty when absent from the
     source file.
 
-    :ivar riviera.ApiExifGpsMetadata.latitude: Latitude / longitude in decimal
-        degrees (positive = N/E, negative = S/W).
-    :ivar riviera.ApiExifGpsMetadata.altitude: Altitude in meters, as reported
-        by the source (string to preserve the original representation, which may
-        include a reference direction).
-    :ivar riviera.ApiExifGpsMetadata.timestamp: Timestamp / datestamp of the GPS
-        fix, in the EXIF-provided format.
+    :ivar ApiExifGpsMetadata.latitude:
+        Latitude / longitude in decimal degrees (positive = N/E, negative =
+        S/W).
+    :ivar ApiExifGpsMetadata.altitude:
+        Altitude in meters, as reported by the source (string to preserve the
+        original representation, which may include a reference direction).
+    :ivar ApiExifGpsMetadata.timestamp:
+        Timestamp / datestamp of the GPS fix, in the EXIF-provided format.
     """
 
     __slots__ = [
@@ -81,15 +82,17 @@ class ApiExifMetadata(bb.Struct):
     Image EXIF metadata. Mirrors the useful subset of the internal
     `riviera.ExifMetadata` message. Fields are best-effort and may be empty.
 
-    :ivar riviera.ApiExifMetadata.date_time_original: Capture time in the
-        EXIF-provided format (local time of the camera).
-    :ivar riviera.ApiExifMetadata.offset_time_original: Timezone offset for
-        `date_time_original`, e.g. "+09:00".
-    :ivar riviera.ApiExifMetadata.orientation: EXIF orientation value (1-8). See
-        the EXIF spec; 1 is the normal upright orientation.
-    :ivar riviera.ApiExifMetadata.exposure_time: fraction in string form, e.g.
-        "1/250"
-    :ivar riviera.ApiExifMetadata.focal_length: e.g. "26.0 mm"
+    :ivar ApiExifMetadata.date_time_original:
+        Capture time in the EXIF-provided format (local time of the camera).
+    :ivar ApiExifMetadata.offset_time_original:
+        Timezone offset for `date_time_original`, e.g. "+09:00".
+    :ivar ApiExifMetadata.orientation:
+        EXIF orientation value (1-8). See the EXIF spec; 1 is the normal upright
+        orientation.
+    :ivar ApiExifMetadata.exposure_time:
+        fraction in string form, e.g. "1/250"
+    :ivar ApiExifMetadata.focal_length:
+        e.g. "26.0 mm"
     """
 
     __slots__ = [
@@ -237,8 +240,8 @@ class ApiMediaMetadata(bb.Struct):
     Audio/video container and per-stream metadata. Mirrors the useful subset of
     the internal `riviera.MediaMetadata` message.
 
-    :ivar riviera.ApiMediaMetadata.creation_time: Container-level creation time,
-        when present.
+    :ivar ApiMediaMetadata.creation_time:
+        Container-level creation time, when present.
     """
 
     __slots__ = [
@@ -289,14 +292,16 @@ class ApiMediaStream(bb.Struct):
     """
     A single audio or video stream within a media file.
 
-    :ivar riviera.ApiMediaStream.codec_type: "audio", "video", etc.
-    :ivar riviera.ApiMediaStream.width: Video-specific fields (zero / empty for
-        audio streams).
-    :ivar riviera.ApiMediaStream.display_aspect_ratio: e.g. "16:9"
-    :ivar riviera.ApiMediaStream.channels: Audio-specific fields (zero / empty
-        for video streams).
-    :ivar riviera.ApiMediaStream.language_iso_639: ISO 639 language code for the
-        stream, when present.
+    :ivar ApiMediaStream.codec_type:
+        "audio", "video", etc.
+    :ivar ApiMediaStream.width:
+        Video-specific fields (zero / empty for audio streams).
+    :ivar ApiMediaStream.display_aspect_ratio:
+        e.g. "16:9"
+    :ivar ApiMediaStream.channels:
+        Audio-specific fields (zero / empty for video streams).
+    :ivar ApiMediaStream.language_iso_639:
+        ISO 639 language code for the stream, when present.
     """
 
     __slots__ = [
@@ -429,8 +434,10 @@ class ApiOfficeMetadata(bb.Struct):
     message. Some fields apply only to specific document types (e.g. `slides`
     for PowerPoint, `words`/`pages` for Word).
 
-    :ivar riviera.ApiOfficeMetadata.pages: Word only.
-    :ivar riviera.ApiOfficeMetadata.slides: PowerPoint only.
+    :ivar ApiOfficeMetadata.pages:
+        Word only.
+    :ivar ApiOfficeMetadata.slides:
+        PowerPoint only.
     """
 
     __slots__ = [
@@ -545,8 +552,8 @@ class ApiPdfMetadata(bb.Struct):
     """
     PDF document metadata.
 
-    :ivar riviera.ApiPdfMetadata.width: Width / height of the first page, in PDF
-        points.
+    :ivar ApiPdfMetadata.width:
+        Width / height of the first page, in PDF points.
     """
 
     __slots__ = [
@@ -665,10 +672,10 @@ class ContentApiV2Error(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar riviera.ContentApiV2Error.not_found_error: The referenced file does
-        not exist or is not accessible.
-    :ivar riviera.ContentApiV2Error.is_a_folder_error: The target is a folder,
-        not a file.
+    :ivar ContentApiV2Error.not_found_error:
+        The referenced file does not exist or is not accessible.
+    :ivar ContentApiV2Error.is_a_folder_error:
+        The target is a folder, not a file.
     """
 
     _catch_all = 'other'
@@ -841,11 +848,16 @@ class ErrorCode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar riviera.ErrorCode.bad_request: 400
-    :ivar riviera.ErrorCode.api_error: 409
-    :ivar riviera.ErrorCode.access_error: 403
-    :ivar riviera.ErrorCode.ratelimit_error: 429
-    :ivar riviera.ErrorCode.unavailable: 503
+    :ivar ErrorCode.bad_request:
+        400
+    :ivar ErrorCode.api_error:
+        409
+    :ivar ErrorCode.access_error:
+        403
+    :ivar ErrorCode.ratelimit_error:
+        429
+    :ivar ErrorCode.unavailable:
+        503
     """
 
     _catch_all = 'other'
@@ -1042,28 +1054,28 @@ class GetMarkdownArgs(bb.Struct):
     `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
     identify the document to convert to markdown.
 
-    :ivar riviera.GetMarkdownArgs.file_id_or_url: Identifier of the document to
-        convert. Callers must set exactly one of the oneof variants: - file_id:
-        a Dropbox-issued file id (format: "id:<id>") for a file the
-        authenticated user has access to. - path: an absolute Dropbox path, e.g.
-        "/folder/report.docx". - url: either a Dropbox shared link
-        (www.dropbox.com) or an external HTTPS URL pointing to a supported
-        document file. - Dropbox shared links are resolved internally using the
-        caller's authenticated identity and the link's visibility / download
-        settings. They therefore require an authenticated user context
-        (anonymous `url` requests against Dropbox links are rejected with an
-        `ACCESS_ERROR`). Links protected by a password are rejected with
-        `shared_link_password_protected`; links with downloads disabled are
-        rejected with `link_download_disabled_error`. - External URLs are
-        fetched over HTTPS through the backend's egress proxy and must point at
-        a supported document file extension. The referenced file must be a
-        document in a supported format; requests against unsupported formats
-        return `unsupported_format_error`.
-    :ivar riviera.GetMarkdownArgs.enable_ocr: Enable OCR for PDF documents.
-        Processing is slower when enabled.
-    :ivar riviera.GetMarkdownArgs.embed_images: When true, embed images as
-        base64 data URIs in the markdown output. This can significantly increase
-        output size.
+    :ivar GetMarkdownArgs.file_id_or_url:
+        Identifier of the document to convert. Callers must set exactly one of
+        the oneof variants: - file_id: a Dropbox-issued file id (format:
+        "id:<id>") for a file the authenticated user has access to. - path: an
+        absolute Dropbox path, e.g. "/folder/report.docx". - url: either a
+        Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
+        to a supported document file. - Dropbox shared links are resolved
+        internally using the caller's authenticated identity and the link's
+        visibility / download settings. They therefore require an authenticated
+        user context (anonymous `url` requests against Dropbox links are
+        rejected with an `ACCESS_ERROR`). Links protected by a password are
+        rejected with `shared_link_password_protected`; links with downloads
+        disabled are rejected with `link_download_disabled_error`. - External
+        URLs are fetched over HTTPS through the backend's egress proxy and must
+        point at a supported document file extension. The referenced file must
+        be a document in a supported format; requests against unsupported
+        formats return `unsupported_format_error`.
+    :ivar GetMarkdownArgs.enable_ocr:
+        Enable OCR for PDF documents. Processing is slower when enabled.
+    :ivar GetMarkdownArgs.embed_images:
+        When true, embed images as base64 data URIs in the markdown output. This
+        can significantly increase output size.
     """
 
     __slots__ = [
@@ -1228,7 +1240,8 @@ GetMarkdownAsyncError_validator = bv.Struct(GetMarkdownAsyncError)
 
 class GetMarkdownResult(bb.Struct):
     """
-    :ivar riviera.GetMarkdownResult.markdown: The converted markdown content
+    :ivar GetMarkdownResult.markdown:
+        The converted markdown content
     """
 
     __slots__ = [
@@ -1257,25 +1270,25 @@ class GetMetadataArgs(bb.Struct):
     `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
     identify the file whose metadata should be extracted.
 
-    :ivar riviera.GetMetadataArgs.file_id_or_url: Identifier of the file to
-        extract metadata from. Callers must set exactly one of the oneof
-        variants: - file_id: a Dropbox-issued file id (format: "id:<id>") for a
-        file the authenticated user has access to. - path: an absolute Dropbox
-        path, e.g. "/folder/photo.jpg". - url: either a Dropbox shared link
-        (www.dropbox.com) or an external HTTPS URL pointing to a supported file.
-        - Dropbox shared links are resolved internally using the caller's
-        authenticated identity and the link's visibility / download settings.
-        They therefore require an authenticated user context (anonymous `url`
-        requests against Dropbox links are rejected with an `ACCESS_ERROR`).
-        Links protected by a password are rejected with
-        `shared_link_password_protected`; links with downloads disabled are
-        rejected with `link_download_disabled_error`. - External URLs are
-        fetched over HTTPS through the backend's egress proxy and must point at
-        a supported file extension. The kind of metadata returned is determined
-        by the file type: image files return EXIF metadata, audio/video files
-        return media metadata, PDFs return PDF metadata, and MS Office documents
-        (docx, pptx, xlsx) return Office metadata. Requests against unsupported
-        formats return `unsupported_format_error`.
+    :ivar GetMetadataArgs.file_id_or_url:
+        Identifier of the file to extract metadata from. Callers must set
+        exactly one of the oneof variants: - file_id: a Dropbox-issued file id
+        (format: "id:<id>") for a file the authenticated user has access to. -
+        path: an absolute Dropbox path, e.g. "/folder/photo.jpg". - url: either
+        a Dropbox shared link (www.dropbox.com) or an external HTTPS URL
+        pointing to a supported file. - Dropbox shared links are resolved
+        internally using the caller's authenticated identity and the link's
+        visibility / download settings. They therefore require an authenticated
+        user context (anonymous `url` requests against Dropbox links are
+        rejected with an `ACCESS_ERROR`). Links protected by a password are
+        rejected with `shared_link_password_protected`; links with downloads
+        disabled are rejected with `link_download_disabled_error`. - External
+        URLs are fetched over HTTPS through the backend's egress proxy and must
+        point at a supported file extension. The kind of metadata returned is
+        determined by the file type: image files return EXIF metadata,
+        audio/video files return media metadata, PDFs return PDF metadata, and
+        MS Office documents (docx, pptx, xlsx) return Office metadata. Requests
+        against unsupported formats return `unsupported_format_error`.
     """
 
     __slots__ = [
@@ -1424,9 +1437,9 @@ GetMetadataAsyncError_validator = bv.Struct(GetMetadataAsyncError)
 
 class GetMetadataResult(bb.Struct):
     """
-    :ivar riviera.GetMetadataResult.metadata_type: The kind of metadata that was
-        extracted for the requested file. Callers should read the matching field
-        of the `metadata` oneof.
+    :ivar GetMetadataResult.metadata_type:
+        The kind of metadata that was extracted for the requested file. Callers
+        should read the matching field of the `metadata` oneof.
     """
 
     __slots__ = [
@@ -1463,37 +1476,39 @@ class GetTranscriptArgs(bb.Struct):
     `file_id`, `path`, or `url` must be supplied via `file_id_or_url` to
     identify the audio or video asset to transcribe.
 
-    :ivar riviera.GetTranscriptArgs.file_id_or_url: Identifier of the media
-        asset to transcribe. Callers must set exactly one of the oneof variants:
-        - file_id: a Dropbox-issued file id (format: "id:<id>") for a file the
-        authenticated user has access to. - path: an absolute Dropbox path, e.g.
-        "/folder/recording.mp4". - url: either a Dropbox shared link
-        (www.dropbox.com) or an external HTTPS URL pointing to a supported
-        audio/video file. - Dropbox shared links are resolved internally using
-        the caller's authenticated identity and the link's visibility / download
-        settings. They therefore require an authenticated user context
-        (anonymous `url` requests against Dropbox links are rejected with an
-        `ACCESS_ERROR`). Links protected by a password are rejected with
-        `shared_link_password_protected`; links with downloads disabled are
-        rejected with `link_download_disabled_error`. - External URLs are
-        fetched over HTTPS through the backend's egress proxy and must point at
-        a supported audio/video file extension. The referenced asset must be an
-        audio or video file in a supported format; requests against files with
-        no audio track return a `no_audio_error`.
-    :ivar riviera.GetTranscriptArgs.timestamp_level: Granularity of the time
-        offsets returned for each transcript segment. Defaults to `SENTENCE. -
-        SENTENCE: one segment per spoken sentence (recommended). - WORD: one
-        segment per word, useful for fine-grained alignment such as captioning
-        or highlight-as-you-listen experiences.
-    :ivar riviera.GetTranscriptArgs.included_special_words: Comma-delimited list
-        of non-lexical filler words to preserve in the transcript output, e.g.
-        `"uh, ah, uhm"`. By default these fillers are stripped. Unrecognized
-        tokens are ignored. Leave empty to use the default filtering behavior.
-    :ivar riviera.GetTranscriptArgs.audio_language: Optional ISO 639-1
-        two-letter language code hinting the spoken language of the source audio
-        (e.g. "en", "ja"). When empty, the service auto-detects the language;
-        supplying a hint improves accuracy and latency for short or ambiguous
-        clips. Unsupported languages fall back to auto-detection.
+    :ivar GetTranscriptArgs.file_id_or_url:
+        Identifier of the media asset to transcribe. Callers must set exactly
+        one of the oneof variants: - file_id: a Dropbox-issued file id (format:
+        "id:<id>") for a file the authenticated user has access to. - path: an
+        absolute Dropbox path, e.g. "/folder/recording.mp4". - url: either a
+        Dropbox shared link (www.dropbox.com) or an external HTTPS URL pointing
+        to a supported audio/video file. - Dropbox shared links are resolved
+        internally using the caller's authenticated identity and the link's
+        visibility / download settings. They therefore require an authenticated
+        user context (anonymous `url` requests against Dropbox links are
+        rejected with an `ACCESS_ERROR`). Links protected by a password are
+        rejected with `shared_link_password_protected`; links with downloads
+        disabled are rejected with `link_download_disabled_error`. - External
+        URLs are fetched over HTTPS through the backend's egress proxy and must
+        point at a supported audio/video file extension. The referenced asset
+        must be an audio or video file in a supported format; requests against
+        files with no audio track return a `no_audio_error`.
+    :ivar GetTranscriptArgs.timestamp_level:
+        Granularity of the time offsets returned for each transcript segment.
+        Defaults to `SENTENCE. - SENTENCE: one segment per spoken sentence
+        (recommended). - WORD: one segment per word, useful for fine-grained
+        alignment such as captioning or highlight-as-you-listen experiences.
+    :ivar GetTranscriptArgs.included_special_words:
+        Comma-delimited list of non-lexical filler words to preserve in the
+        transcript output, e.g. `"uh, ah, uhm"`. By default these fillers are
+        stripped. Unrecognized tokens are ignored. Leave empty to use the
+        default filtering behavior.
+    :ivar GetTranscriptArgs.audio_language:
+        Optional ISO 639-1 two-letter language code hinting the spoken language
+        of the source audio (e.g. "en", "ja"). When empty, the service
+        auto-detects the language; supplying a hint improves accuracy and
+        latency for short or ambiguous clips. Unsupported languages fall back to
+        auto-detection.
     """
 
     __slots__ = [
@@ -1666,10 +1681,10 @@ GetTranscriptAsyncError_validator = bv.Struct(GetTranscriptAsyncError)
 
 class GetTranscriptResult(bb.Struct):
     """
-    :ivar riviera.GetTranscriptResult.structured_transcript: The structured
-        transcript produced for the requested media asset, with per-segment
-        text, start/end offsets (in seconds from the beginning of the media),
-        and the detected or caller-supplied locale.
+    :ivar GetTranscriptResult.structured_transcript:
+        The structured transcript produced for the requested media asset, with
+        per-segment text, start/end offsets (in seconds from the beginning of
+        the media), and the detected or caller-supplied locale.
     """
 
     __slots__ = [
@@ -1698,10 +1713,10 @@ class MarkdownConversionApiV2Error(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar riviera.MarkdownConversionApiV2Error.not_found_error: The referenced
-        file does not exist or is not accessible.
-    :ivar riviera.MarkdownConversionApiV2Error.is_a_folder_error: The target is
-        a folder, not a file.
+    :ivar MarkdownConversionApiV2Error.not_found_error:
+        The referenced file does not exist or is not accessible.
+    :ivar MarkdownConversionApiV2Error.is_a_folder_error:
+        The target is a folder, not a file.
     """
 
     _catch_all = 'other'
@@ -1877,10 +1892,10 @@ class MetadataExtractionApiV2Error(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar riviera.MetadataExtractionApiV2Error.not_found_error: The referenced
-        file does not exist or is not accessible.
-    :ivar riviera.MetadataExtractionApiV2Error.is_a_folder_error: The target is
-        a folder, not a file.
+    :ivar MetadataExtractionApiV2Error.not_found_error:
+        The referenced file does not exist or is not accessible.
+    :ivar MetadataExtractionApiV2Error.is_a_folder_error:
+        The target is a folder, not a file.
     """
 
     _catch_all = 'other'

--- a/dropbox/secondary_emails.py
+++ b/dropbox/secondary_emails.py
@@ -11,9 +11,11 @@ from dropbox import common
 
 class SecondaryEmail(bb.Struct):
     """
-    :ivar secondary_emails.SecondaryEmail.email: Secondary email address.
-    :ivar secondary_emails.SecondaryEmail.is_verified: Whether or not the
-        secondary email address is verified to be owned by a user.
+    :ivar SecondaryEmail.email:
+        Secondary email address.
+    :ivar SecondaryEmail.is_verified:
+        Whether or not the secondary email address is verified to be owned by a
+        user.
     """
 
     __slots__ = [

--- a/dropbox/seen_state.py
+++ b/dropbox/seen_state.py
@@ -15,19 +15,21 @@ class PlatformType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar seen_state.PlatformType.web: The content was viewed on the web.
-    :ivar seen_state.PlatformType.desktop: The content was viewed on a desktop
-        client.
-    :ivar seen_state.PlatformType.mobile_ios: The content was viewed on a mobile
-        iOS client.
-    :ivar seen_state.PlatformType.mobile_android: The content was viewed on a
-        mobile android client.
-    :ivar seen_state.PlatformType.api: The content was viewed from an API
-        client.
-    :ivar seen_state.PlatformType.unknown: The content was viewed on an unknown
-        platform.
-    :ivar seen_state.PlatformType.mobile: The content was viewed on a mobile
-        client. DEPRECATED: Use mobile_ios or mobile_android instead.
+    :ivar PlatformType.web:
+        The content was viewed on the web.
+    :ivar PlatformType.desktop:
+        The content was viewed on a desktop client.
+    :ivar PlatformType.mobile_ios:
+        The content was viewed on a mobile iOS client.
+    :ivar PlatformType.mobile_android:
+        The content was viewed on a mobile android client.
+    :ivar PlatformType.api:
+        The content was viewed from an API client.
+    :ivar PlatformType.unknown:
+        The content was viewed on an unknown platform.
+    :ivar PlatformType.mobile:
+        The content was viewed on a mobile client. DEPRECATED: Use mobile_ios or
+        mobile_android instead.
     """
 
     _catch_all = 'other'

--- a/dropbox/sharing.py
+++ b/dropbox/sharing.py
@@ -28,10 +28,10 @@ class AccessInheritance(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.AccessInheritance.inherit: The shared folder inherits its
-        members from the parent folder.
-    :ivar sharing.AccessInheritance.no_inherit: The shared folder does not
-        inherit its members from the parent folder.
+    :ivar AccessInheritance.inherit:
+        The shared folder inherits its members from the parent folder.
+    :ivar AccessInheritance.no_inherit:
+        The shared folder does not inherit its members from the parent folder.
     """
 
     _catch_all = 'other'
@@ -79,23 +79,25 @@ class AccessLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.AccessLevel.owner: The collaborator is the owner of the shared
-        folder. Owners can view and edit the shared folder as well as set the
-        folder's policies using
+    :ivar AccessLevel.owner:
+        The collaborator is the owner of the shared folder. Owners can view and
+        edit the shared folder as well as set the folder's policies using
         :meth:`dropbox.dropbox_client.Dropbox.sharing_update_folder_policy`.
-    :ivar sharing.AccessLevel.editor: The collaborator can both view and edit
-        the shared folder.
-    :ivar sharing.AccessLevel.viewer: The collaborator can only view the shared
-        folder.
-    :ivar sharing.AccessLevel.viewer_no_comment: The collaborator can only view
-        the shared folder and does not have any access to comments.
-    :ivar sharing.AccessLevel.traverse: The collaborator can only view the
-        shared folder that they have access to.
-    :ivar sharing.AccessLevel.no_access: If there is a Righteous Link on the
-        folder which grants access and the user has visited such link, they are
-        allowed to perform certain action (i.e. add themselves to the folder)
-        via the link access even though the user themselves are not a member on
-        the shared folder yet.
+    :ivar AccessLevel.editor:
+        The collaborator can both view and edit the shared folder.
+    :ivar AccessLevel.viewer:
+        The collaborator can only view the shared folder.
+    :ivar AccessLevel.viewer_no_comment:
+        The collaborator can only view the shared folder and does not have any
+        access to comments.
+    :ivar AccessLevel.traverse:
+        The collaborator can only view the shared folder that they have access
+        to.
+    :ivar AccessLevel.no_access:
+        If there is a Righteous Link on the folder which grants access and the
+        user has visited such link, they are allowed to perform certain action
+        (i.e. add themselves to the folder) via the link access even though the
+        user themselves are not a member on the shared folder yet.
     """
 
     _catch_all = 'other'
@@ -184,9 +186,11 @@ class AclUpdatePolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.AclUpdatePolicy.owner: Only the owner can update the ACL.
-    :ivar sharing.AclUpdatePolicy.editors: Any editor can update the ACL. This
-        may be further restricted to editors on the same team.
+    :ivar AclUpdatePolicy.owner:
+        Only the owner can update the ACL.
+    :ivar AclUpdatePolicy.editors:
+        Any editor can update the ACL. This may be further restricted to editors
+        on the same team.
     """
 
     _catch_all = 'other'
@@ -231,21 +235,26 @@ class AddFileMemberArgs(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_add_file_member`.
 
-    :ivar sharing.AddFileMemberArgs.file: File to which to add members.
-    :ivar sharing.AddFileMemberArgs.members: Members to add. Note that even an
-        email address is given, this may result in a user being directly added
-        to the membership if that email is the user's main account email.
-    :ivar sharing.AddFileMemberArgs.custom_message: Message to send to added
-        members in their invitation.
-    :ivar sharing.AddFileMemberArgs.quiet: Whether added members should be
-        notified via email and device notifications of their invitation.
-    :ivar sharing.AddFileMemberArgs.access_level: AccessLevel union object,
-        describing what access level we want to give new members.
-    :ivar sharing.AddFileMemberArgs.add_message_as_comment: If the custom
-        message should be added as a comment on the file. Only meant for Paper
-        files.
-    :ivar sharing.AddFileMemberArgs.fp_sealed_result: Field is only returned for
-        "internal" callers. The FingerprintJS Sealed Client Result value
+    :ivar AddFileMemberArgs.file:
+        File to which to add members.
+    :ivar AddFileMemberArgs.members:
+        Members to add. Note that even an email address is given, this may
+        result in a user being directly added to the membership if that email is
+        the user's main account email.
+    :ivar AddFileMemberArgs.custom_message:
+        Message to send to added members in their invitation.
+    :ivar AddFileMemberArgs.quiet:
+        Whether added members should be notified via email and device
+        notifications of their invitation.
+    :ivar AddFileMemberArgs.access_level:
+        AccessLevel union object, describing what access level we want to give
+        new members.
+    :ivar AddFileMemberArgs.add_message_as_comment:
+        If the custom message should be added as a comment on the file. Only
+        meant for Paper files.
+    :ivar AddFileMemberArgs.fp_sealed_result:
+        Field is only returned for "internal" callers. The FingerprintJS Sealed
+        Client Result value
     """
 
     __slots__ = [
@@ -324,12 +333,12 @@ class AddFileMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.AddFileMemberError.rate_limit: The user has reached the rate
-        limit for invitations.
-    :ivar sharing.AddFileMemberError.invalid_comment: The custom message did not
-        pass comment permissions checks.
-    :ivar sharing.AddFileMemberError.banned_member: The current user has been
-        banned for abuse reasons.
+    :ivar AddFileMemberError.rate_limit:
+        The user has reached the rate limit for invitations.
+    :ivar AddFileMemberError.invalid_comment:
+        The custom message did not pass comment permissions checks.
+    :ivar AddFileMemberError.banned_member:
+        The current user has been banned for abuse reasons.
     """
 
     _catch_all = 'other'
@@ -439,16 +448,19 @@ AddFileMemberError_validator = bv.Union(AddFileMemberError)
 
 class AddFolderMemberArg(bb.Struct):
     """
-    :ivar sharing.AddFolderMemberArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.AddFolderMemberArg.members: The intended list of members to
-        add.  Added members will receive invites to join the shared folder.
-    :ivar sharing.AddFolderMemberArg.quiet: Whether added members should be
-        notified via email and device notifications of their invite.
-    :ivar sharing.AddFolderMemberArg.custom_message: Optional message to display
-        to added members in their invitation.
-    :ivar sharing.AddFolderMemberArg.fp_sealed_result: Field is only returned
-        for "internal" callers. The FingerprintJS Sealed Client Result value
+    :ivar AddFolderMemberArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar AddFolderMemberArg.members:
+        The intended list of members to add.  Added members will receive invites
+        to join the shared folder.
+    :ivar AddFolderMemberArg.quiet:
+        Whether added members should be notified via email and device
+        notifications of their invite.
+    :ivar AddFolderMemberArg.custom_message:
+        Optional message to display to added members in their invitation.
+    :ivar AddFolderMemberArg.fp_sealed_result:
+        Field is only returned for "internal" callers. The FingerprintJS Sealed
+        Client Result value
     """
 
     __slots__ = [
@@ -509,36 +521,41 @@ class AddFolderMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedFolderAccessError AddFolderMemberError.access_error: Unable to
-        access shared folder.
-    :ivar sharing.AddFolderMemberError.email_unverified: This user's email
-        address is not verified. This functionality is only available on
-        accounts with a verified email address. Users can verify their email
-        address `here <https://www.dropbox.com/help/317>`_.
-    :ivar sharing.AddFolderMemberError.banned_member: The current user has been
-        banned.
-    :ivar AddMemberSelectorError AddFolderMemberError.bad_member:
+    :ivar AddFolderMemberError.access_error:
+        Unable to access shared folder.
+    :vartype AddFolderMemberError.access_error: SharedFolderAccessError
+    :ivar AddFolderMemberError.email_unverified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
+    :ivar AddFolderMemberError.banned_member:
+        The current user has been banned.
+    :ivar AddFolderMemberError.bad_member:
         ``AddFolderMemberArg.members`` contains a bad invitation recipient.
-    :ivar sharing.AddFolderMemberError.cant_share_outside_team: Your team policy
-        does not allow sharing outside of the team.
-    :ivar int sharing.AddFolderMemberError.too_many_members: The value is the
-        member limit that was reached.
-    :ivar int sharing.AddFolderMemberError.too_many_pending_invites: The value
-        is the pending invite limit that was reached.
-    :ivar sharing.AddFolderMemberError.rate_limit: The current user has hit the
-        limit of invites they can send per day. Try again in 24 hours.
-    :ivar sharing.AddFolderMemberError.too_many_invitees: The current user is
-        trying to share with too many people at once.
-    :ivar sharing.AddFolderMemberError.insufficient_plan: The current user's
-        account doesn't support this action. An example of this is when adding a
-        read-only member. This action can only be performed by users that have
-        upgraded to a Pro or Business plan.
-    :ivar sharing.AddFolderMemberError.team_folder: This action cannot be
-        performed on a team shared folder.
-    :ivar sharing.AddFolderMemberError.no_permission: The current user does not
-        have permission to perform this action.
-    :ivar sharing.AddFolderMemberError.invalid_shared_folder: Field is
-        deprecated. Invalid shared folder error will be returned as an
+    :vartype AddFolderMemberError.bad_member: AddMemberSelectorError
+    :ivar AddFolderMemberError.cant_share_outside_team:
+        Your team policy does not allow sharing outside of the team.
+    :ivar AddFolderMemberError.too_many_members:
+        The value is the member limit that was reached.
+    :vartype AddFolderMemberError.too_many_members: int
+    :ivar AddFolderMemberError.too_many_pending_invites:
+        The value is the pending invite limit that was reached.
+    :vartype AddFolderMemberError.too_many_pending_invites: int
+    :ivar AddFolderMemberError.rate_limit:
+        The current user has hit the limit of invites they can send per day. Try
+        again in 24 hours.
+    :ivar AddFolderMemberError.too_many_invitees:
+        The current user is trying to share with too many people at once.
+    :ivar AddFolderMemberError.insufficient_plan:
+        The current user's account doesn't support this action. An example of
+        this is when adding a read-only member. This action can only be
+        performed by users that have upgraded to a Pro or Business plan.
+    :ivar AddFolderMemberError.team_folder:
+        This action cannot be performed on a team shared folder.
+    :ivar AddFolderMemberError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar AddFolderMemberError.invalid_shared_folder:
+        Field is deprecated. Invalid shared folder error will be returned as an
         access_error.
     """
 
@@ -778,9 +795,11 @@ class AddMember(bb.Struct):
     The member and type of access the member should have when added to a shared
     folder.
 
-    :ivar sharing.AddMember.member: The member to add to the shared folder.
-    :ivar sharing.AddMember.access_level: The access level to grant ``member``
-        to the shared folder.  ``AccessLevel.owner`` is disallowed.
+    :ivar AddMember.member:
+        The member to add to the shared folder.
+    :ivar AddMember.access_level:
+        The access level to grant ``member`` to the shared folder.
+        ``AccessLevel.owner`` is disallowed.
     """
 
     __slots__ = [
@@ -817,21 +836,26 @@ class AddMemberSelectorError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.AddMemberSelectorError.automatic_group: Automatically created
-        groups can only be added to team folders.
-    :ivar str sharing.AddMemberSelectorError.invalid_dropbox_id: The value is
-        the ID that could not be identified.
-    :ivar str sharing.AddMemberSelectorError.invalid_email: The value is the
-        e-email address that is malformed.
-    :ivar sharing.AddMemberSelectorError.invalid_group: Provided group is
-        invalid.
-    :ivar str sharing.AddMemberSelectorError.unverified_dropbox_id: The value is
-        the ID of the Dropbox user with an unverified email address. Invite
-        unverified users by email address instead of by their Dropbox ID.
-    :ivar sharing.AddMemberSelectorError.group_deleted: At least one of the
-        specified groups in ``AddFolderMemberArg.members`` is deleted.
-    :ivar sharing.AddMemberSelectorError.group_not_on_team: Sharing to a group
-        that is not on the current user's team.
+    :ivar AddMemberSelectorError.automatic_group:
+        Automatically created groups can only be added to team folders.
+    :ivar AddMemberSelectorError.invalid_dropbox_id:
+        The value is the ID that could not be identified.
+    :vartype AddMemberSelectorError.invalid_dropbox_id: str
+    :ivar AddMemberSelectorError.invalid_email:
+        The value is the e-email address that is malformed.
+    :vartype AddMemberSelectorError.invalid_email: str
+    :ivar AddMemberSelectorError.invalid_group:
+        Provided group is invalid.
+    :ivar AddMemberSelectorError.unverified_dropbox_id:
+        The value is the ID of the Dropbox user with an unverified email
+        address. Invite unverified users by email address instead of by their
+        Dropbox ID.
+    :vartype AddMemberSelectorError.unverified_dropbox_id: str
+    :ivar AddMemberSelectorError.group_deleted:
+        At least one of the specified groups in ``AddFolderMemberArg.members``
+        is deleted.
+    :ivar AddMemberSelectorError.group_not_on_team:
+        Sharing to a group that is not on the current user's team.
     """
 
     _catch_all = 'other'
@@ -998,12 +1022,13 @@ class RequestedVisibility(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RequestedVisibility.public: Anyone who has received the link
-        can access it. No login required.
-    :ivar sharing.RequestedVisibility.team_only: Only members of the same team
-        can access the link. Login is required.
-    :ivar sharing.RequestedVisibility.password: A link-specific password is
-        required to access the link. Login is not required.
+    :ivar RequestedVisibility.public:
+        Anyone who has received the link can access it. No login required.
+    :ivar RequestedVisibility.team_only:
+        Only members of the same team can access the link. Login is required.
+    :ivar RequestedVisibility.password:
+        A link-specific password is required to access the link. Login is not
+        required.
     """
 
     _catch_all = None
@@ -1054,19 +1079,19 @@ class ResolvedVisibility(RequestedVisibility):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ResolvedVisibility.team_and_password: Only members of the same
-        team who have the link-specific password can access the link. Login is
-        required.
-    :ivar sharing.ResolvedVisibility.shared_folder_only: Only members of the
-        shared folder containing the linked file can access the link. Login is
-        required.
-    :ivar sharing.ResolvedVisibility.no_one: The link merely points the user to
-        the content, and does not grant any additional rights. Existing members
-        of the content who use this link can only access the content with their
-        pre-existing access rights. Either on the file directly, or inherited
-        from a parent folder.
-    :ivar sharing.ResolvedVisibility.only_you: Only the current user can view
-        this link.
+    :ivar ResolvedVisibility.team_and_password:
+        Only members of the same team who have the link-specific password can
+        access the link. Login is required.
+    :ivar ResolvedVisibility.shared_folder_only:
+        Only members of the shared folder containing the linked file can access
+        the link. Login is required.
+    :ivar ResolvedVisibility.no_one:
+        The link merely points the user to the content, and does not grant any
+        additional rights. Existing members of the content who use this link can
+        only access the content with their pre-existing access rights. Either on
+        the file directly, or inherited from a parent folder.
+    :ivar ResolvedVisibility.only_you:
+        Only the current user can view this link.
     """
 
     _catch_all = 'other'
@@ -1145,8 +1170,8 @@ class AudienceExceptionContentInfo(bb.Struct):
     Information about the content that has a link audience different than that
     of this folder.
 
-    :ivar sharing.AudienceExceptionContentInfo.name: The name of the content,
-        which is either a file or a folder.
+    :ivar AudienceExceptionContentInfo.name:
+        The name of the content, which is either a file or a folder.
     """
 
     __slots__ = [
@@ -1175,10 +1200,10 @@ class AudienceExceptions(bb.Struct):
     folder that has a different audience than the link on this folder. This is
     only returned for folders.
 
-    :ivar sharing.AudienceExceptions.exceptions: A truncated list of some of the
-        content that is an exception. The length of this list could be smaller
-        than the count since it is only a sample but will not be empty as long
-        as count is not 0.
+    :ivar AudienceExceptions.exceptions:
+        A truncated list of some of the content that is an exception. The length
+        of this list could be smaller than the count since it is only a sample
+        but will not be empty as long as count is not 0.
     """
 
     __slots__ = [
@@ -1214,12 +1239,12 @@ class AudienceRestrictingSharedFolder(bb.Struct):
     Information about the shared folder that prevents the link audience for this
     link from being more restrictive.
 
-    :ivar sharing.AudienceRestrictingSharedFolder.shared_folder_id: The ID of
-        the shared folder.
-    :ivar sharing.AudienceRestrictingSharedFolder.name: The name of the shared
-        folder.
-    :ivar sharing.AudienceRestrictingSharedFolder.audience: The link audience of
-        the shared folder.
+    :ivar AudienceRestrictingSharedFolder.shared_folder_id:
+        The ID of the shared folder.
+    :ivar AudienceRestrictingSharedFolder.name:
+        The name of the shared folder.
+    :ivar AudienceRestrictingSharedFolder.audience:
+        The link audience of the shared folder.
     """
 
     __slots__ = [
@@ -1309,10 +1334,12 @@ class LinkMetadata(bb.Struct):
     Metadata for a shared link. This can be either a :class:`PathLinkMetadata`
     or :class:`CollectionLinkMetadata`.
 
-    :ivar sharing.LinkMetadata.url: URL of the shared link.
-    :ivar sharing.LinkMetadata.visibility: Who can access the link.
-    :ivar sharing.LinkMetadata.expires: Expiration time, if set. By default the
-        link won't expire.
+    :ivar LinkMetadata.url:
+        URL of the shared link.
+    :ivar LinkMetadata.visibility:
+        Who can access the link.
+    :ivar LinkMetadata.expires:
+        Expiration time, if set. By default the link won't expire.
     """
 
     __slots__ = [
@@ -1376,10 +1403,12 @@ CollectionLinkMetadata_validator = bv.Struct(CollectionLinkMetadata)
 
 class CreateSharedLinkArg(bb.Struct):
     """
-    :ivar sharing.CreateSharedLinkArg.path: The path to share.
-    :ivar sharing.CreateSharedLinkArg.short_url: Field is deprecated. None
-    :ivar sharing.CreateSharedLinkArg.pending_upload: If it's okay to share a
-        path that does not yet exist, set this to either
+    :ivar CreateSharedLinkArg.path:
+        The path to share.
+    :ivar CreateSharedLinkArg.short_url:
+        Field is deprecated. None
+    :ivar CreateSharedLinkArg.pending_upload:
+        If it's okay to share a path that does not yet exist, set this to either
         ``PendingUploadMode.file`` or ``PendingUploadMode.folder`` to indicate
         whether to assume it's a file or folder.
     """
@@ -1475,10 +1504,10 @@ CreateSharedLinkError_validator = bv.Union(CreateSharedLinkError)
 
 class CreateSharedLinkWithSettingsArg(bb.Struct):
     """
-    :ivar sharing.CreateSharedLinkWithSettingsArg.path: The path to be shared by
-        the shared link.
-    :ivar sharing.CreateSharedLinkWithSettingsArg.settings: The requested
-        settings for the newly created shared link.
+    :ivar CreateSharedLinkWithSettingsArg.path:
+        The path to be shared by the shared link.
+    :ivar CreateSharedLinkWithSettingsArg.settings:
+        The requested settings for the newly created shared link.
     """
 
     __slots__ = [
@@ -1515,29 +1544,31 @@ class CreateSharedLinkWithSettingsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.CreateSharedLinkWithSettingsError.email_not_verified: This
-        user's email address is not verified. This functionality is only
+    :ivar CreateSharedLinkWithSettingsError.email_not_verified:
+        This user's email address is not verified. This functionality is only
         available on accounts with a verified email address. Users can verify
         their email address `here <https://www.dropbox.com/help/317>`_.
-    :ivar Optional[SharedLinkAlreadyExistsMetadata]
-        sharing.CreateSharedLinkWithSettingsError.shared_link_already_exists:
-        The shared link already exists. You can call :route:`list_shared_links`
-        to get the existing link, or use the provided metadata if it is
-        returned. Existing link metadata will not be returned if custom settings
-        were specified in the request that could make the existing link
-        incompatible with the requested settings.
-    :ivar SharedLinkSettingsError
-        CreateSharedLinkWithSettingsError.settings_error: There is an error with
-        the given settings.
-    :ivar sharing.CreateSharedLinkWithSettingsError.access_denied: The user is
-        not allowed to create a shared link to the specified file. For example,
-        this can occur if the file is restricted or if the user's links are
-        `banned <https://help.dropbox.com/files-folders/share/banned-links>`_.
-    :ivar sharing.CreateSharedLinkWithSettingsError.banned_member: The current
-        user has been `banned
+    :ivar CreateSharedLinkWithSettingsError.shared_link_already_exists:
+        The shared link already exists. You can call
+        :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links` to get
+        the existing link, or use the provided metadata if it is returned.
+        Existing link metadata will not be returned if custom settings were
+        specified in the request that could make the existing link incompatible
+        with the requested settings.
+    :vartype CreateSharedLinkWithSettingsError.shared_link_already_exists: Optional[SharedLinkAlreadyExistsMetadata]
+    :ivar CreateSharedLinkWithSettingsError.settings_error:
+        There is an error with the given settings.
+    :vartype CreateSharedLinkWithSettingsError.settings_error: SharedLinkSettingsError
+    :ivar CreateSharedLinkWithSettingsError.access_denied:
+        The user is not allowed to create a shared link to the specified file.
+        For example, this can occur if the file is restricted or if the user's
+        links are `banned
+        <https://help.dropbox.com/files-folders/share/banned-links>`_.
+    :ivar CreateSharedLinkWithSettingsError.banned_member:
+        The current user has been `banned
         <https://help.dropbox.com/files-folders/share/banned-links>`_ for abuse
         reasons.
-    :ivar sharing.CreateSharedLinkWithSettingsError.too_many_shared_folders:
+    :ivar CreateSharedLinkWithSettingsError.too_many_shared_folders:
         Your Dropbox folder will have too many shared folders after the
         operation.
         https://help.dropbox.com/share/shared-folder-faq#Is-there-a-limit-to-the-number-of-shared-folders-I-can-create
@@ -1688,26 +1719,25 @@ CreateSharedLinkWithSettingsError_validator = bv.Union(CreateSharedLinkWithSetti
 
 class SharedContentLinkMetadataBase(bb.Struct):
     """
-    :ivar sharing.SharedContentLinkMetadataBase.access_level: The access level
-        on the link for this file.
-    :ivar sharing.SharedContentLinkMetadataBase.audience_options: The audience
-        options that are available for the content. Some audience options may be
-        unavailable. For example, team_only may be unavailable if the content is
-        not owned by a user on a team. The 'default' audience option is always
-        available if the user can modify link settings.
-    :ivar
-        sharing.SharedContentLinkMetadataBase.audience_restricting_shared_folder:
+    :ivar SharedContentLinkMetadataBase.access_level:
+        The access level on the link for this file.
+    :ivar SharedContentLinkMetadataBase.audience_options:
+        The audience options that are available for the content. Some audience
+        options may be unavailable. For example, team_only may be unavailable if
+        the content is not owned by a user on a team. The 'default' audience
+        option is always available if the user can modify link settings.
+    :ivar SharedContentLinkMetadataBase.audience_restricting_shared_folder:
         The shared folder that prevents the link audience for this link from
         being more restrictive.
-    :ivar sharing.SharedContentLinkMetadataBase.current_audience: The current
-        audience of the link.
-    :ivar sharing.SharedContentLinkMetadataBase.expiry: Whether the link has an
-        expiry set on it. A link with an expiry will have its audience changed
-        to members when the expiry is reached.
-    :ivar sharing.SharedContentLinkMetadataBase.link_permissions: A list of
-        permissions for actions you can perform on the link.
-    :ivar sharing.SharedContentLinkMetadataBase.password_protected: Whether the
-        link is protected by a password.
+    :ivar SharedContentLinkMetadataBase.current_audience:
+        The current audience of the link.
+    :ivar SharedContentLinkMetadataBase.expiry:
+        Whether the link has an expiry set on it. A link with an expiry will
+        have its audience changed to members when the expiry is reached.
+    :ivar SharedContentLinkMetadataBase.link_permissions:
+        A list of permissions for actions you can perform on the link.
+    :ivar SharedContentLinkMetadataBase.password_protected:
+        Whether the link is protected by a password.
     """
 
     __slots__ = [
@@ -1818,26 +1848,31 @@ class FileAction(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.FileAction.disable_viewer_info: Disable viewer information on
-        the file.
-    :ivar sharing.FileAction.edit_contents: Change or edit contents of the file.
-    :ivar sharing.FileAction.enable_viewer_info: Enable viewer information on
-        the file.
-    :ivar sharing.FileAction.invite_viewer: Add a member with view permissions.
-    :ivar sharing.FileAction.invite_viewer_no_comment: Add a member with view
-        permissions but no comment permissions.
-    :ivar sharing.FileAction.invite_editor: Add a member with edit permissions.
-    :ivar sharing.FileAction.unshare: Stop sharing this file.
-    :ivar sharing.FileAction.relinquish_membership: Relinquish one's own
-        membership to the file.
-    :ivar sharing.FileAction.share_link: Field is deprecated. Use
-        create_view_link and create_edit_link instead.
-    :ivar sharing.FileAction.create_link: Field is deprecated. Use
-        create_view_link and create_edit_link instead.
-    :ivar sharing.FileAction.create_view_link: Create a shared link to a file
-        that only allows users to view the content.
-    :ivar sharing.FileAction.create_edit_link: Create a shared link to a file
-        that allows users to edit the content.
+    :ivar FileAction.disable_viewer_info:
+        Disable viewer information on the file.
+    :ivar FileAction.edit_contents:
+        Change or edit contents of the file.
+    :ivar FileAction.enable_viewer_info:
+        Enable viewer information on the file.
+    :ivar FileAction.invite_viewer:
+        Add a member with view permissions.
+    :ivar FileAction.invite_viewer_no_comment:
+        Add a member with view permissions but no comment permissions.
+    :ivar FileAction.invite_editor:
+        Add a member with edit permissions.
+    :ivar FileAction.unshare:
+        Stop sharing this file.
+    :ivar FileAction.relinquish_membership:
+        Relinquish one's own membership to the file.
+    :ivar FileAction.share_link:
+        Field is deprecated. Use create_view_link and create_edit_link instead.
+    :ivar FileAction.create_link:
+        Field is deprecated. Use create_view_link and create_edit_link instead.
+    :ivar FileAction.create_view_link:
+        Create a shared link to a file that only allows users to view the
+        content.
+    :ivar FileAction.create_edit_link:
+        Create a shared link to a file that allows users to edit the content.
     """
 
     _catch_all = 'other'
@@ -1983,12 +2018,15 @@ class FileErrorResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str sharing.FileErrorResult.file_not_found_error: File specified by id
-        was not found.
-    :ivar str sharing.FileErrorResult.invalid_file_action_error: User does not
-        have permission to take the specified action on the file.
-    :ivar str sharing.FileErrorResult.permission_denied_error: User does not
-        have permission to access file specified by file.Id.
+    :ivar FileErrorResult.file_not_found_error:
+        File specified by id was not found.
+    :vartype FileErrorResult.file_not_found_error: str
+    :ivar FileErrorResult.invalid_file_action_error:
+        User does not have permission to take the specified action on the file.
+    :vartype FileErrorResult.invalid_file_action_error: str
+    :ivar FileErrorResult.permission_denied_error:
+        User does not have permission to access file specified by file.Id.
+    :vartype FileErrorResult.permission_denied_error: str
     """
 
     _catch_all = 'other'
@@ -2105,26 +2143,27 @@ class SharedLinkMetadata(bb.Struct):
     """
     The metadata of a shared link.
 
-    :ivar sharing.SharedLinkMetadata.url: URL of the shared link.
-    :ivar sharing.SharedLinkMetadata.id: A unique identifier for the linked
-        file.
-    :ivar sharing.SharedLinkMetadata.name: The linked file name (including
-        extension). This never contains a slash.
-    :ivar sharing.SharedLinkMetadata.expires: Expiration time, if set. By
-        default the link won't expire.
-    :ivar sharing.SharedLinkMetadata.path_lower: The lowercased full path in the
-        user's Dropbox. This always starts with a slash. This field will only be
-        present only if the linked file is in the authenticated user's dropbox
-        and the user is the owner of the link.
-    :ivar sharing.SharedLinkMetadata.link_permissions: The link's access
-        permissions.
-    :ivar sharing.SharedLinkMetadata.team_member_info: The team membership
-        information of the link's owner.  This field will only be present if the
-        link's owner is a team member.
-    :ivar sharing.SharedLinkMetadata.content_owner_team_info: The team
-        information of the content's owner. This field will only be present if
-        the content's owner is a team member and the content's owner team is
-        different from the link's owner team.
+    :ivar SharedLinkMetadata.url:
+        URL of the shared link.
+    :ivar SharedLinkMetadata.id:
+        A unique identifier for the linked file.
+    :ivar SharedLinkMetadata.name:
+        The linked file name (including extension). This never contains a slash.
+    :ivar SharedLinkMetadata.expires:
+        Expiration time, if set. By default the link won't expire.
+    :ivar SharedLinkMetadata.path_lower:
+        The lowercased full path in the user's Dropbox. This always starts with
+        a slash. This field will only be present only if the linked file is in
+        the authenticated user's dropbox and the user is the owner of the link.
+    :ivar SharedLinkMetadata.link_permissions:
+        The link's access permissions.
+    :ivar SharedLinkMetadata.team_member_info:
+        The team membership information of the link's owner.  This field will
+        only be present if the link's owner is a team member.
+    :ivar SharedLinkMetadata.content_owner_team_info:
+        The team information of the content's owner. This field will only be
+        present if the content's owner is a team member and the content's owner
+        team is different from the link's owner team.
     """
 
     __slots__ = [
@@ -2207,18 +2246,20 @@ class FileLinkMetadata(SharedLinkMetadata):
     """
     The metadata of a file shared link.
 
-    :ivar sharing.FileLinkMetadata.client_modified: The modification time set by
-        the desktop client when the file was added to Dropbox. Since this time
-        is not verified (the Dropbox server stores whatever the desktop client
-        sends up), this should only be used for display purposes (such as
-        sorting) and not, for example, to determine if a file has changed or
-        not.
-    :ivar sharing.FileLinkMetadata.server_modified: The last time the file was
-        modified on Dropbox.
-    :ivar sharing.FileLinkMetadata.rev: A unique identifier for the current
-        revision of a file. This field is the same rev as elsewhere in the API
-        and can be used to detect changes and avoid conflicts.
-    :ivar sharing.FileLinkMetadata.size: The file size in bytes.
+    :ivar FileLinkMetadata.client_modified:
+        The modification time set by the desktop client when the file was added
+        to Dropbox. Since this time is not verified (the Dropbox server stores
+        whatever the desktop client sends up), this should only be used for
+        display purposes (such as sorting) and not, for example, to determine if
+        a file has changed or not.
+    :ivar FileLinkMetadata.server_modified:
+        The last time the file was modified on Dropbox.
+    :ivar FileLinkMetadata.rev:
+        A unique identifier for the current revision of a file. This field is
+        the same rev as elsewhere in the API and can be used to detect changes
+        and avoid conflicts.
+    :ivar FileLinkMetadata.size:
+        The file size in bytes.
     """
 
     __slots__ = [
@@ -2287,16 +2328,18 @@ class FileMemberActionError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.FileMemberActionError.invalid_member: Specified member was not
-        found.
-    :ivar sharing.FileMemberActionError.no_permission: User does not have
-        permission to perform this action on this member.
-    :ivar SharingFileAccessError FileMemberActionError.access_error: Specified
-        file was invalid or user does not have access.
-    :ivar MemberAccessLevelResult FileMemberActionError.no_explicit_access: The
-        action cannot be completed because the target member does not have
+    :ivar FileMemberActionError.invalid_member:
+        Specified member was not found.
+    :ivar FileMemberActionError.no_permission:
+        User does not have permission to perform this action on this member.
+    :ivar FileMemberActionError.access_error:
+        Specified file was invalid or user does not have access.
+    :vartype FileMemberActionError.access_error: SharingFileAccessError
+    :ivar FileMemberActionError.no_explicit_access:
+        The action cannot be completed because the target member does not have
         explicit access to the file. The return value is the access that the
         member has to the file from a parent folder.
+    :vartype FileMemberActionError.no_explicit_access: MemberAccessLevelResult
     """
 
     _catch_all = 'other'
@@ -2406,15 +2449,16 @@ class FileMemberActionIndividualResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar Optional[AccessLevel]
-        sharing.FileMemberActionIndividualResult.success: Part of the response
-        for both add_file_member and remove_file_member_v1 (deprecated). For
-        add_file_member, indicates giving access was successful and at what
-        AccessLevel. For remove_file_member_v1, indicates member was
-        successfully removed from the file. If AccessLevel is given, the member
-        still has access via a parent shared folder.
-    :ivar FileMemberActionError FileMemberActionIndividualResult.member_error:
+    :ivar FileMemberActionIndividualResult.success:
+        Part of the response for both add_file_member and remove_file_member_v1
+        (deprecated). For add_file_member, indicates giving access was
+        successful and at what AccessLevel. For remove_file_member_v1, indicates
+        member was successfully removed from the file. If AccessLevel is given,
+        the member still has access via a parent shared folder.
+    :vartype FileMemberActionIndividualResult.success: Optional[AccessLevel]
+    :ivar FileMemberActionIndividualResult.member_error:
         User was not able to perform this action.
+    :vartype FileMemberActionIndividualResult.member_error: FileMemberActionError
     """
 
     _catch_all = None
@@ -2495,15 +2539,16 @@ class FileMemberActionResult(bb.Struct):
     Per-member result for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_add_file_member`.
 
-    :ivar sharing.FileMemberActionResult.member: One of specified input members.
-    :ivar sharing.FileMemberActionResult.result: The outcome of the action on
-        this member.
-    :ivar sharing.FileMemberActionResult.sckey_sha1: The SHA-1 encrypted shared
-        content key.
-    :ivar sharing.FileMemberActionResult.invitation_signature: The sharing
-        sender-recipient invitation signatures for the input member_id. A
-        member_id can be a group and thus have multiple users and multiple
-        invitation signatures.
+    :ivar FileMemberActionResult.member:
+        One of specified input members.
+    :ivar FileMemberActionResult.result:
+        The outcome of the action on this member.
+    :ivar FileMemberActionResult.sckey_sha1:
+        The SHA-1 encrypted shared content key.
+    :ivar FileMemberActionResult.invitation_signature:
+        The sharing sender-recipient invitation signatures for the input
+        member_id. A member_id can be a group and thus have multiple users and
+        multiple invitation signatures.
     """
 
     __slots__ = [
@@ -2556,10 +2601,12 @@ class FileMemberRemoveActionResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar MemberAccessLevelResult FileMemberRemoveActionResult.success: Member
-        was successfully removed from this file.
-    :ivar FileMemberActionError FileMemberRemoveActionResult.member_error: User
-        was not able to remove this member.
+    :ivar FileMemberRemoveActionResult.success:
+        Member was successfully removed from this file.
+    :vartype FileMemberRemoveActionResult.success: MemberAccessLevelResult
+    :ivar FileMemberRemoveActionResult.member_error:
+        User was not able to remove this member.
+    :vartype FileMemberRemoveActionResult.member_error: FileMemberActionError
     """
 
     _catch_all = 'other'
@@ -2645,12 +2692,13 @@ class FilePermission(bb.Struct):
     """
     Whether the user is allowed to take the sharing action on the file.
 
-    :ivar sharing.FilePermission.action: The action that the user may wish to
-        take on the file.
-    :ivar sharing.FilePermission.allow: True if the user is allowed to take the
-        action.
-    :ivar sharing.FilePermission.reason: The reason why the user is denied the
-        permission. Not present if the action is allowed.
+    :ivar FilePermission.action:
+        The action that the user may wish to take on the file.
+    :ivar FilePermission.allow:
+        True if the user is allowed to take the action.
+    :ivar FilePermission.reason:
+        The reason why the user is denied the permission. Not present if the
+        action is allowed.
     """
 
     __slots__ = [
@@ -2697,36 +2745,41 @@ class FolderAction(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.FolderAction.change_options: Change folder options, such as
-        who can be invited to join the folder.
-    :ivar sharing.FolderAction.disable_viewer_info: Disable viewer information
-        for this folder.
-    :ivar sharing.FolderAction.edit_contents: Change or edit contents of the
+    :ivar FolderAction.change_options:
+        Change folder options, such as who can be invited to join the folder.
+    :ivar FolderAction.disable_viewer_info:
+        Disable viewer information for this folder.
+    :ivar FolderAction.edit_contents:
+        Change or edit contents of the folder.
+    :ivar FolderAction.enable_viewer_info:
+        Enable viewer information on the folder.
+    :ivar FolderAction.invite_editor:
+        Invite a user or group to join the folder with read and write
+        permission.
+    :ivar FolderAction.invite_viewer:
+        Invite a user or group to join the folder with read permission.
+    :ivar FolderAction.invite_viewer_no_comment:
+        Invite a user or group to join the folder with read permission but no
+        comment permissions.
+    :ivar FolderAction.relinquish_membership:
+        Relinquish one's own membership in the folder.
+    :ivar FolderAction.unmount:
+        Unmount the folder.
+    :ivar FolderAction.unshare:
+        Stop sharing this folder.
+    :ivar FolderAction.leave_a_copy:
+        Keep a copy of the contents upon leaving or being kicked from the
         folder.
-    :ivar sharing.FolderAction.enable_viewer_info: Enable viewer information on
-        the folder.
-    :ivar sharing.FolderAction.invite_editor: Invite a user or group to join the
-        folder with read and write permission.
-    :ivar sharing.FolderAction.invite_viewer: Invite a user or group to join the
-        folder with read permission.
-    :ivar sharing.FolderAction.invite_viewer_no_comment: Invite a user or group
-        to join the folder with read permission but no comment permissions.
-    :ivar sharing.FolderAction.relinquish_membership: Relinquish one's own
-        membership in the folder.
-    :ivar sharing.FolderAction.unmount: Unmount the folder.
-    :ivar sharing.FolderAction.unshare: Stop sharing this folder.
-    :ivar sharing.FolderAction.leave_a_copy: Keep a copy of the contents upon
-        leaving or being kicked from the folder.
-    :ivar sharing.FolderAction.share_link: Field is deprecated. Use
-        create_view_link and create_edit_link instead.
-    :ivar sharing.FolderAction.create_link: Field is deprecated. Use
-        create_view_link and create_edit_link instead.
-    :ivar sharing.FolderAction.create_view_link: Create a shared link that only
-        allows users to view the content.
-    :ivar sharing.FolderAction.create_edit_link: Create a shared link that
-        allows users to edit the content.
-    :ivar sharing.FolderAction.set_access_inheritance: Set whether the folder
-        inherits permissions from its parent.
+    :ivar FolderAction.share_link:
+        Field is deprecated. Use create_view_link and create_edit_link instead.
+    :ivar FolderAction.create_link:
+        Field is deprecated. Use create_view_link and create_edit_link instead.
+    :ivar FolderAction.create_view_link:
+        Create a shared link that only allows users to view the content.
+    :ivar FolderAction.create_edit_link:
+        Create a shared link that allows users to edit the content.
+    :ivar FolderAction.set_access_inheritance:
+        Set whether the folder inherits permissions from its parent.
     """
 
     _catch_all = 'other'
@@ -2943,13 +2996,13 @@ class FolderPermission(bb.Struct):
     """
     Whether the user is allowed to take the action on the shared folder.
 
-    :ivar sharing.FolderPermission.action: The action that the user may wish to
-        take on the folder.
-    :ivar sharing.FolderPermission.allow: True if the user is allowed to take
-        the action.
-    :ivar sharing.FolderPermission.reason: The reason why the user is denied the
-        permission. Not present if the action is allowed, or if no reason is
-        available.
+    :ivar FolderPermission.action:
+        The action that the user may wish to take on the folder.
+    :ivar FolderPermission.allow:
+        True if the user is allowed to take the action.
+    :ivar FolderPermission.reason:
+        The reason why the user is denied the permission. Not present if the
+        action is allowed, or if no reason is available.
     """
 
     __slots__ = [
@@ -2992,20 +3045,21 @@ class FolderPolicy(bb.Struct):
     """
     A set of policies governing membership and privileges for a shared folder.
 
-    :ivar sharing.FolderPolicy.member_policy: Who can be a member of this shared
-        folder, as set on the folder itself. The effective policy may differ
-        from this value if the team-wide policy is more restrictive. Present
-        only if the folder is owned by a team.
-    :ivar sharing.FolderPolicy.resolved_member_policy: Who can be a member of
-        this shared folder, taking into account both the folder and the
-        team-wide policy. This value may differ from that of member_policy if
-        the team-wide policy is more restrictive than the folder policy. Present
-        only if the folder is owned by a team.
-    :ivar sharing.FolderPolicy.acl_update_policy: Who can add and remove members
-        from this shared folder.
-    :ivar sharing.FolderPolicy.shared_link_policy: Who links can be shared with.
-    :ivar sharing.FolderPolicy.viewer_info_policy: Who can enable/disable viewer
-        info for this shared folder.
+    :ivar FolderPolicy.member_policy:
+        Who can be a member of this shared folder, as set on the folder itself.
+        The effective policy may differ from this value if the team-wide policy
+        is more restrictive. Present only if the folder is owned by a team.
+    :ivar FolderPolicy.resolved_member_policy:
+        Who can be a member of this shared folder, taking into account both the
+        folder and the team-wide policy. This value may differ from that of
+        member_policy if the team-wide policy is more restrictive than the
+        folder policy. Present only if the folder is owned by a team.
+    :ivar FolderPolicy.acl_update_policy:
+        Who can add and remove members from this shared folder.
+    :ivar FolderPolicy.shared_link_policy:
+        Who links can be shared with.
+    :ivar FolderPolicy.viewer_info_policy:
+        Who can enable/disable viewer info for this shared folder.
     """
 
     __slots__ = [
@@ -3065,11 +3119,12 @@ class GetFileMetadataArg(bb.Struct):
     Arguments of
     :meth:`dropbox.dropbox_client.Dropbox.sharing_get_file_metadata`.
 
-    :ivar sharing.GetFileMetadataArg.file: The file to query.
-    :ivar sharing.GetFileMetadataArg.actions: A list of `FileAction`s
-        corresponding to `FilePermission`s that should appear in the response's
-        ``SharedFileMetadata.permissions`` field describing the actions the
-        authenticated user can perform on the file.
+    :ivar GetFileMetadataArg.file:
+        The file to query.
+    :ivar GetFileMetadataArg.actions:
+        A list of `FileAction`s corresponding to `FilePermission`s that should
+        appear in the response's ``SharedFileMetadata.permissions`` field
+        describing the actions the authenticated user can perform on the file.
     """
 
     __slots__ = [
@@ -3105,11 +3160,12 @@ class GetFileMetadataBatchArg(bb.Struct):
     Arguments of
     :meth:`dropbox.dropbox_client.Dropbox.sharing_get_file_metadata_batch`.
 
-    :ivar sharing.GetFileMetadataBatchArg.files: The files to query.
-    :ivar sharing.GetFileMetadataBatchArg.actions: A list of `FileAction`s
-        corresponding to `FilePermission`s that should appear in the response's
-        ``SharedFileMetadata.permissions`` field describing the actions the
-        authenticated user can perform on the file.
+    :ivar GetFileMetadataBatchArg.files:
+        The files to query.
+    :ivar GetFileMetadataBatchArg.actions:
+        A list of `FileAction`s corresponding to `FilePermission`s that should
+        appear in the response's ``SharedFileMetadata.permissions`` field
+        describing the actions the authenticated user can perform on the file.
     """
 
     __slots__ = [
@@ -3145,10 +3201,11 @@ class GetFileMetadataBatchResult(bb.Struct):
     Per file results of
     :meth:`dropbox.dropbox_client.Dropbox.sharing_get_file_metadata_batch`.
 
-    :ivar sharing.GetFileMetadataBatchResult.file: This is the input file
-        identifier corresponding to one of ``GetFileMetadataBatchArg.files``.
-    :ivar sharing.GetFileMetadataBatchResult.result: The result for this
-        particular file.
+    :ivar GetFileMetadataBatchResult.file:
+        This is the input file identifier corresponding to one of
+        ``GetFileMetadataBatchArg.files``.
+    :ivar GetFileMetadataBatchResult.result:
+        The result for this particular file.
     """
 
     __slots__ = [
@@ -3270,10 +3327,12 @@ class GetFileMetadataIndividualResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedFileMetadata GetFileMetadataIndividualResult.metadata: The
-        result for this file if it was successful.
-    :ivar SharingFileAccessError GetFileMetadataIndividualResult.access_error:
+    :ivar GetFileMetadataIndividualResult.metadata:
+        The result for this file if it was successful.
+    :vartype GetFileMetadataIndividualResult.metadata: SharedFileMetadata
+    :ivar GetFileMetadataIndividualResult.access_error:
         The result for this file if it was an error.
+    :vartype GetFileMetadataIndividualResult.access_error: SharingFileAccessError
     """
 
     _catch_all = 'other'
@@ -3357,12 +3416,13 @@ GetFileMetadataIndividualResult_validator = bv.Union(GetFileMetadataIndividualRe
 
 class GetMetadataArgs(bb.Struct):
     """
-    :ivar sharing.GetMetadataArgs.shared_folder_id: The ID for the shared
+    :ivar GetMetadataArgs.shared_folder_id:
+        The ID for the shared folder.
+    :ivar GetMetadataArgs.actions:
+        A list of `FolderAction`s corresponding to `FolderPermission`s that
+        should appear in the response's ``SharedFolderMetadata.permissions``
+        field describing the actions the authenticated user can perform on the
         folder.
-    :ivar sharing.GetMetadataArgs.actions: A list of `FolderAction`s
-        corresponding to `FolderPermission`s that should appear in the
-        response's ``SharedFolderMetadata.permissions`` field describing the
-        actions the authenticated user can perform on the folder.
     """
 
     __slots__ = [
@@ -3399,15 +3459,16 @@ class SharedLinkError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedLinkError.shared_link_not_found: The shared link wasn't
-        found.
-    :ivar sharing.SharedLinkError.shared_link_access_denied: The caller is not
-        allowed to access this shared link.
-    :ivar sharing.SharedLinkError.unsupported_link_type: This type of link is
-        not supported; use :meth:`dropbox.dropbox_client.Dropbox.sharing_files`
-        instead.
-    :ivar sharing.SharedLinkError.unsupported_parameter_field: Private shared
-        links do not support `path` or `link_password` parameter fields.
+    :ivar SharedLinkError.shared_link_not_found:
+        The shared link wasn't found.
+    :ivar SharedLinkError.shared_link_access_denied:
+        The caller is not allowed to access this shared link.
+    :ivar SharedLinkError.unsupported_link_type:
+        This type of link is not supported; use
+        :meth:`dropbox.dropbox_client.Dropbox.sharing_files` instead.
+    :ivar SharedLinkError.unsupported_parameter_field:
+        Private shared links do not support `path` or `link_password` parameter
+        fields.
     """
 
     _catch_all = 'other'
@@ -3473,8 +3534,8 @@ class GetSharedLinkFileError(SharedLinkError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.GetSharedLinkFileError.shared_link_is_directory: Directories
-        cannot be retrieved by this endpoint.
+    :ivar GetSharedLinkFileError.shared_link_is_directory:
+        Directories cannot be retrieved by this endpoint.
     """
 
     # Attribute is overwritten below the class definition
@@ -3495,13 +3556,14 @@ GetSharedLinkFileError_validator = bv.Union(GetSharedLinkFileError)
 
 class GetSharedLinkMetadataArg(bb.Struct):
     """
-    :ivar sharing.GetSharedLinkMetadataArg.url: URL of the shared link.
-    :ivar sharing.GetSharedLinkMetadataArg.path: If the shared link is to a
-        folder, this parameter can be used to retrieve the metadata for a
-        specific file or sub-folder in this folder. A relative path should be
-        used.
-    :ivar sharing.GetSharedLinkMetadataArg.link_password: If the shared link has
-        a password, this parameter can be used.
+    :ivar GetSharedLinkMetadataArg.url:
+        URL of the shared link.
+    :ivar GetSharedLinkMetadataArg.path:
+        If the shared link is to a folder, this parameter can be used to
+        retrieve the metadata for a specific file or sub-folder in this folder.
+        A relative path should be used.
+    :ivar GetSharedLinkMetadataArg.link_password:
+        If the shared link has a password, this parameter can be used.
     """
 
     __slots__ = [
@@ -3542,8 +3604,8 @@ GetSharedLinkMetadataArg_validator = bv.Struct(GetSharedLinkMetadataArg)
 
 class GetSharedLinksArg(bb.Struct):
     """
-    :ivar sharing.GetSharedLinksArg.path: See
-        :meth:`dropbox.dropbox_client.Dropbox.sharing_get_shared_links`
+    :ivar GetSharedLinksArg.path:
+        See :meth:`dropbox.dropbox_client.Dropbox.sharing_get_shared_links`
         description.
     """
 
@@ -3622,8 +3684,8 @@ GetSharedLinksError_validator = bv.Union(GetSharedLinksError)
 
 class GetSharedLinksResult(bb.Struct):
     """
-    :ivar sharing.GetSharedLinksResult.links: Shared links applicable to the
-        path argument.
+    :ivar GetSharedLinksResult.links:
+        Shared links applicable to the path argument.
     """
 
     __slots__ = [
@@ -3651,13 +3713,14 @@ class GroupInfo(team_common.GroupSummary):
     The information about a group. Groups is a way to manage a list of users who
     need same access permission to the shared folder.
 
-    :ivar sharing.GroupInfo.group_type: Field is deprecated. The type of group.
-    :ivar sharing.GroupInfo.is_member: If the current user is a member of the
-        group.
-    :ivar sharing.GroupInfo.is_owner: If the current user is an owner of the
-        group.
-    :ivar sharing.GroupInfo.same_team: If the group is owned by the current
-        user's team.
+    :ivar GroupInfo.group_type:
+        Field is deprecated. The type of group.
+    :ivar GroupInfo.is_member:
+        If the current user is a member of the group.
+    :ivar GroupInfo.is_owner:
+        If the current user is an owner of the group.
+    :ivar GroupInfo.same_team:
+        If the group is owned by the current user's team.
     """
 
     __slots__ = [
@@ -3718,15 +3781,16 @@ class MembershipInfo(bb.Struct):
     """
     The information about a member of the shared content.
 
-    :ivar sharing.MembershipInfo.access_type: The access type for this member.
-        It contains inherited access type from parent folder, and acquired
-        access type from this folder.
-    :ivar sharing.MembershipInfo.permissions: The permissions that requesting
-        user has on this member. The set of permissions corresponds to the
-        MemberActions in the request.
-    :ivar sharing.MembershipInfo.initials: Field is deprecated. Never set.
-    :ivar sharing.MembershipInfo.is_inherited: True if the member has access on
-        a parent folder.
+    :ivar MembershipInfo.access_type:
+        The access type for this member. It contains inherited access type from
+        parent folder, and acquired access type from this folder.
+    :ivar MembershipInfo.permissions:
+        The permissions that requesting user has on this member. The set of
+        permissions corresponds to the MemberActions in the request.
+    :ivar MembershipInfo.initials:
+        Field is deprecated. Never set.
+    :ivar MembershipInfo.is_inherited:
+        True if the member has access on a parent folder.
     """
 
     __slots__ = [
@@ -3777,8 +3841,8 @@ class GroupMembershipInfo(MembershipInfo):
     """
     The information about a group member of the shared content.
 
-    :ivar sharing.GroupMembershipInfo.group: The information about the
-        membership group.
+    :ivar GroupMembershipInfo.group:
+        The information about the membership group.
     """
 
     __slots__ = [
@@ -3811,11 +3875,13 @@ GroupMembershipInfo_validator = bv.Struct(GroupMembershipInfo)
 
 class InsufficientPlan(bb.Struct):
     """
-    :ivar sharing.InsufficientPlan.message: A message to tell the user to
-        upgrade in order to support expected action.
-    :ivar sharing.InsufficientPlan.upsell_url: A URL to send the user to in
-        order to obtain the account type they need, e.g. upgrading. Absent if
-        there is no action the user can take to upgrade.
+    :ivar InsufficientPlan.message:
+        A message to tell the user to upgrade in order to support expected
+        action.
+    :ivar InsufficientPlan.upsell_url:
+        A URL to send the user to in order to obtain the account type they need,
+        e.g. upgrading. Absent if there is no action the user can take to
+        upgrade.
     """
 
     __slots__ = [
@@ -3848,12 +3914,12 @@ InsufficientPlan_validator = bv.Struct(InsufficientPlan)
 
 class InsufficientQuotaAmounts(bb.Struct):
     """
-    :ivar sharing.InsufficientQuotaAmounts.space_needed: The amount of space
-        needed to add the item (the size of the item).
-    :ivar sharing.InsufficientQuotaAmounts.space_shortage: The amount of extra
-        space needed to add the item.
-    :ivar sharing.InsufficientQuotaAmounts.space_left: The amount of space left
-        in the user's Dropbox, less than space_needed.
+    :ivar InsufficientQuotaAmounts.space_needed:
+        The amount of space needed to add the item (the size of the item).
+    :ivar InsufficientQuotaAmounts.space_shortage:
+        The amount of extra space needed to add the item.
+    :ivar InsufficientQuotaAmounts.space_left:
+        The amount of space left in the user's Dropbox, less than space_needed.
     """
 
     __slots__ = [
@@ -3900,7 +3966,9 @@ class InviteeInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str sharing.InviteeInfo.email: Email address of invited user.
+    :ivar InviteeInfo.email:
+        Email address of invited user.
+    :vartype InviteeInfo.email: str
     """
 
     _catch_all = 'other'
@@ -3955,9 +4023,10 @@ class InviteeMembershipInfo(MembershipInfo):
     """
     Information about an invited member of a shared content.
 
-    :ivar sharing.InviteeMembershipInfo.invitee: Recipient of the invitation.
-    :ivar sharing.InviteeMembershipInfo.user: The user this invitation is tied
-        to, if available.
+    :ivar InviteeMembershipInfo.invitee:
+        Recipient of the invitation.
+    :ivar InviteeMembershipInfo.user:
+        The user this invitation is tied to, if available.
     """
 
     __slots__ = [
@@ -4006,18 +4075,20 @@ class JobError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UnshareFolderError JobError.unshare_folder_error: Error occurred while
-        performing :meth:`dropbox.dropbox_client.Dropbox.sharing_unshare_folder`
-        action.
-    :ivar RemoveFolderMemberError JobError.remove_folder_member_error: Error
-        occurred while performing
+    :ivar JobError.unshare_folder_error:
+        Error occurred while performing
+        :meth:`dropbox.dropbox_client.Dropbox.sharing_unshare_folder` action.
+    :vartype JobError.unshare_folder_error: UnshareFolderError
+    :ivar JobError.remove_folder_member_error:
+        Error occurred while performing
         :meth:`dropbox.dropbox_client.Dropbox.sharing_remove_folder_member`
         action.
-    :ivar RelinquishFolderMembershipError
-        JobError.relinquish_folder_membership_error: Error occurred while
-        performing
+    :vartype JobError.remove_folder_member_error: RemoveFolderMemberError
+    :ivar JobError.relinquish_folder_membership_error:
+        Error occurred while performing
         :meth:`dropbox.dropbox_client.Dropbox.sharing_relinquish_folder_membership`
         action.
+    :vartype JobError.relinquish_folder_membership_error: RelinquishFolderMembershipError
     """
 
     _catch_all = 'other'
@@ -4141,8 +4212,11 @@ class JobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.JobStatus.complete: The asynchronous job has finished.
-    :ivar JobError JobStatus.failed: The asynchronous job returned an error.
+    :ivar JobStatus.complete:
+        The asynchronous job has finished.
+    :ivar JobStatus.failed:
+        The asynchronous job returned an error.
+    :vartype JobStatus.failed: JobError
     """
 
     # Attribute is overwritten below the class definition
@@ -4198,10 +4272,10 @@ class LinkAccessLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.LinkAccessLevel.viewer: Users who use the link can view and
-        comment on the content.
-    :ivar sharing.LinkAccessLevel.editor: Users who use the link can edit, view
-        and comment on the content.
+    :ivar LinkAccessLevel.viewer:
+        Users who use the link can view and comment on the content.
+    :ivar LinkAccessLevel.editor:
+        Users who use the link can edit, view and comment on the content.
     """
 
     _catch_all = 'other'
@@ -4249,15 +4323,18 @@ class LinkAction(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.LinkAction.change_access_level: Change the access level of the
-        link.
-    :ivar sharing.LinkAction.change_audience: Change the audience of the link.
-    :ivar sharing.LinkAction.remove_expiry: Remove the expiry date of the link.
-    :ivar sharing.LinkAction.remove_password: Remove the password of the link.
-    :ivar sharing.LinkAction.set_expiry: Create or modify the expiry date of the
-        link.
-    :ivar sharing.LinkAction.set_password: Create or modify the password of the
-        link.
+    :ivar LinkAction.change_access_level:
+        Change the access level of the link.
+    :ivar LinkAction.change_audience:
+        Change the audience of the link.
+    :ivar LinkAction.remove_expiry:
+        Remove the expiry date of the link.
+    :ivar LinkAction.remove_password:
+        Remove the password of the link.
+    :ivar LinkAction.set_expiry:
+        Create or modify the expiry date of the link.
+    :ivar LinkAction.set_password:
+        Create or modify the password of the link.
     """
 
     _catch_all = 'other'
@@ -4343,17 +4420,20 @@ class LinkAudience(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.LinkAudience.public: Link is accessible by anyone.
-    :ivar sharing.LinkAudience.team: Link is accessible only by team members.
-    :ivar sharing.LinkAudience.no_one: The link can be used by no one. The link
-        merely points the user to the content, and does not grant additional
-        rights to the user. Members of the content who use this link can only
-        access the content with their pre-existing access rights.
-    :ivar sharing.LinkAudience.password: Field is deprecated. Use
-        `require_password` instead. A link-specific password is required to
-        access the link. Login is not required.
-    :ivar sharing.LinkAudience.members: Field is deprecated. Link is accessible
-        only by members of the content.
+    :ivar LinkAudience.public:
+        Link is accessible by anyone.
+    :ivar LinkAudience.team:
+        Link is accessible only by team members.
+    :ivar LinkAudience.no_one:
+        The link can be used by no one. The link merely points the user to the
+        content, and does not grant additional rights to the user. Members of
+        the content who use this link can only access the content with their
+        pre-existing access rights.
+    :ivar LinkAudience.password:
+        Field is deprecated. Use `require_password` instead. A link-specific
+        password is required to access the link. Login is not required.
+    :ivar LinkAudience.members:
+        Field is deprecated. Link is accessible only by members of the content.
     """
 
     _catch_all = 'other'
@@ -4429,20 +4509,21 @@ class VisibilityPolicyDisallowedReason(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.VisibilityPolicyDisallowedReason.delete_and_recreate: The user
-        needs to delete and recreate the link to change the visibility policy.
-    :ivar sharing.VisibilityPolicyDisallowedReason.restricted_by_shared_folder:
+    :ivar VisibilityPolicyDisallowedReason.delete_and_recreate:
+        The user needs to delete and recreate the link to change the visibility
+        policy.
+    :ivar VisibilityPolicyDisallowedReason.restricted_by_shared_folder:
         The parent shared folder restricts sharing of links outside the shared
         folder. To change the visibility policy, remove the restriction from the
         parent shared folder.
-    :ivar sharing.VisibilityPolicyDisallowedReason.restricted_by_team: The team
-        policy prevents links being shared outside the team.
-    :ivar sharing.VisibilityPolicyDisallowedReason.user_not_on_team: The user
-        needs to be on a team to set this policy.
-    :ivar sharing.VisibilityPolicyDisallowedReason.user_account_type: The user
-        is a basic user or is on a limited team.
-    :ivar sharing.VisibilityPolicyDisallowedReason.permission_denied: The user
-        does not have permission.
+    :ivar VisibilityPolicyDisallowedReason.restricted_by_team:
+        The team policy prevents links being shared outside the team.
+    :ivar VisibilityPolicyDisallowedReason.user_not_on_team:
+        The user needs to be on a team to set this policy.
+    :ivar VisibilityPolicyDisallowedReason.user_account_type:
+        The user is a basic user or is on a limited team.
+    :ivar VisibilityPolicyDisallowedReason.permission_denied:
+        The user does not have permission.
     """
 
     _catch_all = 'other'
@@ -4538,13 +4619,13 @@ LinkAudienceDisallowedReason_validator = bv.Union(LinkAudienceDisallowedReason)
 
 class LinkAudienceOption(bb.Struct):
     """
-    :ivar sharing.LinkAudienceOption.audience: Specifies who can access the
-        link.
-    :ivar sharing.LinkAudienceOption.allowed: Whether the user calling this API
-        can select this audience option.
-    :ivar sharing.LinkAudienceOption.disallowed_reason: If ``allowed`` is
-        ``False``, this will provide the reason that the user is not permitted
-        to set the visibility to this policy.
+    :ivar LinkAudienceOption.audience:
+        Specifies who can access the link.
+    :ivar LinkAudienceOption.allowed:
+        Whether the user calling this API can select this audience option.
+    :ivar LinkAudienceOption.disallowed_reason:
+        If ``allowed`` is ``False``, this will provide the reason that the user
+        is not permitted to set the visibility to this policy.
     """
 
     __slots__ = [
@@ -4589,10 +4670,11 @@ class LinkExpiry(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.LinkExpiry.remove_expiry: Remove the currently set expiry for
-        the link.
-    :ivar datetime.datetime sharing.LinkExpiry.set_expiry: Set a new expiry or
-        change an existing expiry.
+    :ivar LinkExpiry.remove_expiry:
+        Remove the currently set expiry for the link.
+    :ivar LinkExpiry.set_expiry:
+        Set a new expiry or change an existing expiry.
+    :vartype LinkExpiry.set_expiry: datetime.datetime
     """
 
     _catch_all = 'other'
@@ -4659,10 +4741,11 @@ class LinkPassword(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.LinkPassword.remove_password: Remove the currently set
-        password for the link.
-    :ivar str sharing.LinkPassword.set_password: Set a new password or change an
-        existing password.
+    :ivar LinkPassword.remove_password:
+        Remove the currently set password for the link.
+    :ivar LinkPassword.set_password:
+        Set a new password or change an existing password.
+    :vartype LinkPassword.set_password: str
     """
 
     _catch_all = 'other'
@@ -4766,78 +4849,81 @@ LinkPermission_validator = bv.Struct(LinkPermission)
 
 class LinkPermissions(bb.Struct):
     """
-    :ivar sharing.LinkPermissions.resolved_visibility: The current visibility of
-        the link after considering the shared links policies of the the team (in
-        case the link's owner is part of a team) and the shared folder (in case
-        the linked file is part of a shared folder). This field is shown only if
-        the caller has access to this info (the link's owner always has access
-        to this data). For some links, an effective_audience value is returned
-        instead.
-    :ivar sharing.LinkPermissions.requested_visibility: The shared link's
-        requested visibility. This can be overridden by the team and shared
-        folder policies. The final visibility, after considering these policies,
-        can be found in ``resolved_visibility``. This is shown only if the
-        caller is the link's owner and resolved_visibility is returned instead
-        of effective_audience.
-    :ivar sharing.LinkPermissions.can_revoke: Whether the caller can revoke the
-        shared link.
-    :ivar sharing.LinkPermissions.revoke_failure_reason: The failure reason for
-        revoking the link. This field will only be present if the ``can_revoke``
-        is ``False``.
-    :ivar sharing.LinkPermissions.effective_audience: The type of audience who
-        can benefit from the access level specified by the `link_access_level`
-        field.
-    :ivar sharing.LinkPermissions.link_access_level: The access level that the
-        link will grant to its users. A link can grant additional rights to a
-        user beyond their current access level. For example, if a user was
-        invited as a viewer to a file, and then opens a link with
-        `link_access_level` set to `editor`, then they will gain editor
-        privileges. The `link_access_level` is a property of the link, and does
-        not depend on who is calling this API. In particular,
+    :ivar LinkPermissions.resolved_visibility:
+        The current visibility of the link after considering the shared links
+        policies of the the team (in case the link's owner is part of a team)
+        and the shared folder (in case the linked file is part of a shared
+        folder). This field is shown only if the caller has access to this info
+        (the link's owner always has access to this data). For some links, an
+        effective_audience value is returned instead.
+    :ivar LinkPermissions.requested_visibility:
+        The shared link's requested visibility. This can be overridden by the
+        team and shared folder policies. The final visibility, after considering
+        these policies, can be found in ``resolved_visibility``. This is shown
+        only if the caller is the link's owner and resolved_visibility is
+        returned instead of effective_audience.
+    :ivar LinkPermissions.can_revoke:
+        Whether the caller can revoke the shared link.
+    :ivar LinkPermissions.revoke_failure_reason:
+        The failure reason for revoking the link. This field will only be
+        present if the ``can_revoke`` is ``False``.
+    :ivar LinkPermissions.effective_audience:
+        The type of audience who can benefit from the access level specified by
+        the `link_access_level` field.
+    :ivar LinkPermissions.link_access_level:
+        The access level that the link will grant to its users. A link can grant
+        additional rights to a user beyond their current access level. For
+        example, if a user was invited as a viewer to a file, and then opens a
+        link with `link_access_level` set to `editor`, then they will gain
+        editor privileges. The `link_access_level` is a property of the link,
+        and does not depend on who is calling this API. In particular,
         `link_access_level` does not take into account the API caller's current
         permissions to the content.
-    :ivar sharing.LinkPermissions.visibility_policies: A list of policies that
-        the user might be able to set for the visibility.
-    :ivar sharing.LinkPermissions.can_set_expiry: Whether the user can set the
-        expiry settings of the link. This refers to the ability to create a new
-        expiry and modify an existing expiry.
-    :ivar sharing.LinkPermissions.can_remove_expiry: Whether the user can remove
-        the expiry of the link.
-    :ivar sharing.LinkPermissions.allow_download: Whether the link can be
-        downloaded or not.
-    :ivar sharing.LinkPermissions.can_allow_download: Whether the user can allow
-        downloads via the link. This refers to the ability to remove a
-        no-download restriction on the link.
-    :ivar sharing.LinkPermissions.can_disallow_download: Whether the user can
-        disallow downloads via the link. This refers to the ability to impose a
-        no-download restriction on the link.
-    :ivar sharing.LinkPermissions.allow_comments: Field is deprecated. Whether
-        comments are enabled for the linked file. This takes the team commenting
-        policy into account.
-    :ivar sharing.LinkPermissions.team_restricts_comments: Field is deprecated.
-        Whether the team has disabled commenting globally.
-    :ivar sharing.LinkPermissions.audience_options: A list of link audience
-        options the user might be able to set as the new audience.
-    :ivar sharing.LinkPermissions.can_set_password: Whether the user can set a
-        password for the link.
-    :ivar sharing.LinkPermissions.can_remove_password: Whether the user can
-        remove the password of the link.
-    :ivar sharing.LinkPermissions.require_password: Whether the user is required
-        to provide a password to view the link.
-    :ivar sharing.LinkPermissions.can_use_extended_sharing_controls: Whether the
-        user can use extended sharing controls, based on their account type.
-    :ivar sharing.LinkPermissions.can_sync: Whether a user can save the content
-        to their Dropbox account.
-    :ivar sharing.LinkPermissions.can_request_access: Whether the user can
-        request access to the content.
-    :ivar sharing.LinkPermissions.enforce_shared_link_password_policy: Whether
-        the updated externally available shared link must have password set. Not
-        provided if the link is not team owned.
-    :ivar sharing.LinkPermissions.days_to_expire_policy: Existing owning team's
-        policy for default number of days from today to link's expiration. Not
-        provided if the link is not team owned.
-    :ivar sharing.LinkPermissions.change_shared_link_expiration_policy: When
-        owning team's policy ``change_shared_link_expiration_policy`` is
+    :ivar LinkPermissions.visibility_policies:
+        A list of policies that the user might be able to set for the
+        visibility.
+    :ivar LinkPermissions.can_set_expiry:
+        Whether the user can set the expiry settings of the link. This refers to
+        the ability to create a new expiry and modify an existing expiry.
+    :ivar LinkPermissions.can_remove_expiry:
+        Whether the user can remove the expiry of the link.
+    :ivar LinkPermissions.allow_download:
+        Whether the link can be downloaded or not.
+    :ivar LinkPermissions.can_allow_download:
+        Whether the user can allow downloads via the link. This refers to the
+        ability to remove a no-download restriction on the link.
+    :ivar LinkPermissions.can_disallow_download:
+        Whether the user can disallow downloads via the link. This refers to the
+        ability to impose a no-download restriction on the link.
+    :ivar LinkPermissions.allow_comments:
+        Field is deprecated. Whether comments are enabled for the linked file.
+        This takes the team commenting policy into account.
+    :ivar LinkPermissions.team_restricts_comments:
+        Field is deprecated. Whether the team has disabled commenting globally.
+    :ivar LinkPermissions.audience_options:
+        A list of link audience options the user might be able to set as the new
+        audience.
+    :ivar LinkPermissions.can_set_password:
+        Whether the user can set a password for the link.
+    :ivar LinkPermissions.can_remove_password:
+        Whether the user can remove the password of the link.
+    :ivar LinkPermissions.require_password:
+        Whether the user is required to provide a password to view the link.
+    :ivar LinkPermissions.can_use_extended_sharing_controls:
+        Whether the user can use extended sharing controls, based on their
+        account type.
+    :ivar LinkPermissions.can_sync:
+        Whether a user can save the content to their Dropbox account.
+    :ivar LinkPermissions.can_request_access:
+        Whether the user can request access to the content.
+    :ivar LinkPermissions.enforce_shared_link_password_policy:
+        Whether the updated externally available shared link must have password
+        set. Not provided if the link is not team owned.
+    :ivar LinkPermissions.days_to_expire_policy:
+        Existing owning team's policy for default number of days from today to
+        link's expiration. Not provided if the link is not team owned.
+    :ivar LinkPermissions.change_shared_link_expiration_policy:
+        When owning team's policy ``change_shared_link_expiration_policy`` is
         ``ChangeLinkExpirationPolicy.not_allowed``, the updated externally
         available shared link expiration value cannot be less strict than
         ``days_to_expire_policy``. In this case ``days_to_expire_policy`` is
@@ -5053,12 +5139,15 @@ class LinkSettings(bb.Struct):
     """
     Settings that apply to a link.
 
-    :ivar sharing.LinkSettings.access_level: The access level on the link for
-        this file. Currently, it only accepts 'viewer' and 'viewer_no_comment'.
-    :ivar sharing.LinkSettings.audience: The type of audience on the link for
-        this file.
-    :ivar sharing.LinkSettings.expiry: An expiry timestamp to set on a link.
-    :ivar sharing.LinkSettings.password: The password for the link.
+    :ivar LinkSettings.access_level:
+        The access level on the link for this file. Currently, it only accepts
+        'viewer' and 'viewer_no_comment'.
+    :ivar LinkSettings.audience:
+        The type of audience on the link for this file.
+    :ivar LinkSettings.expiry:
+        An expiry timestamp to set on a link.
+    :ivar LinkSettings.password:
+        The password for the link.
     """
 
     __slots__ = [
@@ -5110,14 +5199,16 @@ class ListFileMembersArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members`.
 
-    :ivar sharing.ListFileMembersArg.file: The file for which you want to see
-        members.
-    :ivar sharing.ListFileMembersArg.actions: The actions for which to return
-        permissions on a member.
-    :ivar sharing.ListFileMembersArg.include_inherited: Whether to include
-        members who only have access from a parent shared folder.
-    :ivar sharing.ListFileMembersArg.limit: Number of members to return max per
-        query. Defaults to 100 if no limit is specified.
+    :ivar ListFileMembersArg.file:
+        The file for which you want to see members.
+    :ivar ListFileMembersArg.actions:
+        The actions for which to return permissions on a member.
+    :ivar ListFileMembersArg.include_inherited:
+        Whether to include members who only have access from a parent shared
+        folder.
+    :ivar ListFileMembersArg.limit:
+        Number of members to return max per query. Defaults to 100 if no limit
+        is specified.
     """
 
     __slots__ = [
@@ -5169,10 +5260,11 @@ class ListFileMembersBatchArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_batch`.
 
-    :ivar sharing.ListFileMembersBatchArg.files: Files for which to return
-        members.
-    :ivar sharing.ListFileMembersBatchArg.limit: Number of members to return max
-        per query. Defaults to 1000 if no limit is specified.
+    :ivar ListFileMembersBatchArg.files:
+        Files for which to return members.
+    :ivar ListFileMembersBatchArg.limit:
+        Number of members to return max per query. Defaults to 1000 if no limit
+        is specified.
     """
 
     __slots__ = [
@@ -5208,10 +5300,10 @@ class ListFileMembersBatchResult(bb.Struct):
     Per-file result for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_batch`.
 
-    :ivar sharing.ListFileMembersBatchResult.file: This is the input file
-        identifier, whether an ID or a path.
-    :ivar sharing.ListFileMembersBatchResult.result: The result for this
-        particular file.
+    :ivar ListFileMembersBatchResult.file:
+        This is the input file identifier, whether an ID or a path.
+    :ivar ListFileMembersBatchResult.result:
+        The result for this particular file.
     """
 
     __slots__ = [
@@ -5247,8 +5339,8 @@ class ListFileMembersContinueArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_continue`.
 
-    :ivar sharing.ListFileMembersContinueArg.cursor: The cursor returned by your
-        last call to
+    :ivar ListFileMembersContinueArg.cursor:
+        The cursor returned by your last call to
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members`,
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_continue`,
         or
@@ -5284,7 +5376,7 @@ class ListFileMembersContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ListFileMembersContinueError.invalid_cursor:
+    :ivar ListFileMembersContinueError.invalid_cursor:
         ``ListFileMembersContinueArg.cursor`` is invalid.
     """
 
@@ -5375,10 +5467,11 @@ ListFileMembersContinueError_validator = bv.Union(ListFileMembersContinueError)
 
 class ListFileMembersCountResult(bb.Struct):
     """
-    :ivar sharing.ListFileMembersCountResult.members: A list of members on this
-        file.
-    :ivar sharing.ListFileMembersCountResult.member_count: The number of members
-        on this file. This does not include inherited members.
+    :ivar ListFileMembersCountResult.members:
+        A list of members on this file.
+    :ivar ListFileMembersCountResult.member_count:
+        The number of members on this file. This does not include inherited
+        members.
     """
 
     __slots__ = [
@@ -5499,10 +5592,12 @@ class ListFileMembersIndividualResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar ListFileMembersCountResult ListFileMembersIndividualResult.result: The
-        results of the query for this file if it was successful.
-    :ivar SharingFileAccessError ListFileMembersIndividualResult.access_error:
+    :ivar ListFileMembersIndividualResult.result:
+        The results of the query for this file if it was successful.
+    :vartype ListFileMembersIndividualResult.result: ListFileMembersCountResult
+    :ivar ListFileMembersIndividualResult.access_error:
         The result of the query for this file if it was an error.
+    :vartype ListFileMembersIndividualResult.access_error: SharingFileAccessError
     """
 
     _catch_all = 'other'
@@ -5589,12 +5684,13 @@ class ListFilesArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_received_files`.
 
-    :ivar sharing.ListFilesArg.limit: Number of files to return max per query.
-        Defaults to 100 if no limit is specified.
-    :ivar sharing.ListFilesArg.actions: A list of `FileAction`s corresponding to
-        `FilePermission`s that should appear in the response's
-        ``SharedFileMetadata.permissions`` field describing the actions the
-        authenticated user can perform on the file.
+    :ivar ListFilesArg.limit:
+        Number of files to return max per query. Defaults to 100 if no limit is
+        specified.
+    :ivar ListFilesArg.actions:
+        A list of `FileAction`s corresponding to `FilePermission`s that should
+        appear in the response's ``SharedFileMetadata.permissions`` field
+        describing the actions the authenticated user can perform on the file.
     """
 
     __slots__ = [
@@ -5630,8 +5726,8 @@ class ListFilesContinueArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_received_files_continue`.
 
-    :ivar sharing.ListFilesContinueArg.cursor: Cursor in
-        ``ListFilesResult.cursor``.
+    :ivar ListFilesContinueArg.cursor:
+        Cursor in ``ListFilesResult.cursor``.
     """
 
     __slots__ = [
@@ -5663,9 +5759,10 @@ class ListFilesContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharingUserError ListFilesContinueError.user_error: User account had a
-        problem.
-    :ivar sharing.ListFilesContinueError.invalid_cursor:
+    :ivar ListFilesContinueError.user_error:
+        User account had a problem.
+    :vartype ListFilesContinueError.user_error: SharingUserError
+    :ivar ListFilesContinueError.invalid_cursor:
         ``ListFilesContinueArg.cursor`` is invalid.
     """
 
@@ -5732,10 +5829,10 @@ class ListFilesResult(bb.Struct):
     Success results for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_received_files`.
 
-    :ivar sharing.ListFilesResult.entries: Information about the files shared
-        with current user.
-    :ivar sharing.ListFilesResult.cursor: Cursor used to obtain additional
-        shared files.
+    :ivar ListFilesResult.entries:
+        Information about the files shared with current user.
+    :ivar ListFilesResult.cursor:
+        Cursor used to obtain additional shared files.
     """
 
     __slots__ = [
@@ -5768,12 +5865,13 @@ ListFilesResult_validator = bv.Struct(ListFilesResult)
 
 class ListFolderMembersCursorArg(bb.Struct):
     """
-    :ivar sharing.ListFolderMembersCursorArg.actions: This is a list indicating
-        whether each returned member will include a boolean value
-        ``MemberPermission.allow`` that describes whether the current user can
-        perform the MemberAction on the member.
-    :ivar sharing.ListFolderMembersCursorArg.limit: The maximum number of
-        results that include members, groups and invitees to return per request.
+    :ivar ListFolderMembersCursorArg.actions:
+        This is a list indicating whether each returned member will include a
+        boolean value ``MemberPermission.allow`` that describes whether the
+        current user can perform the MemberAction on the member.
+    :ivar ListFolderMembersCursorArg.limit:
+        The maximum number of results that include members, groups and invitees
+        to return per request.
     """
 
     __slots__ = [
@@ -5806,13 +5904,14 @@ ListFolderMembersCursorArg_validator = bv.Struct(ListFolderMembersCursorArg)
 
 class ListFolderMembersArgs(ListFolderMembersCursorArg):
     """
-    :ivar sharing.ListFolderMembersArgs.shared_folder_id: The ID for the shared
-        folder. When path is provided, the folder ID will be extracted from the
-        path instead.
-    :ivar sharing.ListFolderMembersArgs.path: Optional path to get inherited
-        members. When omitted, uses shared_folder_id to return direct members.
-        When provided, extracts folder ID from this path and returns users who
-        have access through parent shared folder.
+    :ivar ListFolderMembersArgs.shared_folder_id:
+        The ID for the shared folder. When path is provided, the folder ID will
+        be extracted from the path instead.
+    :ivar ListFolderMembersArgs.path:
+        Optional path to get inherited members. When omitted, uses
+        shared_folder_id to return direct members. When provided, extracts
+        folder ID from this path and returns users who have access through
+        parent shared folder.
     """
 
     __slots__ = [
@@ -5849,8 +5948,8 @@ ListFolderMembersArgs_validator = bv.Struct(ListFolderMembersArgs)
 
 class ListFolderMembersContinueArg(bb.Struct):
     """
-    :ivar sharing.ListFolderMembersContinueArg.cursor: The cursor returned by
-        your last call to
+    :ivar ListFolderMembersContinueArg.cursor:
+        The cursor returned by your last call to
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_folder_members` or
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_folder_members_continue`.
     """
@@ -5881,7 +5980,7 @@ class ListFolderMembersContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ListFolderMembersContinueError.invalid_cursor:
+    :ivar ListFolderMembersContinueError.invalid_cursor:
         ``ListFolderMembersContinueArg.cursor`` is invalid.
     """
 
@@ -5943,12 +6042,13 @@ ListFolderMembersContinueError_validator = bv.Union(ListFolderMembersContinueErr
 
 class ListFoldersArgs(bb.Struct):
     """
-    :ivar sharing.ListFoldersArgs.limit: The maximum number of results to return
-        per request.
-    :ivar sharing.ListFoldersArgs.actions: A list of `FolderAction`s
-        corresponding to `FolderPermission`s that should appear in the
-        response's ``SharedFolderMetadata.permissions`` field describing the
-        actions the authenticated user can perform on the folder.
+    :ivar ListFoldersArgs.limit:
+        The maximum number of results to return per request.
+    :ivar ListFoldersArgs.actions:
+        A list of `FolderAction`s corresponding to `FolderPermission`s that
+        should appear in the response's ``SharedFolderMetadata.permissions``
+        field describing the actions the authenticated user can perform on the
+        folder.
     """
 
     __slots__ = [
@@ -5981,8 +6081,9 @@ ListFoldersArgs_validator = bv.Struct(ListFoldersArgs)
 
 class ListFoldersContinueArg(bb.Struct):
     """
-    :ivar sharing.ListFoldersContinueArg.cursor: The cursor returned by the
-        previous API call specified in the endpoint description.
+    :ivar ListFoldersContinueArg.cursor:
+        The cursor returned by the previous API call specified in the endpoint
+        description.
     """
 
     __slots__ = [
@@ -6011,7 +6112,7 @@ class ListFoldersContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ListFoldersContinueError.invalid_cursor:
+    :ivar ListFoldersContinueError.invalid_cursor:
         ``ListFoldersContinueArg.cursor`` is invalid.
     """
 
@@ -6049,11 +6150,12 @@ class ListFoldersResult(bb.Struct):
     depending on which endpoint was requested. Unmounted shared folders can be
     identified by the absence of ``SharedFolderMetadata.path_lower``.
 
-    :ivar sharing.ListFoldersResult.entries: List of all shared folders the
-        authenticated user has access to.
-    :ivar sharing.ListFoldersResult.cursor: Present if there are additional
-        shared folders that have not been returned yet. Pass the cursor into the
-        corresponding continue endpoint (either
+    :ivar ListFoldersResult.entries:
+        List of all shared folders the authenticated user has access to.
+    :ivar ListFoldersResult.cursor:
+        Present if there are additional shared folders that have not been
+        returned yet. Pass the cursor into the corresponding continue endpoint
+        (either
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_folders_continue` or
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_mountable_folders_continue`)
         to list additional folders.
@@ -6089,14 +6191,14 @@ ListFoldersResult_validator = bv.Struct(ListFoldersResult)
 
 class ListSharedLinksArg(bb.Struct):
     """
-    :ivar sharing.ListSharedLinksArg.path: See
-        :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links`
+    :ivar ListSharedLinksArg.path:
+        See :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links`
         description.
-    :ivar sharing.ListSharedLinksArg.cursor: The cursor returned by your last
-        call to
+    :ivar ListSharedLinksArg.cursor:
+        The cursor returned by your last call to
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links`.
-    :ivar sharing.ListSharedLinksArg.direct_only: See
-        :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links`
+    :ivar ListSharedLinksArg.direct_only:
+        See :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links`
         description.
     """
 
@@ -6142,8 +6244,8 @@ class ListSharedLinksError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ListSharedLinksError.reset: Indicates that the cursor has been
-        invalidated. Call
+    :ivar ListSharedLinksError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links` to
         obtain a new cursor.
     """
@@ -6206,13 +6308,15 @@ ListSharedLinksError_validator = bv.Union(ListSharedLinksError)
 
 class ListSharedLinksResult(bb.Struct):
     """
-    :ivar sharing.ListSharedLinksResult.links: Shared links applicable to the
-        path argument.
-    :ivar sharing.ListSharedLinksResult.has_more: Is true if there are
-        additional shared links that have not been returned yet. Pass the cursor
-        into :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links` to
+    :ivar ListSharedLinksResult.links:
+        Shared links applicable to the path argument.
+    :ivar ListSharedLinksResult.has_more:
+        Is true if there are additional shared links that have not been returned
+        yet. Pass the cursor into
+        :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links` to
         retrieve them.
-    :ivar sharing.ListSharedLinksResult.cursor: Pass the cursor into
+    :ivar ListSharedLinksResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_shared_links` to
         obtain the additional links. Cursor is returned only if no path is
         given.
@@ -6259,14 +6363,16 @@ class MemberAccessLevelResult(bb.Struct):
     Contains information about a member's access level to content after an
     operation.
 
-    :ivar sharing.MemberAccessLevelResult.access_level: The member still has
-        this level of access to the content through a parent folder.
-    :ivar sharing.MemberAccessLevelResult.warning: A localized string with
-        additional information about why the user has this access level to the
-        content.
-    :ivar sharing.MemberAccessLevelResult.access_details: The parent folders
-        that a member has access to. The field is present if the user has access
-        to the first parent folder where the member gains access.
+    :ivar MemberAccessLevelResult.access_level:
+        The member still has this level of access to the content through a
+        parent folder.
+    :ivar MemberAccessLevelResult.warning:
+        A localized string with additional information about why the user has
+        this access level to the content.
+    :ivar MemberAccessLevelResult.access_details:
+        The parent folders that a member has access to. The field is present if
+        the user has access to the first parent folder where the member gains
+        access.
     """
 
     __slots__ = [
@@ -6313,17 +6419,18 @@ class MemberAction(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.MemberAction.leave_a_copy: Allow the member to keep a copy of
-        the folder when removing.
-    :ivar sharing.MemberAction.make_editor: Make the member an editor of the
-        folder.
-    :ivar sharing.MemberAction.make_owner: Make the member an owner of the
-        folder.
-    :ivar sharing.MemberAction.make_viewer: Make the member a viewer of the
-        folder.
-    :ivar sharing.MemberAction.make_viewer_no_comment: Make the member a viewer
-        of the folder without commenting permissions.
-    :ivar sharing.MemberAction.remove: Remove the member from the folder.
+    :ivar MemberAction.leave_a_copy:
+        Allow the member to keep a copy of the folder when removing.
+    :ivar MemberAction.make_editor:
+        Make the member an editor of the folder.
+    :ivar MemberAction.make_owner:
+        Make the member an owner of the folder.
+    :ivar MemberAction.make_viewer:
+        Make the member a viewer of the folder.
+    :ivar MemberAction.make_viewer_no_comment:
+        Make the member a viewer of the folder without commenting permissions.
+    :ivar MemberAction.remove:
+        Remove the member from the folder.
     """
 
     _catch_all = 'other'
@@ -6407,12 +6514,13 @@ class MemberPermission(bb.Struct):
     """
     Whether the user is allowed to take the action on the associated member.
 
-    :ivar sharing.MemberPermission.action: The action that the user may wish to
-        take on the member.
-    :ivar sharing.MemberPermission.allow: True if the user is allowed to take
-        the action.
-    :ivar sharing.MemberPermission.reason: The reason why the user is denied the
-        permission. Not present if the action is allowed.
+    :ivar MemberPermission.action:
+        The action that the user may wish to take on the member.
+    :ivar MemberPermission.allow:
+        True if the user is allowed to take the action.
+    :ivar MemberPermission.reason:
+        The reason why the user is denied the permission. Not present if the
+        action is allowed.
     """
 
     __slots__ = [
@@ -6460,10 +6568,12 @@ class MemberPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.MemberPolicy.team: Only a teammate can become a member.
-    :ivar sharing.MemberPolicy.anyone: Anyone can become a member.
-    :ivar sharing.MemberPolicy.team_and_approved: Only a teammate and approved
-        people can become a member.
+    :ivar MemberPolicy.team:
+        Only a teammate can become a member.
+    :ivar MemberPolicy.anyone:
+        Anyone can become a member.
+    :ivar MemberPolicy.team_and_approved:
+        Only a teammate and approved people can become a member.
     """
 
     _catch_all = 'other'
@@ -6521,9 +6631,12 @@ class MemberSelector(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str sharing.MemberSelector.dropbox_id: Dropbox account, team member,
-        or group ID of member.
-    :ivar str sharing.MemberSelector.email: Email address of member.
+    :ivar MemberSelector.dropbox_id:
+        Dropbox account, team member, or group ID of member.
+    :vartype MemberSelector.dropbox_id: str
+    :ivar MemberSelector.email:
+        Email address of member.
+    :vartype MemberSelector.email: str
     """
 
     _catch_all = 'other'
@@ -6607,12 +6720,12 @@ MemberSelector_validator = bv.Union(MemberSelector)
 
 class ModifySharedLinkSettingsArgs(bb.Struct):
     """
-    :ivar sharing.ModifySharedLinkSettingsArgs.url: URL of the shared link to
-        change its settings.
-    :ivar sharing.ModifySharedLinkSettingsArgs.settings: Set of settings for the
-        shared link.
-    :ivar sharing.ModifySharedLinkSettingsArgs.remove_expiration: If set to
-        true, removes the expiration of the shared link.
+    :ivar ModifySharedLinkSettingsArgs.url:
+        URL of the shared link to change its settings.
+    :ivar ModifySharedLinkSettingsArgs.settings:
+        Set of settings for the shared link.
+    :ivar ModifySharedLinkSettingsArgs.remove_expiration:
+        If set to true, removes the expiration of the shared link.
     """
 
     __slots__ = [
@@ -6657,12 +6770,13 @@ class ModifySharedLinkSettingsError(SharedLinkError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedLinkSettingsError ModifySharedLinkSettingsError.settings_error:
+    :ivar ModifySharedLinkSettingsError.settings_error:
         There is an error with the given settings.
-    :ivar sharing.ModifySharedLinkSettingsError.email_not_verified: This user's
-        email address is not verified. This functionality is only available on
-        accounts with a verified email address. Users can verify their email
-        address `here <https://www.dropbox.com/help/317>`_.
+    :vartype ModifySharedLinkSettingsError.settings_error: SharedLinkSettingsError
+    :ivar ModifySharedLinkSettingsError.email_not_verified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
     """
 
     # Attribute is overwritten below the class definition
@@ -6714,8 +6828,8 @@ ModifySharedLinkSettingsError_validator = bv.Union(ModifySharedLinkSettingsError
 
 class MountFolderArg(bb.Struct):
     """
-    :ivar sharing.MountFolderArg.shared_folder_id: The ID of the shared folder
-        to mount.
+    :ivar MountFolderArg.shared_folder_id:
+        The ID of the shared folder to mount.
     """
 
     __slots__ = [
@@ -6744,20 +6858,23 @@ class MountFolderError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.MountFolderError.inside_shared_folder: Mounting would cause a
-        shared folder to be inside another, which is disallowed.
-    :ivar InsufficientQuotaAmounts MountFolderError.insufficient_quota: The
-        current user does not have enough space to mount the shared folder.
-    :ivar sharing.MountFolderError.already_mounted: The shared folder is already
-        mounted.
-    :ivar sharing.MountFolderError.no_permission: The current user does not have
-        permission to perform this action.
-    :ivar sharing.MountFolderError.not_mountable: The shared folder is not
-        mountable. One example where this can occur is when the shared folder
-        belongs within a team folder in the user's Dropbox.
-    :ivar sharing.MountFolderError.must_automount: The shared folder is not
-        mountable by directly call APIs, instead the automounter is responsible
-        for mounting it.
+    :ivar MountFolderError.inside_shared_folder:
+        Mounting would cause a shared folder to be inside another, which is
+        disallowed.
+    :ivar MountFolderError.insufficient_quota:
+        The current user does not have enough space to mount the shared folder.
+    :vartype MountFolderError.insufficient_quota: InsufficientQuotaAmounts
+    :ivar MountFolderError.already_mounted:
+        The shared folder is already mounted.
+    :ivar MountFolderError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar MountFolderError.not_mountable:
+        The shared folder is not mountable. One example where this can occur is
+        when the shared folder belongs within a team folder in the user's
+        Dropbox.
+    :ivar MountFolderError.must_automount:
+        The shared folder is not mountable by directly call APIs, instead the
+        automounter is responsible for mounting it.
     """
 
     _catch_all = 'other'
@@ -6891,14 +7008,15 @@ class ParentFolderAccessInfo(bb.Struct):
     """
     Contains information about a parent folder that a member has access to.
 
-    :ivar sharing.ParentFolderAccessInfo.folder_name: Display name for the
-        folder.
-    :ivar sharing.ParentFolderAccessInfo.shared_folder_id: The identifier of the
-        parent shared folder.
-    :ivar sharing.ParentFolderAccessInfo.permissions: The user's permissions for
-        the parent shared folder.
-    :ivar sharing.ParentFolderAccessInfo.path: The full path to the parent
-        shared folder relative to the acting user's root.
+    :ivar ParentFolderAccessInfo.folder_name:
+        Display name for the folder.
+    :ivar ParentFolderAccessInfo.shared_folder_id:
+        The identifier of the parent shared folder.
+    :ivar ParentFolderAccessInfo.permissions:
+        The user's permissions for the parent shared folder.
+    :ivar ParentFolderAccessInfo.path:
+        The full path to the parent shared folder relative to the acting user's
+        root.
     """
 
     __slots__ = [
@@ -6949,7 +7067,8 @@ class PathLinkMetadata(LinkMetadata):
     """
     Metadata for a path-based shared link.
 
-    :ivar sharing.PathLinkMetadata.path: Path in user's Dropbox.
+    :ivar PathLinkMetadata.path:
+        Path in user's Dropbox.
     """
 
     __slots__ = [
@@ -6987,8 +7106,10 @@ class PendingUploadMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.PendingUploadMode.file: Assume pending uploads are files.
-    :ivar sharing.PendingUploadMode.folder: Assume pending uploads are folders.
+    :ivar PendingUploadMode.file:
+        Assume pending uploads are files.
+    :ivar PendingUploadMode.folder:
+        Assume pending uploads are folders.
     """
 
     _catch_all = None
@@ -7026,34 +7147,35 @@ class PermissionDeniedReason(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.PermissionDeniedReason.user_not_same_team_as_owner: User is
-        not on the same team as the folder owner.
-    :ivar sharing.PermissionDeniedReason.user_not_allowed_by_owner: User is
-        prohibited by the owner from taking the action.
-    :ivar sharing.PermissionDeniedReason.target_is_indirect_member: Target is
-        indirectly a member of the folder, for example by being part of a group.
-    :ivar sharing.PermissionDeniedReason.target_is_owner: Target is the owner of
-        the folder.
-    :ivar sharing.PermissionDeniedReason.target_is_self: Target is the user
-        itself.
-    :ivar sharing.PermissionDeniedReason.target_not_active: Target is not an
-        active member of the team.
-    :ivar sharing.PermissionDeniedReason.folder_is_limited_team_folder: Folder
-        is team folder for a limited team.
-    :ivar sharing.PermissionDeniedReason.owner_not_on_team: The content owner
-        needs to be on a Dropbox team to perform this action.
-    :ivar sharing.PermissionDeniedReason.permission_denied: The user does not
-        have permission to perform this action on the link.
-    :ivar sharing.PermissionDeniedReason.restricted_by_team: The user's team
-        policy prevents performing this action on the link.
-    :ivar sharing.PermissionDeniedReason.user_account_type: The user's account
-        type does not support this action.
-    :ivar sharing.PermissionDeniedReason.user_not_on_team: The user needs to be
-        on a Dropbox team to perform this action.
-    :ivar sharing.PermissionDeniedReason.folder_is_inside_shared_folder: Folder
-        is inside of another shared folder.
-    :ivar sharing.PermissionDeniedReason.restricted_by_parent_folder: Policy
-        cannot be changed due to restrictions from parent folder.
+    :ivar PermissionDeniedReason.user_not_same_team_as_owner:
+        User is not on the same team as the folder owner.
+    :ivar PermissionDeniedReason.user_not_allowed_by_owner:
+        User is prohibited by the owner from taking the action.
+    :ivar PermissionDeniedReason.target_is_indirect_member:
+        Target is indirectly a member of the folder, for example by being part
+        of a group.
+    :ivar PermissionDeniedReason.target_is_owner:
+        Target is the owner of the folder.
+    :ivar PermissionDeniedReason.target_is_self:
+        Target is the user itself.
+    :ivar PermissionDeniedReason.target_not_active:
+        Target is not an active member of the team.
+    :ivar PermissionDeniedReason.folder_is_limited_team_folder:
+        Folder is team folder for a limited team.
+    :ivar PermissionDeniedReason.owner_not_on_team:
+        The content owner needs to be on a Dropbox team to perform this action.
+    :ivar PermissionDeniedReason.permission_denied:
+        The user does not have permission to perform this action on the link.
+    :ivar PermissionDeniedReason.restricted_by_team:
+        The user's team policy prevents performing this action on the link.
+    :ivar PermissionDeniedReason.user_account_type:
+        The user's account type does not support this action.
+    :ivar PermissionDeniedReason.user_not_on_team:
+        The user needs to be on a Dropbox team to perform this action.
+    :ivar PermissionDeniedReason.folder_is_inside_shared_folder:
+        Folder is inside of another shared folder.
+    :ivar PermissionDeniedReason.restricted_by_parent_folder:
+        Policy cannot be changed due to restrictions from parent folder.
     """
 
     _catch_all = 'other'
@@ -7249,7 +7371,8 @@ class RelinquishAccessArg(bb.Struct):
     you need control over keeping folder contents, use the
     relinquish_folder_membership endpoint instead.
 
-    :ivar sharing.RelinquishAccessArg.file_id: The id for the file or folder.
+    :ivar RelinquishAccessArg.file_id:
+        The id for the file or folder.
     """
 
     __slots__ = [
@@ -7280,22 +7403,23 @@ class RelinquishAccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RelinquishAccessError.invalid_file_id: File or folder not
-        found or has been deleted.
-    :ivar sharing.RelinquishAccessError.email_unverified: Caller's email address
-        is not verified.
-    :ivar sharing.RelinquishAccessError.owner: User is the owner of the
-        file/folder.
-    :ivar sharing.RelinquishAccessError.no_explicit_access: User has only
-        non-removable access — inherited from a parent folder or via group
-        membership. Either way, relinquish_access cannot remove the caller's
-        access from this surface; the caller must take action on the source of
-        the access (e.g. leave the parent shared folder, or be removed from the
-        group).
-    :ivar sharing.RelinquishAccessError.team_folder: Team folder restrictions
-        apply.
-    :ivar sharing.RelinquishAccessError.no_permission: Caller does not have
-        permission to perform this action. Generic fallback.
+    :ivar RelinquishAccessError.invalid_file_id:
+        File or folder not found or has been deleted.
+    :ivar RelinquishAccessError.email_unverified:
+        Caller's email address is not verified.
+    :ivar RelinquishAccessError.owner:
+        User is the owner of the file/folder.
+    :ivar RelinquishAccessError.no_explicit_access:
+        User has only non-removable access — inherited from a parent folder or
+        via group membership. Either way, relinquish_access cannot remove the
+        caller's access from this surface; the caller must take action on the
+        source of the access (e.g. leave the parent shared folder, or be removed
+        from the group).
+    :ivar RelinquishAccessError.team_folder:
+        Team folder restrictions apply.
+    :ivar RelinquishAccessError.no_permission:
+        Caller does not have permission to perform this action. Generic
+        fallback.
     """
 
     _catch_all = 'other'
@@ -7395,7 +7519,8 @@ RelinquishAccessResult_validator = bv.Struct(RelinquishAccessResult)
 
 class RelinquishFileMembershipArg(bb.Struct):
     """
-    :ivar sharing.RelinquishFileMembershipArg.file: The path or id for the file.
+    :ivar RelinquishFileMembershipArg.file:
+        The path or id for the file.
     """
 
     __slots__ = [
@@ -7424,11 +7549,11 @@ class RelinquishFileMembershipError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RelinquishFileMembershipError.group_access: The current user
-        has access to the shared file via a group.  You can't relinquish
-        membership to a file shared via groups.
-    :ivar sharing.RelinquishFileMembershipError.no_permission: The current user
-        does not have permission to perform this action.
+    :ivar RelinquishFileMembershipError.group_access:
+        The current user has access to the shared file via a group.  You can't
+        relinquish membership to a file shared via groups.
+    :ivar RelinquishFileMembershipError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     _catch_all = 'other'
@@ -7499,11 +7624,12 @@ RelinquishFileMembershipError_validator = bv.Union(RelinquishFileMembershipError
 
 class RelinquishFolderMembershipArg(bb.Struct):
     """
-    :ivar sharing.RelinquishFolderMembershipArg.shared_folder_id: The ID for the
+    :ivar RelinquishFolderMembershipArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar RelinquishFolderMembershipArg.leave_a_copy:
+        Keep a copy of the folder's contents upon relinquishing membership. This
+        must be set to false when the folder is within a team folder or another
         shared folder.
-    :ivar sharing.RelinquishFolderMembershipArg.leave_a_copy: Keep a copy of the
-        folder's contents upon relinquishing membership. This must be set to
-        false when the folder is within a team folder or another shared folder.
     """
 
     __slots__ = [
@@ -7540,22 +7666,23 @@ class RelinquishFolderMembershipError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RelinquishFolderMembershipError.folder_owner: The current user
-        is the owner of the shared folder. Owners cannot relinquish membership
-        to their own folders. Try unsharing or transferring ownership first.
-    :ivar sharing.RelinquishFolderMembershipError.mounted: The shared folder is
-        currently mounted.  Unmount the shared folder before relinquishing
-        membership.
-    :ivar sharing.RelinquishFolderMembershipError.group_access: The current user
-        has access to the shared folder via a group.  You can't relinquish
-        membership to folders shared via groups.
-    :ivar sharing.RelinquishFolderMembershipError.team_folder: This action
-        cannot be performed on a team shared folder.
-    :ivar sharing.RelinquishFolderMembershipError.no_permission: The current
-        user does not have permission to perform this action.
-    :ivar sharing.RelinquishFolderMembershipError.no_explicit_access: The
-        current user only has inherited access to the shared folder.  You can't
-        relinquish inherited membership to folders.
+    :ivar RelinquishFolderMembershipError.folder_owner:
+        The current user is the owner of the shared folder. Owners cannot
+        relinquish membership to their own folders. Try unsharing or
+        transferring ownership first.
+    :ivar RelinquishFolderMembershipError.mounted:
+        The shared folder is currently mounted.  Unmount the shared folder
+        before relinquishing membership.
+    :ivar RelinquishFolderMembershipError.group_access:
+        The current user has access to the shared folder via a group.  You can't
+        relinquish membership to folders shared via groups.
+    :ivar RelinquishFolderMembershipError.team_folder:
+        This action cannot be performed on a team shared folder.
+    :ivar RelinquishFolderMembershipError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar RelinquishFolderMembershipError.no_explicit_access:
+        The current user only has inherited access to the shared folder.  You
+        can't relinquish inherited membership to folders.
     """
 
     _catch_all = 'other'
@@ -7669,11 +7796,12 @@ class RemoveFileMemberArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_remove_file_member_2`.
 
-    :ivar sharing.RemoveFileMemberArg.file: File from which to remove members.
-    :ivar sharing.RemoveFileMemberArg.member: Member to remove from this file.
-        Note that even if an email is specified, it may result in the removal of
-        a user (not an invitee) if the user's main account corresponds to that
-        email address.
+    :ivar RemoveFileMemberArg.file:
+        File from which to remove members.
+    :ivar RemoveFileMemberArg.member:
+        Member to remove from this file. Note that even if an email is
+        specified, it may result in the removal of a user (not an invitee) if
+        the user's main account corresponds to that email address.
     """
 
     __slots__ = [
@@ -7713,10 +7841,11 @@ class RemoveFileMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar MemberAccessLevelResult RemoveFileMemberError.no_explicit_access: This
-        member does not have explicit access to the file and therefore cannot be
-        removed. The return value is the access that a user might have to the
-        file from a parent folder.
+    :ivar RemoveFileMemberError.no_explicit_access:
+        This member does not have explicit access to the file and therefore
+        cannot be removed. The return value is the access that a user might have
+        to the file from a parent folder.
+    :vartype RemoveFileMemberError.no_explicit_access: MemberAccessLevelResult
     """
 
     _catch_all = 'other'
@@ -7829,15 +7958,15 @@ RemoveFileMemberError_validator = bv.Union(RemoveFileMemberError)
 
 class RemoveFolderMemberArg(bb.Struct):
     """
-    :ivar sharing.RemoveFolderMemberArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.RemoveFolderMemberArg.member: The member to remove from the
-        folder.
-    :ivar sharing.RemoveFolderMemberArg.leave_a_copy: If true, the removed user
-        will keep their copy of the folder after it's unshared, assuming it was
-        mounted. Otherwise, it will be removed from their Dropbox. This must be
-        set to false when removing a group, or when the folder is within a team
-        folder or another shared folder.
+    :ivar RemoveFolderMemberArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar RemoveFolderMemberArg.member:
+        The member to remove from the folder.
+    :ivar RemoveFolderMemberArg.leave_a_copy:
+        If true, the removed user will keep their copy of the folder after it's
+        unshared, assuming it was mounted. Otherwise, it will be removed from
+        their Dropbox. This must be set to false when removing a group, or when
+        the folder is within a team folder or another shared folder.
     """
 
     __slots__ = [
@@ -7882,18 +8011,18 @@ class RemoveFolderMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RemoveFolderMemberError.folder_owner: The target user is the
-        owner of the shared folder. You can't remove this user until ownership
-        has been transferred to another member.
-    :ivar sharing.RemoveFolderMemberError.group_access: The target user has
-        access to the shared folder via a group.
-    :ivar sharing.RemoveFolderMemberError.team_folder: This action cannot be
-        performed on a team shared folder.
-    :ivar sharing.RemoveFolderMemberError.no_permission: The current user does
-        not have permission to perform this action.
-    :ivar sharing.RemoveFolderMemberError.too_many_files: This shared folder has
-        too many files for leaving a copy. You can still remove this user
-        without leaving a copy.
+    :ivar RemoveFolderMemberError.folder_owner:
+        The target user is the owner of the shared folder. You can't remove this
+        user until ownership has been transferred to another member.
+    :ivar RemoveFolderMemberError.group_access:
+        The target user has access to the shared folder via a group.
+    :ivar RemoveFolderMemberError.team_folder:
+        This action cannot be performed on a team shared folder.
+    :ivar RemoveFolderMemberError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar RemoveFolderMemberError.too_many_files:
+        This shared folder has too many files for leaving a copy. You can still
+        remove this user without leaving a copy.
     """
 
     _catch_all = 'other'
@@ -8027,9 +8156,10 @@ class RemoveMemberJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar MemberAccessLevelResult RemoveMemberJobStatus.complete: Removing the
-        folder member has finished. The value is information about whether the
-        member has another form of access.
+    :ivar RemoveMemberJobStatus.complete:
+        Removing the folder member has finished. The value is information about
+        whether the member has another form of access.
+    :vartype RemoveMemberJobStatus.complete: MemberAccessLevelResult
     """
 
     @classmethod
@@ -8104,15 +8234,15 @@ class RequestedLinkAccessLevel(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RequestedLinkAccessLevel.viewer: Users who use the link can
-        view and comment on the content.
-    :ivar sharing.RequestedLinkAccessLevel.editor: Users who use the link can
-        edit, view and comment on the content. Note not all file types support
-        edit links yet.
-    :ivar sharing.RequestedLinkAccessLevel.max: Request for the maximum access
-        level you can set the link to.
-    :ivar sharing.RequestedLinkAccessLevel.default: Request for the default
-        access level the user has set.
+    :ivar RequestedLinkAccessLevel.viewer:
+        Users who use the link can view and comment on the content.
+    :ivar RequestedLinkAccessLevel.editor:
+        Users who use the link can edit, view and comment on the content. Note
+        not all file types support edit links yet.
+    :ivar RequestedLinkAccessLevel.max:
+        Request for the maximum access level you can set the link to.
+    :ivar RequestedLinkAccessLevel.default:
+        Request for the default access level the user has set.
     """
 
     _catch_all = 'other'
@@ -8174,7 +8304,8 @@ RequestedLinkAccessLevel_validator = bv.Union(RequestedLinkAccessLevel)
 
 class RevokeSharedLinkArg(bb.Struct):
     """
-    :ivar sharing.RevokeSharedLinkArg.url: URL of the shared link.
+    :ivar RevokeSharedLinkArg.url:
+        URL of the shared link.
     """
 
     __slots__ = [
@@ -8203,8 +8334,8 @@ class RevokeSharedLinkError(SharedLinkError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.RevokeSharedLinkError.shared_link_malformed: Shared link is
-        malformed.
+    :ivar RevokeSharedLinkError.shared_link_malformed:
+        Shared link is malformed.
     """
 
     # Attribute is overwritten below the class definition
@@ -8225,10 +8356,10 @@ RevokeSharedLinkError_validator = bv.Union(RevokeSharedLinkError)
 
 class SetAccessInheritanceArg(bb.Struct):
     """
-    :ivar sharing.SetAccessInheritanceArg.access_inheritance: The access
-        inheritance settings for the folder.
-    :ivar sharing.SetAccessInheritanceArg.shared_folder_id: The ID for the
-        shared folder.
+    :ivar SetAccessInheritanceArg.access_inheritance:
+        The access inheritance settings for the folder.
+    :ivar SetAccessInheritanceArg.shared_folder_id:
+        The ID for the shared folder.
     """
 
     __slots__ = [
@@ -8265,10 +8396,11 @@ class SetAccessInheritanceError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedFolderAccessError SetAccessInheritanceError.access_error: Unable
-        to access shared folder.
-    :ivar sharing.SetAccessInheritanceError.no_permission: The current user does
-        not have permission to perform this action.
+    :ivar SetAccessInheritanceError.access_error:
+        Unable to access shared folder.
+    :vartype SetAccessInheritanceError.access_error: SharedFolderAccessError
+    :ivar SetAccessInheritanceError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     _catch_all = 'other'
@@ -8331,22 +8463,24 @@ SetAccessInheritanceError_validator = bv.Union(SetAccessInheritanceError)
 
 class ShareFolderArgBase(bb.Struct):
     """
-    :ivar sharing.ShareFolderArgBase.acl_update_policy: Who can add and remove
-        members of this shared folder.
-    :ivar sharing.ShareFolderArgBase.force_async: Whether to force the share to
-        happen asynchronously.
-    :ivar sharing.ShareFolderArgBase.member_policy: Who can be a member of this
-        shared folder. Only applicable if the current user is on a team.
-    :ivar sharing.ShareFolderArgBase.path: The path or the file id to the folder
-        to share. If it does not exist, then a new one is created.
-    :ivar sharing.ShareFolderArgBase.shared_link_policy: The policy to apply to
-        shared links created for content inside this shared folder.  The current
-        user must be on a team to set this policy to
+    :ivar ShareFolderArgBase.acl_update_policy:
+        Who can add and remove members of this shared folder.
+    :ivar ShareFolderArgBase.force_async:
+        Whether to force the share to happen asynchronously.
+    :ivar ShareFolderArgBase.member_policy:
+        Who can be a member of this shared folder. Only applicable if the
+        current user is on a team.
+    :ivar ShareFolderArgBase.path:
+        The path or the file id to the folder to share. If it does not exist,
+        then a new one is created.
+    :ivar ShareFolderArgBase.shared_link_policy:
+        The policy to apply to shared links created for content inside this
+        shared folder.  The current user must be on a team to set this policy to
         ``SharedLinkPolicy.members``.
-    :ivar sharing.ShareFolderArgBase.viewer_info_policy: Who can enable/disable
-        viewer info for this shared folder.
-    :ivar sharing.ShareFolderArgBase.access_inheritance: The access inheritance
-        settings for the folder.
+    :ivar ShareFolderArgBase.viewer_info_policy:
+        Who can enable/disable viewer info for this shared folder.
+    :ivar ShareFolderArgBase.access_inheritance:
+        The access inheritance settings for the folder.
     """
 
     __slots__ = [
@@ -8419,12 +8553,13 @@ ShareFolderArgBase_validator = bv.Struct(ShareFolderArgBase)
 
 class ShareFolderArg(ShareFolderArgBase):
     """
-    :ivar sharing.ShareFolderArg.actions: A list of `FolderAction`s
-        corresponding to `FolderPermission`s that should appear in the
-        response's ``SharedFolderMetadata.permissions`` field describing the
-        actions the authenticated user can perform on the folder.
-    :ivar sharing.ShareFolderArg.link_settings: Settings on the link for this
+    :ivar ShareFolderArg.actions:
+        A list of `FolderAction`s corresponding to `FolderPermission`s that
+        should appear in the response's ``SharedFolderMetadata.permissions``
+        field describing the actions the authenticated user can perform on the
         folder.
+    :ivar ShareFolderArg.link_settings:
+        Settings on the link for this folder.
     """
 
     __slots__ = [
@@ -8475,17 +8610,18 @@ class ShareFolderErrorBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ShareFolderErrorBase.email_unverified: This user's email
-        address is not verified. This functionality is only available on
-        accounts with a verified email address. Users can verify their email
-        address `here <https://www.dropbox.com/help/317>`_.
-    :ivar SharePathError ShareFolderErrorBase.bad_path: ``ShareFolderArg.path``
-        is invalid.
-    :ivar sharing.ShareFolderErrorBase.team_policy_disallows_member_policy: Team
-        policy or group sharing settings are more restrictive than
+    :ivar ShareFolderErrorBase.email_unverified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
+    :ivar ShareFolderErrorBase.bad_path:
+        ``ShareFolderArg.path`` is invalid.
+    :vartype ShareFolderErrorBase.bad_path: SharePathError
+    :ivar ShareFolderErrorBase.team_policy_disallows_member_policy:
+        Team policy or group sharing settings are more restrictive than
         ``ShareFolderArg.member_policy``.
-    :ivar sharing.ShareFolderErrorBase.disallowed_shared_link_policy: The
-        current user's account is not allowed to select the specified
+    :ivar ShareFolderErrorBase.disallowed_shared_link_policy:
+        The current user's account is not allowed to select the specified
         ``ShareFolderArg.shared_link_policy``.
     """
 
@@ -8573,8 +8709,8 @@ class ShareFolderError(ShareFolderErrorBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ShareFolderError.no_permission: The current user does not have
-        permission to perform this action.
+    :ivar ShareFolderError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     # Attribute is overwritten below the class definition
@@ -8599,15 +8735,15 @@ class ShareFolderErrorBaseV2(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ShareFolderErrorBaseV2.email_unverified: This user's email
-        address is not verified. This functionality is only available on
-        accounts with a verified email address. Users can verify their email
-        address `here <https://www.dropbox.com/help/317>`_.
-    :ivar sharing.ShareFolderErrorBaseV2.team_policy_disallows_member_policy:
+    :ivar ShareFolderErrorBaseV2.email_unverified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
+    :ivar ShareFolderErrorBaseV2.team_policy_disallows_member_policy:
         Team policy or group sharing settings are more restrictive than
         ``ShareFolderArg.member_policy``.
-    :ivar sharing.ShareFolderErrorBaseV2.disallowed_shared_link_policy: The
-        current user's account is not allowed to select the specified
+    :ivar ShareFolderErrorBaseV2.disallowed_shared_link_policy:
+        The current user's account is not allowed to select the specified
         ``ShareFolderArg.shared_link_policy``.
     """
 
@@ -8664,8 +8800,8 @@ class ShareFolderErrorV2(ShareFolderErrorBaseV2):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ShareFolderErrorV2.no_permission: The current user does not
-        have permission to perform this action.
+    :ivar ShareFolderErrorV2.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     # Attribute is overwritten below the class definition
@@ -8690,8 +8826,9 @@ class ShareFolderJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedFolderMetadata ShareFolderJobStatus.complete: The share job has
-        finished. The value is the metadata for the folder.
+    :ivar ShareFolderJobStatus.complete:
+        The share job has finished. The value is the metadata for the folder.
+    :vartype ShareFolderJobStatus.complete: SharedFolderMetadata
     """
 
     @classmethod
@@ -8806,36 +8943,41 @@ class SharePathError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharePathError.is_file: A file is at the specified path.
-    :ivar sharing.SharePathError.inside_shared_folder: We do not support sharing
-        a folder inside a shared folder.
-    :ivar sharing.SharePathError.contains_shared_folder: We do not support
-        shared folders that contain shared folders.
-    :ivar sharing.SharePathError.contains_app_folder: We do not support shared
-        folders that contain app folders.
-    :ivar sharing.SharePathError.contains_team_folder: We do not support shared
-        folders that contain team folders.
-    :ivar sharing.SharePathError.is_app_folder: We do not support sharing an app
+    :ivar SharePathError.is_file:
+        A file is at the specified path.
+    :ivar SharePathError.inside_shared_folder:
+        We do not support sharing a folder inside a shared folder.
+    :ivar SharePathError.contains_shared_folder:
+        We do not support shared folders that contain shared folders.
+    :ivar SharePathError.contains_app_folder:
+        We do not support shared folders that contain app folders.
+    :ivar SharePathError.contains_team_folder:
+        We do not support shared folders that contain team folders.
+    :ivar SharePathError.is_app_folder:
+        We do not support sharing an app folder.
+    :ivar SharePathError.inside_app_folder:
+        We do not support sharing a folder inside an app folder.
+    :ivar SharePathError.is_public_folder:
+        A public folder can't be shared this way. Use a public link instead.
+    :ivar SharePathError.inside_public_folder:
+        A folder inside a public folder can't be shared this way. Use a public
+        link instead.
+    :ivar SharePathError.already_shared:
+        Folder is already shared. Contains metadata about the existing shared
         folder.
-    :ivar sharing.SharePathError.inside_app_folder: We do not support sharing a
-        folder inside an app folder.
-    :ivar sharing.SharePathError.is_public_folder: A public folder can't be
-        shared this way. Use a public link instead.
-    :ivar sharing.SharePathError.inside_public_folder: A folder inside a public
-        folder can't be shared this way. Use a public link instead.
-    :ivar SharedFolderMetadata SharePathError.already_shared: Folder is already
-        shared. Contains metadata about the existing shared folder.
-    :ivar sharing.SharePathError.invalid_path: Path is not valid.
-    :ivar sharing.SharePathError.is_osx_package: We do not support sharing a Mac
-        OS X package.
-    :ivar sharing.SharePathError.inside_osx_package: We do not support sharing a
-        folder inside a Mac OS X package.
-    :ivar sharing.SharePathError.is_vault: We do not support sharing the Vault
-        folder.
-    :ivar sharing.SharePathError.is_vault_locked: We do not support sharing a
-        folder inside a locked Vault.
-    :ivar sharing.SharePathError.is_family: We do not support sharing the Family
-        folder.
+    :vartype SharePathError.already_shared: SharedFolderMetadata
+    :ivar SharePathError.invalid_path:
+        Path is not valid.
+    :ivar SharePathError.is_osx_package:
+        We do not support sharing a Mac OS X package.
+    :ivar SharePathError.inside_osx_package:
+        We do not support sharing a folder inside a Mac OS X package.
+    :ivar SharePathError.is_vault:
+        We do not support sharing the Vault folder.
+    :ivar SharePathError.is_vault_locked:
+        We do not support sharing a folder inside a locked Vault.
+    :ivar SharePathError.is_family:
+        We do not support sharing the Family folder.
     """
 
     _catch_all = 'other'
@@ -9043,32 +9185,37 @@ class SharePathErrorBaseV2(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharePathErrorBaseV2.is_file: A file is at the specified path.
-    :ivar sharing.SharePathErrorBaseV2.inside_shared_folder: We do not support
-        sharing a folder inside a shared folder.
-    :ivar sharing.SharePathErrorBaseV2.contains_shared_folder: We do not support
-        shared folders that contain shared folders.
-    :ivar sharing.SharePathErrorBaseV2.contains_team_folder: We do not support
-        shared folders that contain team folders.
-    :ivar sharing.SharePathErrorBaseV2.is_app_folder: We do not support sharing
-        an app folder.
-    :ivar sharing.SharePathErrorBaseV2.inside_app_folder: We do not support
-        sharing a folder inside an app folder.
-    :ivar sharing.SharePathErrorBaseV2.is_public_folder: A public folder can't
-        be shared this way. Use a public link instead.
-    :ivar sharing.SharePathErrorBaseV2.inside_public_folder: A folder inside a
-        public folder can't be shared this way. Use a public link instead.
-    :ivar SharedFolderMetadata SharePathErrorBaseV2.already_shared: Folder is
-        already shared. Contains metadata about the existing shared folder.
-    :ivar sharing.SharePathErrorBaseV2.invalid_path: Path is not valid.
-    :ivar sharing.SharePathErrorBaseV2.is_osx_package: We do not support sharing
-        a Mac OS X package.
-    :ivar sharing.SharePathErrorBaseV2.inside_osx_package: We do not support
-        sharing a folder inside a Mac OS X package.
-    :ivar sharing.SharePathErrorBaseV2.is_vault: We do not support sharing the
-        Vault folder.
-    :ivar sharing.SharePathErrorBaseV2.is_vault_locked: We do not support
-        sharing a folder inside a locked Vault.
+    :ivar SharePathErrorBaseV2.is_file:
+        A file is at the specified path.
+    :ivar SharePathErrorBaseV2.inside_shared_folder:
+        We do not support sharing a folder inside a shared folder.
+    :ivar SharePathErrorBaseV2.contains_shared_folder:
+        We do not support shared folders that contain shared folders.
+    :ivar SharePathErrorBaseV2.contains_team_folder:
+        We do not support shared folders that contain team folders.
+    :ivar SharePathErrorBaseV2.is_app_folder:
+        We do not support sharing an app folder.
+    :ivar SharePathErrorBaseV2.inside_app_folder:
+        We do not support sharing a folder inside an app folder.
+    :ivar SharePathErrorBaseV2.is_public_folder:
+        A public folder can't be shared this way. Use a public link instead.
+    :ivar SharePathErrorBaseV2.inside_public_folder:
+        A folder inside a public folder can't be shared this way. Use a public
+        link instead.
+    :ivar SharePathErrorBaseV2.already_shared:
+        Folder is already shared. Contains metadata about the existing shared
+        folder.
+    :vartype SharePathErrorBaseV2.already_shared: SharedFolderMetadata
+    :ivar SharePathErrorBaseV2.invalid_path:
+        Path is not valid.
+    :ivar SharePathErrorBaseV2.is_osx_package:
+        We do not support sharing a Mac OS X package.
+    :ivar SharePathErrorBaseV2.inside_osx_package:
+        We do not support sharing a folder inside a Mac OS X package.
+    :ivar SharePathErrorBaseV2.is_vault:
+        We do not support sharing the Vault folder.
+    :ivar SharePathErrorBaseV2.is_vault_locked:
+        We do not support sharing a folder inside a locked Vault.
     """
 
     _catch_all = 'other'
@@ -9256,10 +9403,10 @@ class SharePathErrorV2(SharePathErrorBaseV2):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharePathErrorV2.is_family: We do not support sharing the
-        Family folder.
-    :ivar sharing.SharePathErrorV2.contains_app_folder: We do not support shared
-        folders that contain app folders.
+    :ivar SharePathErrorV2.is_family:
+        We do not support sharing the Family folder.
+    :ivar SharePathErrorV2.contains_app_folder:
+        We do not support shared folders that contain app folders.
     """
 
     # Attribute is overwritten below the class definition
@@ -9292,11 +9439,12 @@ class SharedContentLinkMetadata(SharedContentLinkMetadataBase):
     """
     Metadata of a shared link for a file or folder.
 
-    :ivar sharing.SharedContentLinkMetadata.audience_exceptions: The content
-        inside this folder with link audience different than this folder's. This
-        is only returned when an endpoint that returns metadata for a single
-        shared folder is called, e.g. /get_folder_metadata.
-    :ivar sharing.SharedContentLinkMetadata.url: The URL of the link.
+    :ivar SharedContentLinkMetadata.audience_exceptions:
+        The content inside this folder with link audience different than this
+        folder's. This is only returned when an endpoint that returns metadata
+        for a single shared folder is called, e.g. /get_folder_metadata.
+    :ivar SharedContentLinkMetadata.url:
+        The URL of the link.
     """
 
     __slots__ = [
@@ -9349,15 +9497,16 @@ class SharedFileMembers(bb.Struct):
     and used as part of the results for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_batch`.
 
-    :ivar sharing.SharedFileMembers.users: The list of user members of the
-        shared file.
-    :ivar sharing.SharedFileMembers.groups: The list of group members of the
-        shared file.
-    :ivar sharing.SharedFileMembers.invitees: The list of invited members of a
-        file, but have not logged in and claimed this.
-    :ivar sharing.SharedFileMembers.cursor: Present if there are additional
-        shared file members that have not been returned yet. Pass the cursor
-        into
+    :ivar SharedFileMembers.users:
+        The list of user members of the shared file.
+    :ivar SharedFileMembers.groups:
+        The list of group members of the shared file.
+    :ivar SharedFileMembers.invitees:
+        The list of invited members of a file, but have not logged in and
+        claimed this.
+    :ivar SharedFileMembers.cursor:
+        Present if there are additional shared file members that have not been
+        returned yet. Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_file_members_continue`
         to list additional members.
     """
@@ -9410,44 +9559,49 @@ class SharedFileMetadata(bb.Struct):
     """
     Properties of the shared file.
 
-    :ivar sharing.SharedFileMetadata.access_type: The current user's access
-        level for this shared file.
-    :ivar sharing.SharedFileMetadata.id: The ID of the file.
-    :ivar sharing.SharedFileMetadata.expected_link_metadata: The expected
-        metadata of the link associated for the file when it is first shared.
-        Absent if the link already exists. This is for an unreleased feature so
-        it may not be returned yet.
-    :ivar sharing.SharedFileMetadata.link_metadata: The metadata of the link
-        associated for the file. This is for an unreleased feature so it may not
-        be returned yet.
-    :ivar sharing.SharedFileMetadata.name: The name of this file.
-    :ivar sharing.SharedFileMetadata.owner_display_names: The display names of
-        the users that own the file. If the file is part of a team folder, the
-        display names of the team admins are also included. Absent if the owner
-        display names cannot be fetched.
-    :ivar sharing.SharedFileMetadata.owner_team: The team that owns the file.
-        This field is not present if the file is not owned by a team.
-    :ivar sharing.SharedFileMetadata.parent_shared_folder_id: The ID of the
-        parent shared folder. This field is present only if the file is
-        contained within a shared folder.
-    :ivar sharing.SharedFileMetadata.path_display: The cased path to be used for
-        display purposes only. In rare instances the casing will not correctly
-        match the user's filesystem, but this behavior will match the path
-        provided in the Core API v1. Absent for unmounted files.
-    :ivar sharing.SharedFileMetadata.path_lower: The lower-case full path of
-        this file. Absent for unmounted files.
-    :ivar sharing.SharedFileMetadata.permissions: The sharing permissions that
-        requesting user has on this file. This corresponds to the entries given
-        in ``GetFileMetadataBatchArg.actions`` or
-        ``GetFileMetadataArg.actions``.
-    :ivar sharing.SharedFileMetadata.policy: Policies governing this shared
-        file.
-    :ivar sharing.SharedFileMetadata.preview_url: URL for displaying a web
-        preview of the shared file.
-    :ivar sharing.SharedFileMetadata.time_invited: Timestamp indicating when the
-        current user was invited to this shared file. If the user was not
-        invited to the shared file, the timestamp will indicate when the user
-        was invited to the parent shared folder. This value may be absent.
+    :ivar SharedFileMetadata.access_type:
+        The current user's access level for this shared file.
+    :ivar SharedFileMetadata.id:
+        The ID of the file.
+    :ivar SharedFileMetadata.expected_link_metadata:
+        The expected metadata of the link associated for the file when it is
+        first shared. Absent if the link already exists. This is for an
+        unreleased feature so it may not be returned yet.
+    :ivar SharedFileMetadata.link_metadata:
+        The metadata of the link associated for the file. This is for an
+        unreleased feature so it may not be returned yet.
+    :ivar SharedFileMetadata.name:
+        The name of this file.
+    :ivar SharedFileMetadata.owner_display_names:
+        The display names of the users that own the file. If the file is part of
+        a team folder, the display names of the team admins are also included.
+        Absent if the owner display names cannot be fetched.
+    :ivar SharedFileMetadata.owner_team:
+        The team that owns the file. This field is not present if the file is
+        not owned by a team.
+    :ivar SharedFileMetadata.parent_shared_folder_id:
+        The ID of the parent shared folder. This field is present only if the
+        file is contained within a shared folder.
+    :ivar SharedFileMetadata.path_display:
+        The cased path to be used for display purposes only. In rare instances
+        the casing will not correctly match the user's filesystem, but this
+        behavior will match the path provided in the Core API v1. Absent for
+        unmounted files.
+    :ivar SharedFileMetadata.path_lower:
+        The lower-case full path of this file. Absent for unmounted files.
+    :ivar SharedFileMetadata.permissions:
+        The sharing permissions that requesting user has on this file. This
+        corresponds to the entries given in ``GetFileMetadataBatchArg.actions``
+        or ``GetFileMetadataArg.actions``.
+    :ivar SharedFileMetadata.policy:
+        Policies governing this shared file.
+    :ivar SharedFileMetadata.preview_url:
+        URL for displaying a web preview of the shared file.
+    :ivar SharedFileMetadata.time_invited:
+        Timestamp indicating when the current user was invited to this shared
+        file. If the user was not invited to the shared file, the timestamp will
+        indicate when the user was invited to the parent shared folder. This
+        value may be absent.
     """
 
     __slots__ = [
@@ -9582,16 +9736,16 @@ class SharedFolderAccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedFolderAccessError.invalid_id: This shared folder ID is
-        invalid.
-    :ivar sharing.SharedFolderAccessError.not_a_member: The user is not a member
-        of the shared folder thus cannot access it.
-    :ivar sharing.SharedFolderAccessError.invalid_member: The user does not
-        exist or their account is disabled.
-    :ivar sharing.SharedFolderAccessError.email_unverified: Field is deprecated.
-        Never set.
-    :ivar sharing.SharedFolderAccessError.unmounted: The shared folder is
-        unmounted.
+    :ivar SharedFolderAccessError.invalid_id:
+        This shared folder ID is invalid.
+    :ivar SharedFolderAccessError.not_a_member:
+        The user is not a member of the shared folder thus cannot access it.
+    :ivar SharedFolderAccessError.invalid_member:
+        The user does not exist or their account is disabled.
+    :ivar SharedFolderAccessError.email_unverified:
+        Field is deprecated. Never set.
+    :ivar SharedFolderAccessError.unmounted:
+        The shared folder is unmounted.
     """
 
     _catch_all = 'other'
@@ -9667,12 +9821,13 @@ class SharedFolderMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedFolderMemberError.invalid_dropbox_id: The target
-        dropbox_id is invalid.
-    :ivar sharing.SharedFolderMemberError.not_a_member: The target dropbox_id is
-        not a member of the shared folder.
-    :ivar MemberAccessLevelResult SharedFolderMemberError.no_explicit_access:
+    :ivar SharedFolderMemberError.invalid_dropbox_id:
+        The target dropbox_id is invalid.
+    :ivar SharedFolderMemberError.not_a_member:
+        The target dropbox_id is not a member of the shared folder.
+    :ivar SharedFolderMemberError.no_explicit_access:
         The target member only has inherited access to the shared folder.
+    :vartype SharedFolderMemberError.no_explicit_access: MemberAccessLevelResult
     """
 
     _catch_all = 'other'
@@ -9747,15 +9902,15 @@ class SharedFolderMembers(bb.Struct):
     """
     Shared folder user and group membership.
 
-    :ivar sharing.SharedFolderMembers.users: The list of user members of the
-        shared folder.
-    :ivar sharing.SharedFolderMembers.groups: The list of group members of the
-        shared folder.
-    :ivar sharing.SharedFolderMembers.invitees: The list of invitees to the
-        shared folder.
-    :ivar sharing.SharedFolderMembers.cursor: Present if there are additional
-        shared folder members that have not been returned yet. Pass the cursor
-        into
+    :ivar SharedFolderMembers.users:
+        The list of user members of the shared folder.
+    :ivar SharedFolderMembers.groups:
+        The list of group members of the shared folder.
+    :ivar SharedFolderMembers.invitees:
+        The list of invitees to the shared folder.
+    :ivar SharedFolderMembers.cursor:
+        Present if there are additional shared folder members that have not been
+        returned yet. Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.sharing_list_folder_members_continue`
         to list additional members.
     """
@@ -9808,27 +9963,30 @@ class SharedFolderMetadataBase(bb.Struct):
     """
     Properties of the shared folder.
 
-    :ivar sharing.SharedFolderMetadataBase.access_type: The current user's
-        access level for this shared folder.
-    :ivar sharing.SharedFolderMetadataBase.is_inside_team_folder: Whether this
-        folder is inside of a team folder.
-    :ivar sharing.SharedFolderMetadataBase.is_team_folder: Whether this folder
-        is a `team folder <https://www.dropbox.com/en/help/986>`_.
-    :ivar sharing.SharedFolderMetadataBase.owner_display_names: The display
-        names of the users that own the folder. If the folder is part of a team
-        folder, the display names of the team admins are also included. Absent
-        if the owner display names cannot be fetched.
-    :ivar sharing.SharedFolderMetadataBase.owner_team: The team that owns the
-        folder. This field is not present if the folder is not owned by a team.
-    :ivar sharing.SharedFolderMetadataBase.parent_shared_folder_id: The ID of
-        the parent shared folder. This field is present only if the folder is
-        contained within another shared folder.
-    :ivar sharing.SharedFolderMetadataBase.path_display: The full path of this
-        shared folder. Absent for unmounted folders.
-    :ivar sharing.SharedFolderMetadataBase.path_lower: The lower-cased full path
-        of this shared folder. Absent for unmounted folders.
-    :ivar sharing.SharedFolderMetadataBase.parent_folder_name: Display name for
-        the parent folder.
+    :ivar SharedFolderMetadataBase.access_type:
+        The current user's access level for this shared folder.
+    :ivar SharedFolderMetadataBase.is_inside_team_folder:
+        Whether this folder is inside of a team folder.
+    :ivar SharedFolderMetadataBase.is_team_folder:
+        Whether this folder is a `team folder
+        <https://www.dropbox.com/en/help/986>`_.
+    :ivar SharedFolderMetadataBase.owner_display_names:
+        The display names of the users that own the folder. If the folder is
+        part of a team folder, the display names of the team admins are also
+        included. Absent if the owner display names cannot be fetched.
+    :ivar SharedFolderMetadataBase.owner_team:
+        The team that owns the folder. This field is not present if the folder
+        is not owned by a team.
+    :ivar SharedFolderMetadataBase.parent_shared_folder_id:
+        The ID of the parent shared folder. This field is present only if the
+        folder is contained within another shared folder.
+    :ivar SharedFolderMetadataBase.path_display:
+        The full path of this shared folder. Absent for unmounted folders.
+    :ivar SharedFolderMetadataBase.path_lower:
+        The lower-cased full path of this shared folder. Absent for unmounted
+        folders.
+    :ivar SharedFolderMetadataBase.parent_folder_name:
+        Display name for the parent folder.
     """
 
     __slots__ = [
@@ -9919,24 +10077,28 @@ class SharedFolderMetadata(SharedFolderMetadataBase):
     """
     The metadata which includes basic information about the shared folder.
 
-    :ivar sharing.SharedFolderMetadata.link_metadata: The metadata of the shared
-        content link to this shared folder. Absent if there is no link on the
-        folder. This is for an unreleased feature so it may not be returned yet.
-    :ivar sharing.SharedFolderMetadata.name: The name of the this shared folder.
-    :ivar sharing.SharedFolderMetadata.permissions: Actions the current user may
-        perform on the folder and its contents. The set of permissions
-        corresponds to the FolderActions in the request.
-    :ivar sharing.SharedFolderMetadata.policy: Policies governing this shared
+    :ivar SharedFolderMetadata.link_metadata:
+        The metadata of the shared content link to this shared folder. Absent if
+        there is no link on the folder. This is for an unreleased feature so it
+        may not be returned yet.
+    :ivar SharedFolderMetadata.name:
+        The name of the this shared folder.
+    :ivar SharedFolderMetadata.permissions:
+        Actions the current user may perform on the folder and its contents. The
+        set of permissions corresponds to the FolderActions in the request.
+    :ivar SharedFolderMetadata.policy:
+        Policies governing this shared folder.
+    :ivar SharedFolderMetadata.preview_url:
+        URL for displaying a web preview of the shared folder.
+    :ivar SharedFolderMetadata.shared_folder_id:
+        The ID of the shared folder.
+    :ivar SharedFolderMetadata.time_invited:
+        Timestamp indicating when the current user was invited to this shared
         folder.
-    :ivar sharing.SharedFolderMetadata.preview_url: URL for displaying a web
-        preview of the shared folder.
-    :ivar sharing.SharedFolderMetadata.shared_folder_id: The ID of the shared
-        folder.
-    :ivar sharing.SharedFolderMetadata.time_invited: Timestamp indicating when
-        the current user was invited to this shared folder.
-    :ivar sharing.SharedFolderMetadata.access_inheritance: Whether the folder
-        inherits its members from its parent.
-    :ivar sharing.SharedFolderMetadata.folder_id: The ID of the content.
+    :ivar SharedFolderMetadata.access_inheritance:
+        Whether the folder inherits its members from its parent.
+    :ivar SharedFolderMetadata.folder_id:
+        The ID of the content.
     """
 
     __slots__ = [
@@ -10047,18 +10209,18 @@ class SharedLinkAccessFailureReason(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedLinkAccessFailureReason.login_required: User is not
-        logged in.
-    :ivar sharing.SharedLinkAccessFailureReason.email_verify_required: This
-        user's email address is not verified. This functionality is only
+    :ivar SharedLinkAccessFailureReason.login_required:
+        User is not logged in.
+    :ivar SharedLinkAccessFailureReason.email_verify_required:
+        This user's email address is not verified. This functionality is only
         available on accounts with a verified email address. Users can verify
         their email address `here <https://www.dropbox.com/help/317>`_.
-    :ivar sharing.SharedLinkAccessFailureReason.password_required: The link is
-        password protected.
-    :ivar sharing.SharedLinkAccessFailureReason.team_only: Access is allowed for
-        team members only.
-    :ivar sharing.SharedLinkAccessFailureReason.owner_only: Access is allowed
-        for the shared link's owner only.
+    :ivar SharedLinkAccessFailureReason.password_required:
+        The link is password protected.
+    :ivar SharedLinkAccessFailureReason.team_only:
+        Access is allowed for team members only.
+    :ivar SharedLinkAccessFailureReason.owner_only:
+        Access is allowed for the shared link's owner only.
     """
 
     _catch_all = 'other'
@@ -10134,8 +10296,9 @@ class SharedLinkAlreadyExistsMetadata(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SharedLinkMetadata SharedLinkAlreadyExistsMetadata.metadata: Metadata
-        of the shared link that already exists.
+    :ivar SharedLinkAlreadyExistsMetadata.metadata:
+        Metadata of the shared link that already exists.
+    :vartype SharedLinkAlreadyExistsMetadata.metadata: SharedLinkMetadata
     """
 
     _catch_all = 'other'
@@ -10208,11 +10371,13 @@ class SharedLinkPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedLinkPolicy.anyone: Links can be shared with anyone.
-    :ivar sharing.SharedLinkPolicy.team: Field is deprecated. Links can be
-        shared with anyone on the same team as the owner.
-    :ivar sharing.SharedLinkPolicy.members: Links can only be shared among
-        members of the shared folder.
+    :ivar SharedLinkPolicy.anyone:
+        Links can be shared with anyone.
+    :ivar SharedLinkPolicy.team:
+        Field is deprecated. Links can be shared with anyone on the same team as
+        the owner.
+    :ivar SharedLinkPolicy.members:
+        Links can only be shared among members of the shared folder.
     """
 
     _catch_all = 'other'
@@ -10264,25 +10429,27 @@ SharedLinkPolicy_validator = bv.Union(SharedLinkPolicy)
 
 class SharedLinkSettings(bb.Struct):
     """
-    :ivar sharing.SharedLinkSettings.require_password: Boolean flag to enable or
-        disable password protection.
-    :ivar sharing.SharedLinkSettings.link_password: If ``require_password`` is
-        true, this is needed to specify the password to access the link.
-    :ivar sharing.SharedLinkSettings.expires: Expiration time of the shared
-        link. By default the link won't expire.
-    :ivar sharing.SharedLinkSettings.audience: The new audience who can benefit
-        from the access level specified by the link's access level specified in
-        the `link_access_level` field of `LinkPermissions`. This is used in
-        conjunction with team policies and shared folder policies to determine
-        the final effective audience type in the `effective_audience` field of
-        `LinkPermissions.
-    :ivar sharing.SharedLinkSettings.access: Requested access level you want the
-        audience to gain from this link. Note, modifying access level for an
-        existing link is not supported.
-    :ivar sharing.SharedLinkSettings.requested_visibility: Field is deprecated.
-        Use ``audience`` instead.  The requested access for this shared link.
-    :ivar sharing.SharedLinkSettings.allow_download: Boolean flag to allow or
-        not download capabilities for shared links.
+    :ivar SharedLinkSettings.require_password:
+        Boolean flag to enable or disable password protection.
+    :ivar SharedLinkSettings.link_password:
+        If ``require_password`` is true, this is needed to specify the password
+        to access the link.
+    :ivar SharedLinkSettings.expires:
+        Expiration time of the shared link. By default the link won't expire.
+    :ivar SharedLinkSettings.audience:
+        The new audience who can benefit from the access level specified by the
+        link's access level specified in the `link_access_level` field of
+        `LinkPermissions`. This is used in conjunction with team policies and
+        shared folder policies to determine the final effective audience type in
+        the `effective_audience` field of `LinkPermissions.
+    :ivar SharedLinkSettings.access:
+        Requested access level you want the audience to gain from this link.
+        Note, modifying access level for an existing link is not supported.
+    :ivar SharedLinkSettings.requested_visibility:
+        Field is deprecated. Use ``audience`` instead.  The requested access for
+        this shared link.
+    :ivar SharedLinkSettings.allow_download:
+        Boolean flag to allow or not download capabilities for shared links.
     """
 
     __slots__ = [
@@ -10359,15 +10526,15 @@ class SharedLinkSettingsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharedLinkSettingsError.invalid_settings: The given settings
-        are invalid (for example, all attributes of the
+    :ivar SharedLinkSettingsError.invalid_settings:
+        The given settings are invalid (for example, all attributes of the
         :class:`SharedLinkSettings` are empty, the requested visibility is
         ``RequestedVisibility.password`` but the
         ``SharedLinkSettings.link_password`` is missing,
         ``SharedLinkSettings.expires`` is set to the past, etc.).
-    :ivar sharing.SharedLinkSettingsError.not_authorized: User is not allowed to
-        modify the settings of this link. Note that basic users can only set
-        ``RequestedVisibility.public`` as the
+    :ivar SharedLinkSettingsError.not_authorized:
+        User is not allowed to modify the settings of this link. Note that basic
+        users can only set ``RequestedVisibility.public`` as the
         ``SharedLinkSettings.requested_visibility`` and cannot set
         ``SharedLinkSettings.expires``.
     """
@@ -10407,16 +10574,19 @@ class SharingFileAccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharingFileAccessError.no_permission: Current user does not
-        have sufficient privileges to perform the desired action.
-    :ivar sharing.SharingFileAccessError.invalid_file: File specified was not
-        found.
-    :ivar sharing.SharingFileAccessError.is_folder: A folder can't be shared
-        this way. Use folder sharing or a shared link instead.
-    :ivar sharing.SharingFileAccessError.inside_public_folder: A file inside a
-        public folder can't be shared this way. Use a public link instead.
-    :ivar sharing.SharingFileAccessError.inside_osx_package: A Mac OS X package
-        can't be shared this way. Use a shared link instead.
+    :ivar SharingFileAccessError.no_permission:
+        Current user does not have sufficient privileges to perform the desired
+        action.
+    :ivar SharingFileAccessError.invalid_file:
+        File specified was not found.
+    :ivar SharingFileAccessError.is_folder:
+        A folder can't be shared this way. Use folder sharing or a shared link
+        instead.
+    :ivar SharingFileAccessError.inside_public_folder:
+        A file inside a public folder can't be shared this way. Use a public
+        link instead.
+    :ivar SharingFileAccessError.inside_osx_package:
+        A Mac OS X package can't be shared this way. Use a shared link instead.
     """
 
     _catch_all = 'other'
@@ -10494,10 +10664,10 @@ class SharingUserError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.SharingUserError.email_unverified: This user's email address
-        is not verified. This functionality is only available on accounts with a
-        verified email address. Users can verify their email address `here
-        <https://www.dropbox.com/help/317>`_.
+    :ivar SharingUserError.email_unverified:
+        This user's email address is not verified. This functionality is only
+        available on accounts with a verified email address. Users can verify
+        their email address `here <https://www.dropbox.com/help/317>`_.
     """
 
     _catch_all = 'other'
@@ -10531,11 +10701,13 @@ class TeamMemberInfo(bb.Struct):
     """
     Information about a team member.
 
-    :ivar sharing.TeamMemberInfo.team_info: Information about the member's team.
-    :ivar sharing.TeamMemberInfo.display_name: The display name of the user.
-    :ivar sharing.TeamMemberInfo.member_id: ID of user as a member of a team.
-        This field will only be present if the member is in the same team as
-        current user.
+    :ivar TeamMemberInfo.team_info:
+        Information about the member's team.
+    :ivar TeamMemberInfo.display_name:
+        The display name of the user.
+    :ivar TeamMemberInfo.member_id:
+        ID of user as a member of a team. This field will only be present if the
+        member is in the same team as current user.
     """
 
     __slots__ = [
@@ -10576,10 +10748,10 @@ TeamMemberInfo_validator = bv.Struct(TeamMemberInfo)
 
 class TransferFolderArg(bb.Struct):
     """
-    :ivar sharing.TransferFolderArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.TransferFolderArg.to_dropbox_id: A account or team member ID
-        to transfer ownership to.
+    :ivar TransferFolderArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar TransferFolderArg.to_dropbox_id:
+        A account or team member ID to transfer ownership to.
     """
 
     __slots__ = [
@@ -10616,20 +10788,21 @@ class TransferFolderError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.TransferFolderError.invalid_dropbox_id:
+    :ivar TransferFolderError.invalid_dropbox_id:
         ``TransferFolderArg.to_dropbox_id`` is invalid.
-    :ivar sharing.TransferFolderError.new_owner_not_a_member: The new designated
-        owner is not currently a member of the shared folder.
-    :ivar sharing.TransferFolderError.new_owner_unmounted: The new designated
-        owner has not added the folder to their Dropbox.
-    :ivar sharing.TransferFolderError.new_owner_email_unverified: The new
-        designated owner's email address is not verified. This functionality is
-        only available on accounts with a verified email address. Users can
-        verify their email address `here <https://www.dropbox.com/help/317>`_.
-    :ivar sharing.TransferFolderError.team_folder: This action cannot be
-        performed on a team shared folder.
-    :ivar sharing.TransferFolderError.no_permission: The current user does not
-        have permission to perform this action.
+    :ivar TransferFolderError.new_owner_not_a_member:
+        The new designated owner is not currently a member of the shared folder.
+    :ivar TransferFolderError.new_owner_unmounted:
+        The new designated owner has not added the folder to their Dropbox.
+    :ivar TransferFolderError.new_owner_email_unverified:
+        The new designated owner's email address is not verified. This
+        functionality is only available on accounts with a verified email
+        address. Users can verify their email address `here
+        <https://www.dropbox.com/help/317>`_.
+    :ivar TransferFolderError.team_folder:
+        This action cannot be performed on a team shared folder.
+    :ivar TransferFolderError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     _catch_all = 'other'
@@ -10740,8 +10913,8 @@ TransferFolderError_validator = bv.Union(TransferFolderError)
 
 class UnmountFolderArg(bb.Struct):
     """
-    :ivar sharing.UnmountFolderArg.shared_folder_id: The ID for the shared
-        folder.
+    :ivar UnmountFolderArg.shared_folder_id:
+        The ID for the shared folder.
     """
 
     __slots__ = [
@@ -10770,12 +10943,12 @@ class UnmountFolderError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.UnmountFolderError.no_permission: The current user does not
-        have permission to perform this action.
-    :ivar sharing.UnmountFolderError.not_unmountable: The shared folder can't be
-        unmounted. One example where this can occur is when the shared folder's
-        parent folder is also a shared folder that resides in the current user's
-        Dropbox.
+    :ivar UnmountFolderError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar UnmountFolderError.not_unmountable:
+        The shared folder can't be unmounted. One example where this can occur
+        is when the shared folder's parent folder is also a shared folder that
+        resides in the current user's Dropbox.
     """
 
     _catch_all = 'other'
@@ -10848,7 +11021,8 @@ class UnshareFileArg(bb.Struct):
     """
     Arguments for :meth:`dropbox.dropbox_client.Dropbox.sharing_unshare_file`.
 
-    :ivar sharing.UnshareFileArg.file: The file to unshare.
+    :ivar UnshareFileArg.file:
+        The file to unshare.
     """
 
     __slots__ = [
@@ -10958,12 +11132,12 @@ UnshareFileError_validator = bv.Union(UnshareFileError)
 
 class UnshareFolderArg(bb.Struct):
     """
-    :ivar sharing.UnshareFolderArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.UnshareFolderArg.leave_a_copy: If true, members of this shared
-        folder will get a copy of this folder after it's unshared. Otherwise, it
-        will be removed from their Dropbox. The current user, who is an owner,
-        will always retain their copy.
+    :ivar UnshareFolderArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar UnshareFolderArg.leave_a_copy:
+        If true, members of this shared folder will get a copy of this folder
+        after it's unshared. Otherwise, it will be removed from their Dropbox.
+        The current user, who is an owner, will always retain their copy.
     """
 
     __slots__ = [
@@ -11000,12 +11174,12 @@ class UnshareFolderError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.UnshareFolderError.team_folder: This action cannot be
-        performed on a team shared folder.
-    :ivar sharing.UnshareFolderError.no_permission: The current user does not
-        have permission to perform this action.
-    :ivar sharing.UnshareFolderError.too_many_files: This shared folder has too
-        many files to be unshared.
+    :ivar UnshareFolderError.team_folder:
+        This action cannot be performed on a team shared folder.
+    :ivar UnshareFolderError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar UnshareFolderError.too_many_files:
+        This shared folder has too many files to be unshared.
     """
 
     _catch_all = 'other'
@@ -11089,12 +11263,12 @@ class UpdateFileMemberArgs(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_update_file_member`.
 
-    :ivar sharing.UpdateFileMemberArgs.file: File for which we are changing a
-        member's access.
-    :ivar sharing.UpdateFileMemberArgs.member: The member whose access we are
-        changing.
-    :ivar sharing.UpdateFileMemberArgs.access_level: The new access level for
-        the member.
+    :ivar UpdateFileMemberArgs.file:
+        File for which we are changing a member's access.
+    :ivar UpdateFileMemberArgs.member:
+        The member whose access we are changing.
+    :ivar UpdateFileMemberArgs.access_level:
+        The new access level for the member.
     """
 
     __slots__ = [
@@ -11138,16 +11312,16 @@ class UpdateFilePolicyArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.sharing_update_file_policy`.
 
-    :ivar sharing.UpdateFilePolicyArg.file: File that we are changing the policy
-        for.
-    :ivar sharing.UpdateFilePolicyArg.actions: A list of `FileAction`s
-        corresponding to `FilePermission`s that should appear in the response's
-        ``SharedFileMetadata.permissions`` field describing the actions the
-        authenticated user can perform on the file.
-    :ivar sharing.UpdateFilePolicyArg.link_settings: Field is deprecated.
-        Settings on the link for the file.
-    :ivar sharing.UpdateFilePolicyArg.viewer_info_policy: The presence and seen
-        state policy on the file.
+    :ivar UpdateFilePolicyArg.file:
+        File that we are changing the policy for.
+    :ivar UpdateFilePolicyArg.actions:
+        A list of `FileAction`s corresponding to `FilePermission`s that should
+        appear in the response's ``SharedFileMetadata.permissions`` field
+        describing the actions the authenticated user can perform on the file.
+    :ivar UpdateFilePolicyArg.link_settings:
+        Field is deprecated. Settings on the link for the file.
+    :ivar UpdateFilePolicyArg.viewer_info_policy:
+        The presence and seen state policy on the file.
     """
 
     __slots__ = [
@@ -11203,10 +11377,10 @@ class UpdateFilePolicyError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.UpdateFilePolicyError.invalid_file_settings: The file settings
-        are invalid.
-    :ivar sharing.UpdateFilePolicyError.no_permission: The current user does not
-        have permission to perform this action.
+    :ivar UpdateFilePolicyError.invalid_file_settings:
+        The file settings are invalid.
+    :ivar UpdateFilePolicyError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     _catch_all = 'other'
@@ -11277,13 +11451,14 @@ UpdateFilePolicyError_validator = bv.Union(UpdateFilePolicyError)
 
 class UpdateFolderMemberArg(bb.Struct):
     """
-    :ivar sharing.UpdateFolderMemberArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.UpdateFolderMemberArg.member: The member of the shared folder
-        to update.  Only the ``MemberSelector.dropbox_id`` may be set at this
-        time.
-    :ivar sharing.UpdateFolderMemberArg.access_level: The new access level for
-        ``member``. ``AccessLevel.owner`` is disallowed.
+    :ivar UpdateFolderMemberArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar UpdateFolderMemberArg.member:
+        The member of the shared folder to update.  Only the
+        ``MemberSelector.dropbox_id`` may be set at this time.
+    :ivar UpdateFolderMemberArg.access_level:
+        The new access level for ``member``. ``AccessLevel.owner`` is
+        disallowed.
     """
 
     __slots__ = [
@@ -11328,15 +11503,16 @@ class UpdateFolderMemberError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar AddFolderMemberError UpdateFolderMemberError.no_explicit_access: If
-        updating the access type required the member to be added to the shared
-        folder and there was an error when adding the member.
-    :ivar sharing.UpdateFolderMemberError.insufficient_plan: The current user's
-        account doesn't support this action. An example of this is when
-        downgrading a member from editor to viewer. This action can only be
-        performed by users that have upgraded to a Pro or Business plan.
-    :ivar sharing.UpdateFolderMemberError.no_permission: The current user does
-        not have permission to perform this action.
+    :ivar UpdateFolderMemberError.no_explicit_access:
+        If updating the access type required the member to be added to the
+        shared folder and there was an error when adding the member.
+    :vartype UpdateFolderMemberError.no_explicit_access: AddFolderMemberError
+    :ivar UpdateFolderMemberError.insufficient_plan:
+        The current user's account doesn't support this action. An example of
+        this is when downgrading a member from editor to viewer. This action can
+        only be performed by users that have upgraded to a Pro or Business plan.
+    :ivar UpdateFolderMemberError.no_permission:
+        The current user does not have permission to perform this action.
     """
 
     _catch_all = 'other'
@@ -11470,24 +11646,26 @@ class UpdateFolderPolicyArg(bb.Struct):
     """
     If any of the policies are unset, then they retain their current setting.
 
-    :ivar sharing.UpdateFolderPolicyArg.shared_folder_id: The ID for the shared
-        folder.
-    :ivar sharing.UpdateFolderPolicyArg.member_policy: Who can be a member of
-        this shared folder. Only applicable if the current user is on a team.
-    :ivar sharing.UpdateFolderPolicyArg.acl_update_policy: Who can add and
-        remove members of this shared folder.
-    :ivar sharing.UpdateFolderPolicyArg.viewer_info_policy: Who can
-        enable/disable viewer info for this shared folder.
-    :ivar sharing.UpdateFolderPolicyArg.shared_link_policy: The policy to apply
-        to shared links created for content inside this shared folder. The
-        current user must be on a team to set this policy to
+    :ivar UpdateFolderPolicyArg.shared_folder_id:
+        The ID for the shared folder.
+    :ivar UpdateFolderPolicyArg.member_policy:
+        Who can be a member of this shared folder. Only applicable if the
+        current user is on a team.
+    :ivar UpdateFolderPolicyArg.acl_update_policy:
+        Who can add and remove members of this shared folder.
+    :ivar UpdateFolderPolicyArg.viewer_info_policy:
+        Who can enable/disable viewer info for this shared folder.
+    :ivar UpdateFolderPolicyArg.shared_link_policy:
+        The policy to apply to shared links created for content inside this
+        shared folder. The current user must be on a team to set this policy to
         ``SharedLinkPolicy.members``.
-    :ivar sharing.UpdateFolderPolicyArg.link_settings: Settings on the link for
-        this folder.
-    :ivar sharing.UpdateFolderPolicyArg.actions: A list of `FolderAction`s
-        corresponding to `FolderPermission`s that should appear in the
-        response's ``SharedFolderMetadata.permissions`` field describing the
-        actions the authenticated user can perform on the folder.
+    :ivar UpdateFolderPolicyArg.link_settings:
+        Settings on the link for this folder.
+    :ivar UpdateFolderPolicyArg.actions:
+        A list of `FolderAction`s corresponding to `FolderPermission`s that
+        should appear in the response's ``SharedFolderMetadata.permissions``
+        field describing the actions the authenticated user can perform on the
+        folder.
     """
 
     __slots__ = [
@@ -11564,19 +11742,19 @@ class UpdateFolderPolicyError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.UpdateFolderPolicyError.not_on_team:
+    :ivar UpdateFolderPolicyError.not_on_team:
         ``UpdateFolderPolicyArg.member_policy`` was set even though user is not
         on a team.
-    :ivar sharing.UpdateFolderPolicyError.team_policy_disallows_member_policy:
+    :ivar UpdateFolderPolicyError.team_policy_disallows_member_policy:
         Team policy or group sharing settings are more restrictive than
         ``ShareFolderArg.member_policy``.
-    :ivar sharing.UpdateFolderPolicyError.disallowed_shared_link_policy: The
-        current account is not allowed to select the specified
+    :ivar UpdateFolderPolicyError.disallowed_shared_link_policy:
+        The current account is not allowed to select the specified
         ``ShareFolderArg.shared_link_policy``.
-    :ivar sharing.UpdateFolderPolicyError.no_permission: The current user does
-        not have permission to perform this action.
-    :ivar sharing.UpdateFolderPolicyError.team_folder: This action cannot be
-        performed on a team shared folder.
+    :ivar UpdateFolderPolicyError.no_permission:
+        The current user does not have permission to perform this action.
+    :ivar UpdateFolderPolicyError.team_folder:
+        This action cannot be performed on a team shared folder.
     """
 
     _catch_all = 'other'
@@ -11679,8 +11857,8 @@ class UserMembershipInfo(MembershipInfo):
     """
     The information about a user member of the shared content.
 
-    :ivar sharing.UserMembershipInfo.user: The account information for the
-        membership user.
+    :ivar UserMembershipInfo.user:
+        The account information for the membership user.
     """
 
     __slots__ = [
@@ -11716,11 +11894,12 @@ class UserFileMembershipInfo(UserMembershipInfo):
     The information about a user member of the shared content with an appended
     last seen timestamp.
 
-    :ivar sharing.UserFileMembershipInfo.time_last_seen: The UTC timestamp of
-        when the user has last seen the content. Only populated if the user has
-        seen the content and the caller has a plan that includes viewer history.
-    :ivar sharing.UserFileMembershipInfo.platform_type: The platform on which
-        the user has last seen the content, or unknown.
+    :ivar UserFileMembershipInfo.time_last_seen:
+        The UTC timestamp of when the user has last seen the content. Only
+        populated if the user has seen the content and the caller has a plan
+        that includes viewer history.
+    :ivar UserFileMembershipInfo.platform_type:
+        The platform on which the user has last seen the content, or unknown.
     """
 
     __slots__ = [
@@ -11768,13 +11947,17 @@ class UserInfo(bb.Struct):
     :meth:`dropbox.dropbox_client.Dropbox.sharing_users_account_batch` to obtain
     more detailed information.
 
-    :ivar sharing.UserInfo.account_id: The account ID of the user.
-    :ivar sharing.UserInfo.email: Email address of user.
-    :ivar sharing.UserInfo.display_name: The display name of the user.
-    :ivar sharing.UserInfo.same_team: If the user is in the same team as current
-        user.
-    :ivar sharing.UserInfo.team_member_id: The team member ID of the shared
-        folder member. Only present if ``same_team`` is true.
+    :ivar UserInfo.account_id:
+        The account ID of the user.
+    :ivar UserInfo.email:
+        Email address of user.
+    :ivar UserInfo.display_name:
+        The display name of the user.
+    :ivar UserInfo.same_team:
+        If the user is in the same team as current user.
+    :ivar UserInfo.team_member_id:
+        The team member ID of the shared folder member. Only present if
+        ``same_team`` is true.
     """
 
     __slots__ = [
@@ -11835,10 +12018,10 @@ class ViewerInfoPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.ViewerInfoPolicy.enabled: Viewer information is available on
-        this file.
-    :ivar sharing.ViewerInfoPolicy.disabled: Viewer information is disabled on
-        this file.
+    :ivar ViewerInfoPolicy.enabled:
+        Viewer information is available on this file.
+    :ivar ViewerInfoPolicy.disabled:
+        Viewer information is disabled on this file.
     """
 
     _catch_all = 'other'
@@ -11888,17 +12071,19 @@ class Visibility(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar sharing.Visibility.public: Anyone who has received the link can access
-        it. No login required.
-    :ivar sharing.Visibility.team_only: Only members of the same team can access
-        the link. Login is required.
-    :ivar sharing.Visibility.password: A link-specific password is required to
-        access the link. Login is not required.
-    :ivar sharing.Visibility.team_and_password: Only members of the same team
-        who have the link-specific password can access the link.
-    :ivar sharing.Visibility.shared_folder_only: Only members of the shared
-        folder containing the linked file can access the link. Login is
+    :ivar Visibility.public:
+        Anyone who has received the link can access it. No login required.
+    :ivar Visibility.team_only:
+        Only members of the same team can access the link. Login is required.
+    :ivar Visibility.password:
+        A link-specific password is required to access the link. Login is not
         required.
+    :ivar Visibility.team_and_password:
+        Only members of the same team who have the link-specific password can
+        access the link.
+    :ivar Visibility.shared_folder_only:
+        Only members of the shared folder containing the linked file can access
+        the link. Login is required.
     """
 
     _catch_all = 'other'
@@ -11970,17 +12155,18 @@ Visibility_validator = bv.Union(Visibility)
 
 class VisibilityPolicy(bb.Struct):
     """
-    :ivar sharing.VisibilityPolicy.policy: This is the value to submit when
-        saving the visibility setting.
-    :ivar sharing.VisibilityPolicy.resolved_policy: This is what the effective
-        policy would be, if you selected this option. The resolved policy is
-        obtained after considering external effects such as shared folder
-        settings and team policy. This value is guaranteed to be provided.
-    :ivar sharing.VisibilityPolicy.allowed: Whether the user is permitted to set
-        the visibility to this policy.
-    :ivar sharing.VisibilityPolicy.disallowed_reason: If ``allowed`` is
-        ``False``, this will provide the reason that the user is not permitted
-        to set the visibility to this policy.
+    :ivar VisibilityPolicy.policy:
+        This is the value to submit when saving the visibility setting.
+    :ivar VisibilityPolicy.resolved_policy:
+        This is what the effective policy would be, if you selected this option.
+        The resolved policy is obtained after considering external effects such
+        as shared folder settings and team policy. This value is guaranteed to
+        be provided.
+    :ivar VisibilityPolicy.allowed:
+        Whether the user is permitted to set the visibility to this policy.
+    :ivar VisibilityPolicy.disallowed_reason:
+        If ``allowed`` is ``False``, this will provide the reason that the user
+        is not permitted to set the visibility to this policy.
     """
 
     __slots__ = [

--- a/dropbox/team.py
+++ b/dropbox/team.py
@@ -20,14 +20,16 @@ from dropbox import users_common
 
 class DeviceSession(bb.Struct):
     """
-    :ivar team.DeviceSession.session_id: The session id.
-    :ivar team.DeviceSession.ip_address: The IP address of the last activity
-        from this session.
-    :ivar team.DeviceSession.country: The country from which the last activity
-        from this session was made.
-    :ivar team.DeviceSession.created: The time this session was created.
-    :ivar team.DeviceSession.updated: The time of the last activity from this
-        session.
+    :ivar DeviceSession.session_id:
+        The session id.
+    :ivar DeviceSession.ip_address:
+        The IP address of the last activity from this session.
+    :ivar DeviceSession.country:
+        The country from which the last activity from this session was made.
+    :ivar DeviceSession.created:
+        The time this session was created.
+    :ivar DeviceSession.updated:
+        The time of the last activity from this session.
     """
 
     __slots__ = [
@@ -86,11 +88,14 @@ class ActiveWebSession(DeviceSession):
     """
     Information on active web sessions.
 
-    :ivar team.ActiveWebSession.user_agent: Information on the hosting device.
-    :ivar team.ActiveWebSession.os: Information on the hosting operating system.
-    :ivar team.ActiveWebSession.browser: Information on the browser used for
-        this web session.
-    :ivar team.ActiveWebSession.expires: The time this session expires.
+    :ivar ActiveWebSession.user_agent:
+        Information on the hosting device.
+    :ivar ActiveWebSession.os:
+        Information on the hosting operating system.
+    :ivar ActiveWebSession.browser:
+        Information on the browser used for this web session.
+    :ivar ActiveWebSession.expires:
+        The time this session expires.
     """
 
     __slots__ = [
@@ -158,24 +163,34 @@ class AddSecondaryEmailResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SecondaryEmail AddSecondaryEmailResult.success: Describes a secondary
-        email that was successfully added to a user.
-    :ivar str team.AddSecondaryEmailResult.unavailable: Secondary email is not
-        available to be claimed by the user.
-    :ivar str team.AddSecondaryEmailResult.already_pending: Secondary email is
-        already a pending email for the user.
-    :ivar str team.AddSecondaryEmailResult.already_owned_by_user: Secondary
-        email is already a verified email for the user.
-    :ivar str team.AddSecondaryEmailResult.reached_limit: User already has the
-        maximum number of secondary emails allowed.
-    :ivar str team.AddSecondaryEmailResult.transient_error: Field is deprecated.
-        A transient error occurred. Please try again later.
-    :ivar str team.AddSecondaryEmailResult.too_many_updates: An error occurred
-        due to conflicting updates. Please try again later.
-    :ivar str team.AddSecondaryEmailResult.unknown_error: An unknown error
-        occurred.
-    :ivar str team.AddSecondaryEmailResult.rate_limited: Too many emails are
-        being sent to this email address. Please try again later.
+    :ivar AddSecondaryEmailResult.success:
+        Describes a secondary email that was successfully added to a user.
+    :vartype AddSecondaryEmailResult.success: secondary_emails.SecondaryEmail
+    :ivar AddSecondaryEmailResult.unavailable:
+        Secondary email is not available to be claimed by the user.
+    :vartype AddSecondaryEmailResult.unavailable: str
+    :ivar AddSecondaryEmailResult.already_pending:
+        Secondary email is already a pending email for the user.
+    :vartype AddSecondaryEmailResult.already_pending: str
+    :ivar AddSecondaryEmailResult.already_owned_by_user:
+        Secondary email is already a verified email for the user.
+    :vartype AddSecondaryEmailResult.already_owned_by_user: str
+    :ivar AddSecondaryEmailResult.reached_limit:
+        User already has the maximum number of secondary emails allowed.
+    :vartype AddSecondaryEmailResult.reached_limit: str
+    :ivar AddSecondaryEmailResult.transient_error:
+        Field is deprecated. A transient error occurred. Please try again later.
+    :vartype AddSecondaryEmailResult.transient_error: str
+    :ivar AddSecondaryEmailResult.too_many_updates:
+        An error occurred due to conflicting updates. Please try again later.
+    :vartype AddSecondaryEmailResult.too_many_updates: str
+    :ivar AddSecondaryEmailResult.unknown_error:
+        An unknown error occurred.
+    :vartype AddSecondaryEmailResult.unknown_error: str
+    :ivar AddSecondaryEmailResult.rate_limited:
+        Too many emails are being sent to this email address. Please try again
+        later.
+    :vartype AddSecondaryEmailResult.rate_limited: str
     """
 
     _catch_all = 'other'
@@ -477,8 +492,8 @@ AddSecondaryEmailResult_validator = bv.Union(AddSecondaryEmailResult)
 
 class AddSecondaryEmailsArg(bb.Struct):
     """
-    :ivar team.AddSecondaryEmailsArg.new_secondary_emails: List of users and
-        secondary emails to add.
+    :ivar AddSecondaryEmailsArg.new_secondary_emails:
+        List of users and secondary emails to add.
     """
 
     __slots__ = [
@@ -509,10 +524,10 @@ class AddSecondaryEmailsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.AddSecondaryEmailsError.secondary_emails_disabled: Secondary
-        emails are disabled for the team.
-    :ivar team.AddSecondaryEmailsError.too_many_emails: A maximum of 20
-        secondary emails can be added in a single call.
+    :ivar AddSecondaryEmailsError.secondary_emails_disabled:
+        Secondary emails are disabled for the team.
+    :ivar AddSecondaryEmailsError.too_many_emails:
+        A maximum of 20 secondary emails can be added in a single call.
     """
 
     _catch_all = 'other'
@@ -554,8 +569,8 @@ AddSecondaryEmailsError_validator = bv.Union(AddSecondaryEmailsError)
 
 class AddSecondaryEmailsResult(bb.Struct):
     """
-    :ivar team.AddSecondaryEmailsResult.results: List of users and secondary
-        email results.
+    :ivar AddSecondaryEmailsResult.results:
+        List of users and secondary email results.
     """
 
     __slots__ = [
@@ -586,14 +601,16 @@ class AdminTier(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.AdminTier.team_admin: User is an administrator of the team - has
-        all permissions.
-    :ivar team.AdminTier.user_management_admin: User can do most user
-        provisioning, de-provisioning and management.
-    :ivar team.AdminTier.support_admin: User can do a limited set of common
-        support tasks for existing users. Note: Dropbox is adding new types of
-        admin roles; these may display as support_admin.
-    :ivar team.AdminTier.member_only: User is not an admin of the team.
+    :ivar AdminTier.team_admin:
+        User is an administrator of the team - has all permissions.
+    :ivar AdminTier.user_management_admin:
+        User can do most user provisioning, de-provisioning and management.
+    :ivar AdminTier.support_admin:
+        User can do a limited set of common support tasks for existing users.
+        Note: Dropbox is adding new types of admin roles; these may display as
+        support_admin.
+    :ivar AdminTier.member_only:
+        User is not an admin of the team.
     """
 
     _catch_all = None
@@ -647,13 +664,18 @@ class ApiApp(bb.Struct):
     """
     Information on linked third party applications.
 
-    :ivar team.ApiApp.app_id: The application unique id.
-    :ivar team.ApiApp.app_name: The application name.
-    :ivar team.ApiApp.publisher: The application publisher name.
-    :ivar team.ApiApp.publisher_url: The publisher's URL.
-    :ivar team.ApiApp.linked: The time this application was linked.
-    :ivar team.ApiApp.is_app_folder: Whether the linked application uses a
-        dedicated folder.
+    :ivar ApiApp.app_id:
+        The application unique id.
+    :ivar ApiApp.app_name:
+        The application name.
+    :ivar ApiApp.publisher:
+        The application publisher name.
+    :ivar ApiApp.publisher_url:
+        The publisher's URL.
+    :ivar ApiApp.linked:
+        The time this application was linked.
+    :ivar ApiApp.is_app_folder:
+        Whether the linked application uses a dedicated folder.
     """
 
     __slots__ = [
@@ -720,8 +742,8 @@ class BaseDfbReport(bb.Struct):
     """
     Base report structure.
 
-    :ivar team.BaseDfbReport.start_date: First date present in the results as
-        'YYYY-MM-DD' or None.
+    :ivar BaseDfbReport.start_date:
+        First date present in the results as 'YYYY-MM-DD' or None.
     """
 
     __slots__ = [
@@ -865,8 +887,8 @@ class CustomQuotaError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.CustomQuotaError.too_many_users: A maximum of 1000 users can be
-        set for a single call.
+    :ivar CustomQuotaError.too_many_users:
+        A maximum of 1000 users can be set for a single call.
     """
 
     _catch_all = 'other'
@@ -904,9 +926,12 @@ class CustomQuotaResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserCustomQuotaResult CustomQuotaResult.success: User's custom quota.
-    :ivar UserSelectorArg CustomQuotaResult.invalid_user: Invalid user (not in
-        team).
+    :ivar CustomQuotaResult.success:
+        User's custom quota.
+    :vartype CustomQuotaResult.success: UserCustomQuotaResult
+    :ivar CustomQuotaResult.invalid_user:
+        Invalid user (not in team).
+    :vartype CustomQuotaResult.invalid_user: UserSelectorArg
     """
 
     _catch_all = 'other'
@@ -990,7 +1015,8 @@ CustomQuotaResult_validator = bv.Union(CustomQuotaResult)
 
 class CustomQuotaUsersArg(bb.Struct):
     """
-    :ivar team.CustomQuotaUsersArg.users: List of users.
+    :ivar CustomQuotaUsersArg.users:
+        List of users.
     """
 
     __slots__ = [
@@ -1017,10 +1043,11 @@ class DateRange(bb.Struct):
     """
     Input arguments that can be provided for most reports.
 
-    :ivar team.DateRange.start_date: Optional starting date (inclusive). If
-        start_date is None or too long ago, this field will be set to 6 months
-        ago.
-    :ivar team.DateRange.end_date: Optional ending date (exclusive).
+    :ivar DateRange.start_date:
+        Optional starting date (inclusive). If start_date is None or too long
+        ago, this field will be set to 6 months ago.
+    :ivar DateRange.end_date:
+        Optional ending date (exclusive).
     """
 
     __slots__ = [
@@ -1088,12 +1115,16 @@ class DeleteSecondaryEmailResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.DeleteSecondaryEmailResult.success: The secondary email was
-        successfully deleted.
-    :ivar str team.DeleteSecondaryEmailResult.not_found: The email address was
-        not found for the user.
-    :ivar str team.DeleteSecondaryEmailResult.cannot_remove_primary: The email
-        address is the primary email address of the user, and cannot be removed.
+    :ivar DeleteSecondaryEmailResult.success:
+        The secondary email was successfully deleted.
+    :vartype DeleteSecondaryEmailResult.success: str
+    :ivar DeleteSecondaryEmailResult.not_found:
+        The email address was not found for the user.
+    :vartype DeleteSecondaryEmailResult.not_found: str
+    :ivar DeleteSecondaryEmailResult.cannot_remove_primary:
+        The email address is the primary email address of the user, and cannot
+        be removed.
+    :vartype DeleteSecondaryEmailResult.cannot_remove_primary: str
     """
 
     _catch_all = 'other'
@@ -1209,8 +1240,8 @@ DeleteSecondaryEmailResult_validator = bv.Union(DeleteSecondaryEmailResult)
 
 class DeleteSecondaryEmailsArg(bb.Struct):
     """
-    :ivar team.DeleteSecondaryEmailsArg.emails_to_delete: List of users and
-        their secondary emails to delete.
+    :ivar DeleteSecondaryEmailsArg.emails_to_delete:
+        List of users and their secondary emails to delete.
     """
 
     __slots__ = [
@@ -1259,14 +1290,16 @@ class DesktopClientSession(DeviceSession):
     """
     Information about linked Dropbox desktop client sessions.
 
-    :ivar team.DesktopClientSession.host_name: Name of the hosting desktop.
-    :ivar team.DesktopClientSession.client_type: The Dropbox desktop client
-        type.
-    :ivar team.DesktopClientSession.client_version: The Dropbox client version.
-    :ivar team.DesktopClientSession.platform: Information on the hosting
-        platform.
-    :ivar team.DesktopClientSession.is_delete_on_unlink_supported: Whether it's
-        possible to delete all of the account files upon unlinking.
+    :ivar DesktopClientSession.host_name:
+        Name of the hosting desktop.
+    :ivar DesktopClientSession.client_type:
+        The Dropbox desktop client type.
+    :ivar DesktopClientSession.client_version:
+        The Dropbox client version.
+    :ivar DesktopClientSession.platform:
+        Information on the hosting platform.
+    :ivar DesktopClientSession.is_delete_on_unlink_supported:
+        Whether it's possible to delete all of the account files upon unlinking.
     """
 
     __slots__ = [
@@ -1337,9 +1370,12 @@ class DesktopPlatform(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.DesktopPlatform.windows: Official Windows Dropbox desktop client.
-    :ivar team.DesktopPlatform.mac: Official Mac Dropbox desktop client.
-    :ivar team.DesktopPlatform.linux: Official Linux Dropbox desktop client.
+    :ivar DesktopPlatform.windows:
+        Official Windows Dropbox desktop client.
+    :ivar DesktopPlatform.mac:
+        Official Mac Dropbox desktop client.
+    :ivar DesktopPlatform.linux:
+        Official Linux Dropbox desktop client.
     """
 
     _catch_all = 'other'
@@ -1391,9 +1427,10 @@ DesktopPlatform_validator = bv.Union(DesktopPlatform)
 
 class DeviceSessionArg(bb.Struct):
     """
-    :ivar team.DeviceSessionArg.session_id: The session id.
-    :ivar team.DeviceSessionArg.team_member_id: The unique id of the member
-        owning the device.
+    :ivar DeviceSessionArg.session_id:
+        The session id.
+    :ivar DeviceSessionArg.team_member_id:
+        The unique id of the member owning the device.
     """
 
     __slots__ = [
@@ -1430,20 +1467,21 @@ class DevicesActive(bb.Struct):
     number of devices active within a time window, ending with that day. If
     there is no data for a day, then the value will be None.
 
-    :ivar team.DevicesActive.windows: Array of number of linked windows
-        (desktop) clients with activity.
-    :ivar team.DevicesActive.macos: Array of number of linked mac (desktop)
-        clients with activity.
-    :ivar team.DevicesActive.linux: Array of number of linked linus (desktop)
-        clients with activity.
-    :ivar team.DevicesActive.ios: Array of number of linked ios devices with
-        activity.
-    :ivar team.DevicesActive.android: Array of number of linked android devices
+    :ivar DevicesActive.windows:
+        Array of number of linked windows (desktop) clients with activity.
+    :ivar DevicesActive.macos:
+        Array of number of linked mac (desktop) clients with activity.
+    :ivar DevicesActive.linux:
+        Array of number of linked linus (desktop) clients with activity.
+    :ivar DevicesActive.ios:
+        Array of number of linked ios devices with activity.
+    :ivar DevicesActive.android:
+        Array of number of linked android devices with activity.
+    :ivar DevicesActive.other:
+        Array of number of other linked devices (blackberry, windows phone, etc)
         with activity.
-    :ivar team.DevicesActive.other: Array of number of other linked devices
-        (blackberry, windows phone, etc) with activity.
-    :ivar team.DevicesActive.total: Array of total number of linked clients with
-        activity.
+    :ivar DevicesActive.total:
+        Array of total number of linked clients with activity.
     """
 
     __slots__ = [
@@ -1518,7 +1556,8 @@ class ExcludedUsersListArg(bb.Struct):
     """
     Excluded users list argument.
 
-    :ivar team.ExcludedUsersListArg.limit: Number of results to return per call.
+    :ivar ExcludedUsersListArg.limit:
+        Number of results to return per call.
     """
 
     __slots__ = [
@@ -1545,8 +1584,8 @@ class ExcludedUsersListContinueArg(bb.Struct):
     """
     Excluded users list continue argument.
 
-    :ivar team.ExcludedUsersListContinueArg.cursor: Indicates from what point to
-        get the next set of users.
+    :ivar ExcludedUsersListContinueArg.cursor:
+        Indicates from what point to get the next set of users.
     """
 
     __slots__ = [
@@ -1577,8 +1616,8 @@ class ExcludedUsersListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ExcludedUsersListContinueError.invalid_cursor: The cursor is
-        invalid.
+    :ivar ExcludedUsersListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     _catch_all = 'other'
@@ -1616,7 +1655,8 @@ class ExcludedUsersListError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ExcludedUsersListError.list_error: An error occurred.
+    :ivar ExcludedUsersListError.list_error:
+        An error occurred.
     """
 
     _catch_all = 'other'
@@ -1650,11 +1690,13 @@ class ExcludedUsersListResult(bb.Struct):
     """
     Excluded users list result.
 
-    :ivar team.ExcludedUsersListResult.cursor: Pass the cursor into
+    :ivar ExcludedUsersListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_member_space_limits_excluded_users_list_continue`
         to obtain additional excluded users.
-    :ivar team.ExcludedUsersListResult.has_more: Is true if there are additional
-        excluded users that have not been returned yet. An additional call to
+    :ivar ExcludedUsersListResult.has_more:
+        Is true if there are additional excluded users that have not been
+        returned yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_member_space_limits_excluded_users_list_continue`
         can retrieve them.
     """
@@ -1701,7 +1743,8 @@ class ExcludedUsersUpdateArg(bb.Struct):
     to add/remove (according to endpoint), Maximum size of the list is 1000
     users.
 
-    :ivar team.ExcludedUsersUpdateArg.users: List of users to be added/removed.
+    :ivar ExcludedUsersUpdateArg.users:
+        List of users to be added/removed.
     """
 
     __slots__ = [
@@ -1732,10 +1775,10 @@ class ExcludedUsersUpdateError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ExcludedUsersUpdateError.users_not_in_team: At least one of the
-        users is not part of your team.
-    :ivar team.ExcludedUsersUpdateError.too_many_users: A maximum of 1000 users
-        for each of addition/removal can be supplied.
+    :ivar ExcludedUsersUpdateError.users_not_in_team:
+        At least one of the users is not part of your team.
+    :ivar ExcludedUsersUpdateError.too_many_users:
+        A maximum of 1000 users for each of addition/removal can be supplied.
     """
 
     _catch_all = 'other'
@@ -1779,7 +1822,8 @@ class ExcludedUsersUpdateResult(bb.Struct):
     """
     Excluded users update result.
 
-    :ivar team.ExcludedUsersUpdateResult.status: Update status.
+    :ivar ExcludedUsersUpdateResult.status:
+        Update status.
     """
 
     __slots__ = [
@@ -1810,7 +1854,8 @@ class ExcludedUsersUpdateStatus(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ExcludedUsersUpdateStatus.success: Update successful.
+    :ivar ExcludedUsersUpdateStatus.success:
+        Update successful.
     """
 
     _catch_all = 'other'
@@ -1848,15 +1893,16 @@ class Feature(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.Feature.upload_api_rate_limit: The number of upload API calls
-        allowed per month.
-    :ivar team.Feature.has_team_shared_dropbox: Does this team have a shared
-        team root.
-    :ivar team.Feature.has_team_file_events: Does this team have file events.
-    :ivar team.Feature.has_team_selective_sync: Does this team have team
-        selective sync enabled.
-    :ivar team.Feature.has_distinct_member_homes: Does this team have team
-        member folder.
+    :ivar Feature.upload_api_rate_limit:
+        The number of upload API calls allowed per month.
+    :ivar Feature.has_team_shared_dropbox:
+        Does this team have a shared team root.
+    :ivar Feature.has_team_file_events:
+        Does this team have file events.
+    :ivar Feature.has_team_selective_sync:
+        Does this team have team selective sync enabled.
+    :ivar Feature.has_distinct_member_homes:
+        Does this team have team member folder.
     """
 
     _catch_all = 'other'
@@ -2100,9 +2146,9 @@ FeatureValue_validator = bv.Union(FeatureValue)
 
 class FeaturesGetValuesBatchArg(bb.Struct):
     """
-    :ivar team.FeaturesGetValuesBatchArg.features: A list of features in
-        :class:`Feature`. If the list is empty, this route will return
-        :class:`FeaturesGetValuesBatchError`.
+    :ivar FeaturesGetValuesBatchArg.features:
+        A list of features in :class:`Feature`. If the list is empty, this route
+        will return :class:`FeaturesGetValuesBatchError`.
     """
 
     __slots__ = [
@@ -2131,8 +2177,8 @@ class FeaturesGetValuesBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.FeaturesGetValuesBatchError.empty_features_list: At least one
-        :class:`Feature` must be included in the
+    :ivar FeaturesGetValuesBatchError.empty_features_list:
+        At least one :class:`Feature` must be included in the
         :class:`FeaturesGetValuesBatchArg`.features list.
     """
 
@@ -2191,37 +2237,41 @@ class GetActivityReport(BaseDfbReport):
     of values, one value per day. If there is no data for a day, then the value
     will be None.
 
-    :ivar team.GetActivityReport.adds: Array of total number of adds by team
-        members.
-    :ivar team.GetActivityReport.edits: Array of number of edits by team
-        members. If the same user edits the same file multiple times this is
-        counted as a single edit.
-    :ivar team.GetActivityReport.deletes: Array of total number of deletes by
-        team members.
-    :ivar team.GetActivityReport.active_users_28_day: Array of the number of
-        users who have been active in the last 28 days.
-    :ivar team.GetActivityReport.active_users_7_day: Array of the number of
-        users who have been active in the last week.
-    :ivar team.GetActivityReport.active_users_1_day: Array of the number of
-        users who have been active in the last day.
-    :ivar team.GetActivityReport.active_shared_folders_28_day: Array of the
-        number of shared folders with some activity in the last 28 days.
-    :ivar team.GetActivityReport.active_shared_folders_7_day: Array of the
-        number of shared folders with some activity in the last week.
-    :ivar team.GetActivityReport.active_shared_folders_1_day: Array of the
-        number of shared folders with some activity in the last day.
-    :ivar team.GetActivityReport.shared_links_created: Array of the number of
-        shared links created.
-    :ivar team.GetActivityReport.shared_links_viewed_by_team: Array of the
-        number of views by team users to shared links created by the team.
-    :ivar team.GetActivityReport.shared_links_viewed_by_outside_user: Array of
-        the number of views by users outside of the team to shared links created
-        by the team.
-    :ivar team.GetActivityReport.shared_links_viewed_by_not_logged_in: Array of
-        the number of views by non-logged-in users to shared links created by
+    :ivar GetActivityReport.adds:
+        Array of total number of adds by team members.
+    :ivar GetActivityReport.edits:
+        Array of number of edits by team members. If the same user edits the
+        same file multiple times this is counted as a single edit.
+    :ivar GetActivityReport.deletes:
+        Array of total number of deletes by team members.
+    :ivar GetActivityReport.active_users_28_day:
+        Array of the number of users who have been active in the last 28 days.
+    :ivar GetActivityReport.active_users_7_day:
+        Array of the number of users who have been active in the last week.
+    :ivar GetActivityReport.active_users_1_day:
+        Array of the number of users who have been active in the last day.
+    :ivar GetActivityReport.active_shared_folders_28_day:
+        Array of the number of shared folders with some activity in the last 28
+        days.
+    :ivar GetActivityReport.active_shared_folders_7_day:
+        Array of the number of shared folders with some activity in the last
+        week.
+    :ivar GetActivityReport.active_shared_folders_1_day:
+        Array of the number of shared folders with some activity in the last
+        day.
+    :ivar GetActivityReport.shared_links_created:
+        Array of the number of shared links created.
+    :ivar GetActivityReport.shared_links_viewed_by_team:
+        Array of the number of views by team users to shared links created by
         the team.
-    :ivar team.GetActivityReport.shared_links_viewed_total: Array of the total
-        number of views to shared links created by the team.
+    :ivar GetActivityReport.shared_links_viewed_by_outside_user:
+        Array of the number of views by users outside of the team to shared
+        links created by the team.
+    :ivar GetActivityReport.shared_links_viewed_by_not_logged_in:
+        Array of the number of views by non-logged-in users to shared links
+        created by the team.
+    :ivar GetActivityReport.shared_links_viewed_total:
+        Array of the total number of views to shared links created by the team.
     """
 
     __slots__ = [
@@ -2357,12 +2407,12 @@ class GetDevicesReport(BaseDfbReport):
     array of values, one value per day. If there is no data for a day, then the
     value will be None.
 
-    :ivar team.GetDevicesReport.active_1_day: Report of the number of devices
-        active in the last day.
-    :ivar team.GetDevicesReport.active_7_day: Report of the number of devices
-        active in the last 7 days.
-    :ivar team.GetDevicesReport.active_28_day: Report of the number of devices
-        active in the last 28 days.
+    :ivar GetDevicesReport.active_1_day:
+        Report of the number of devices active in the last day.
+    :ivar GetDevicesReport.active_7_day:
+        Report of the number of devices active in the last 7 days.
+    :ivar GetDevicesReport.active_28_day:
+        Report of the number of devices active in the last 28 days.
     """
 
     __slots__ = [
@@ -2409,15 +2459,16 @@ class GetMembershipReport(BaseDfbReport):
     array of values, one value per day. If there is no data for a day, then the
     value will be None.
 
-    :ivar team.GetMembershipReport.team_size: Team size, for each day.
-    :ivar team.GetMembershipReport.pending_invites: The number of pending
-        invites to the team, for each day.
-    :ivar team.GetMembershipReport.members_joined: The number of members that
-        joined the team, for each day.
-    :ivar team.GetMembershipReport.suspended_members: The number of suspended
-        team members, for each day.
-    :ivar team.GetMembershipReport.licenses: The total number of licenses the
-        team has, for each day.
+    :ivar GetMembershipReport.team_size:
+        Team size, for each day.
+    :ivar GetMembershipReport.pending_invites:
+        The number of pending invites to the team, for each day.
+    :ivar GetMembershipReport.members_joined:
+        The number of members that joined the team, for each day.
+    :ivar GetMembershipReport.suspended_members:
+        The number of suspended team members, for each day.
+    :ivar GetMembershipReport.licenses:
+        The total number of licenses the team has, for each day.
     """
 
     __slots__ = [
@@ -2480,20 +2531,24 @@ class GetStorageReport(BaseDfbReport):
     of values, one value per day. If there is no data for a day, then the value
     will be None.
 
-    :ivar team.GetStorageReport.total_usage: Sum of the shared, unshared, and
-        datastore usages, for each day.
-    :ivar team.GetStorageReport.shared_usage: Array of the combined size (bytes)
-        of team members' shared folders, for each day.
-    :ivar team.GetStorageReport.unshared_usage: Array of the combined size
-        (bytes) of team members' root namespaces, for each day.
-    :ivar team.GetStorageReport.shared_folders: Array of the number of shared
-        folders owned by team members, for each day.
-    :ivar team.GetStorageReport.member_storage_map: Array of storage summaries
-        of team members' account sizes. Each storage summary is an array of key,
-        value pairs, where each pair describes a storage bucket. The key
-        indicates the upper bound of the bucket and the value is the number of
-        users in that bucket. There is one such summary per day. If there is no
-        data for a day, the storage summary will be empty.
+    :ivar GetStorageReport.total_usage:
+        Sum of the shared, unshared, and datastore usages, for each day.
+    :ivar GetStorageReport.shared_usage:
+        Array of the combined size (bytes) of team members' shared folders, for
+        each day.
+    :ivar GetStorageReport.unshared_usage:
+        Array of the combined size (bytes) of team members' root namespaces, for
+        each day.
+    :ivar GetStorageReport.shared_folders:
+        Array of the number of shared folders owned by team members, for each
+        day.
+    :ivar GetStorageReport.member_storage_map:
+        Array of storage summaries of team members' account sizes. Each storage
+        summary is an array of key, value pairs, where each pair describes a
+        storage bucket. The key indicates the upper bound of the bucket and the
+        value is the number of users in that bucket. There is one such summary
+        per day. If there is no data for a day, the storage summary will be
+        empty.
     """
 
     __slots__ = [
@@ -2558,10 +2613,10 @@ class GroupAccessType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupAccessType.member: User is a member of the group, but has no
-        special permissions.
-    :ivar team.GroupAccessType.owner: User can rename the group, and add/remove
-        members.
+    :ivar GroupAccessType.member:
+        User is a member of the group, but has no special permissions.
+    :ivar GroupAccessType.owner:
+        User can rename the group, and add/remove members.
     """
 
     _catch_all = None
@@ -2593,13 +2648,16 @@ GroupAccessType_validator = bv.Union(GroupAccessType)
 
 class GroupCreateArg(bb.Struct):
     """
-    :ivar team.GroupCreateArg.group_name: Group name.
-    :ivar team.GroupCreateArg.add_creator_as_owner: Automatically add the
-        creator of the group.
-    :ivar team.GroupCreateArg.group_external_id: The creator of a team can
-        associate an arbitrary external ID to the group.
-    :ivar team.GroupCreateArg.group_management_type: Whether the team can be
-        managed by selected users, or only by team admins.
+    :ivar GroupCreateArg.group_name:
+        Group name.
+    :ivar GroupCreateArg.add_creator_as_owner:
+        Automatically add the creator of the group.
+    :ivar GroupCreateArg.group_external_id:
+        The creator of a team can associate an arbitrary external ID to the
+        group.
+    :ivar GroupCreateArg.group_management_type:
+        Whether the team can be managed by selected users, or only by team
+        admins.
     """
 
     __slots__ = [
@@ -2652,14 +2710,14 @@ class GroupCreateError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupCreateError.group_name_already_used: The requested group
-        name is already being used by another group.
-    :ivar team.GroupCreateError.group_name_invalid: Group name is empty or has
-        invalid characters.
-    :ivar team.GroupCreateError.external_id_already_in_use: The requested
-        external ID is already being used by another group.
-    :ivar team.GroupCreateError.system_managed_group_disallowed: System-managed
-        group cannot be manually created.
+    :ivar GroupCreateError.group_name_already_used:
+        The requested group name is already being used by another group.
+    :ivar GroupCreateError.group_name_invalid:
+        Group name is empty or has invalid characters.
+    :ivar GroupCreateError.external_id_already_in_use:
+        The requested external ID is already being used by another group.
+    :ivar GroupCreateError.system_managed_group_disallowed:
+        System-managed group cannot be manually created.
     """
 
     _catch_all = 'other'
@@ -2727,8 +2785,8 @@ class GroupSelectorError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupSelectorError.group_not_found: No matching group found. No
-        groups match the specified group ID.
+    :ivar GroupSelectorError.group_not_found:
+        No matching group found. No groups match the specified group ID.
     """
 
     _catch_all = 'other'
@@ -2767,7 +2825,7 @@ class GroupSelectorWithTeamGroupError(GroupSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupSelectorWithTeamGroupError.system_managed_group_disallowed:
+    :ivar GroupSelectorWithTeamGroupError.system_managed_group_disallowed:
         This operation is not supported on system-managed groups.
     """
 
@@ -2793,8 +2851,8 @@ class GroupDeleteError(GroupSelectorWithTeamGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupDeleteError.group_already_deleted: This group has already
-        been deleted.
+    :ivar GroupDeleteError.group_already_deleted:
+        This group has already been deleted.
     """
 
     # Attribute is overwritten below the class definition
@@ -2817,9 +2875,11 @@ class GroupFullInfo(team_common.GroupSummary):
     """
     Full description of a group.
 
-    :ivar team.GroupFullInfo.members: List of group members.
-    :ivar team.GroupFullInfo.created: The group creation time as a UTC timestamp
-        in milliseconds since the Unix epoch.
+    :ivar GroupFullInfo.members:
+        List of group members.
+    :ivar GroupFullInfo.created:
+        The group creation time as a UTC timestamp in milliseconds since the
+        Unix epoch.
     """
 
     __slots__ = [
@@ -2864,9 +2924,10 @@ class GroupMemberInfo(bb.Struct):
     """
     Profile of group member, and role in group.
 
-    :ivar team.GroupMemberInfo.profile: Profile of group member.
-    :ivar team.GroupMemberInfo.access_type: The role that the user has in the
-        group.
+    :ivar GroupMemberInfo.profile:
+        Profile of group member.
+    :ivar GroupMemberInfo.access_type:
+        The role that the user has in the group.
     """
 
     __slots__ = [
@@ -2901,9 +2962,10 @@ class GroupMemberSelector(bb.Struct):
     """
     Argument for selecting a group and a single user.
 
-    :ivar team.GroupMemberSelector.group: Specify a group.
-    :ivar team.GroupMemberSelector.user: Identity of a user that is a member of
-        ``group``.
+    :ivar GroupMemberSelector.group:
+        Specify a group.
+    :ivar GroupMemberSelector.user:
+        Identity of a user that is a member of ``group``.
     """
 
     __slots__ = [
@@ -2943,8 +3005,8 @@ class GroupMemberSelectorError(GroupSelectorWithTeamGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupMemberSelectorError.member_not_in_group: The specified user
-        is not a member of this group.
+    :ivar GroupMemberSelectorError.member_not_in_group:
+        The specified user is not a member of this group.
     """
 
     # Attribute is overwritten below the class definition
@@ -2969,8 +3031,7 @@ class GroupMemberSetAccessTypeError(GroupMemberSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar
-        team.GroupMemberSetAccessTypeError.user_cannot_be_manager_of_company_managed_group:
+    :ivar GroupMemberSetAccessTypeError.user_cannot_be_manager_of_company_managed_group:
         A company managed group cannot be managed by a user.
     """
 
@@ -2992,10 +3053,10 @@ GroupMemberSetAccessTypeError_validator = bv.Union(GroupMemberSetAccessTypeError
 
 class IncludeMembersArg(bb.Struct):
     """
-    :ivar team.IncludeMembersArg.return_members: Whether to return the list of
-        members in the group. Note that the default value will cause all the
-        group members to be returned in the response. This may take a long time
-        for large groups.
+    :ivar IncludeMembersArg.return_members:
+        Whether to return the list of members in the group. Note that the
+        default value will cause all the group members to be returned in the
+        response. This may take a long time for large groups.
     """
 
     __slots__ = [
@@ -3020,9 +3081,10 @@ IncludeMembersArg_validator = bv.Struct(IncludeMembersArg)
 
 class GroupMembersAddArg(IncludeMembersArg):
     """
-    :ivar team.GroupMembersAddArg.group: Group to which users will be added.
-    :ivar team.GroupMembersAddArg.members: List of users to be added to the
-        group.
+    :ivar GroupMembersAddArg.group:
+        Group to which users will be added.
+    :ivar GroupMembersAddArg.members:
+        List of users to be added to the group.
     """
 
     __slots__ = [
@@ -3061,23 +3123,28 @@ class GroupMembersAddError(GroupSelectorWithTeamGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupMembersAddError.duplicate_user: You cannot add duplicate
-        users. One or more of the members you are trying to add is already a
-        member of the group.
-    :ivar team.GroupMembersAddError.group_not_in_team: Group is not in this
-        team. You cannot add members to a group that is outside of your team.
-    :ivar list of [str] team.GroupMembersAddError.members_not_in_team: These
-        members are not part of your team. Currently, you cannot add members to
-        a group if they are not part of your team, though this may change in a
-        subsequent version. To add new members to your Dropbox Business team,
-        use the :route:`members/add` endpoint.
-    :ivar list of [str] team.GroupMembersAddError.users_not_found: These users
-        were not found in Dropbox.
-    :ivar team.GroupMembersAddError.user_must_be_active_to_be_owner: A suspended
-        user cannot be added to a group as ``GroupAccessType.owner``.
-    :ivar list of [str]
-        team.GroupMembersAddError.user_cannot_be_manager_of_company_managed_group:
+    :ivar GroupMembersAddError.duplicate_user:
+        You cannot add duplicate users. One or more of the members you are
+        trying to add is already a member of the group.
+    :ivar GroupMembersAddError.group_not_in_team:
+        Group is not in this team. You cannot add members to a group that is
+        outside of your team.
+    :ivar GroupMembersAddError.members_not_in_team:
+        These members are not part of your team. Currently, you cannot add
+        members to a group if they are not part of your team, though this may
+        change in a subsequent version. To add new members to your Dropbox
+        Business team, use the
+        :meth:`dropbox.dropbox_client.Dropbox.team_members_add` endpoint.
+    :vartype GroupMembersAddError.members_not_in_team: list of [str]
+    :ivar GroupMembersAddError.users_not_found:
+        These users were not found in Dropbox.
+    :vartype GroupMembersAddError.users_not_found: list of [str]
+    :ivar GroupMembersAddError.user_must_be_active_to_be_owner:
+        A suspended user cannot be added to a group as
+        ``GroupAccessType.owner``.
+    :ivar GroupMembersAddError.user_cannot_be_manager_of_company_managed_group:
         A company-managed group cannot be managed by a user.
+    :vartype GroupMembersAddError.user_cannot_be_manager_of_company_managed_group: list of [str]
     """
 
     # Attribute is overwritten below the class definition
@@ -3220,13 +3287,13 @@ class GroupMembersChangeResult(bb.Struct):
     :meth:`dropbox.dropbox_client.Dropbox.team_groups_members_add` and
     :meth:`dropbox.dropbox_client.Dropbox.team_groups_members_remove`.
 
-    :ivar team.GroupMembersChangeResult.group_info: The group info after member
-        change operation has been performed.
-    :ivar team.GroupMembersChangeResult.async_job_id: Field is deprecated. For
-        legacy purposes async_job_id will always return one space ' '. Formerly,
-        it was an ID that was used to obtain the status of granting/revoking
-        group-owned resources. It's no longer necessary because the async
-        processing now happens automatically.
+    :ivar GroupMembersChangeResult.group_info:
+        The group info after member change operation has been performed.
+    :ivar GroupMembersChangeResult.async_job_id:
+        Field is deprecated. For legacy purposes async_job_id will always return
+        one space ' '. Formerly, it was an ID that was used to obtain the status
+        of granting/revoking group-owned resources. It's no longer necessary
+        because the async processing now happens automatically.
     """
 
     __slots__ = [
@@ -3259,10 +3326,10 @@ GroupMembersChangeResult_validator = bv.Struct(GroupMembersChangeResult)
 
 class GroupMembersRemoveArg(IncludeMembersArg):
     """
-    :ivar team.GroupMembersRemoveArg.group: Group from which users will be
-        removed.
-    :ivar team.GroupMembersRemoveArg.users: List of users to be removed from the
-        group.
+    :ivar GroupMembersRemoveArg.group:
+        Group from which users will be removed.
+    :ivar GroupMembersRemoveArg.users:
+        List of users to be removed from the group.
     """
 
     __slots__ = [
@@ -3304,8 +3371,8 @@ class GroupMembersSelectorError(GroupSelectorWithTeamGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupMembersSelectorError.member_not_in_group: At least one of
-        the specified users is not a member of the group.
+    :ivar GroupMembersSelectorError.member_not_in_group:
+        At least one of the specified users is not a member of the group.
     """
 
     # Attribute is overwritten below the class definition
@@ -3330,13 +3397,15 @@ class GroupMembersRemoveError(GroupMembersSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupMembersRemoveError.group_not_in_team: Group is not in this
-        team. You cannot remove members from a group that is outside of your
-        team.
-    :ivar list of [str] team.GroupMembersRemoveError.members_not_in_team: These
-        members are not part of your team.
-    :ivar list of [str] team.GroupMembersRemoveError.users_not_found: These
-        users were not found in Dropbox.
+    :ivar GroupMembersRemoveError.group_not_in_team:
+        Group is not in this team. You cannot remove members from a group that
+        is outside of your team.
+    :ivar GroupMembersRemoveError.members_not_in_team:
+        These members are not part of your team.
+    :vartype GroupMembersRemoveError.members_not_in_team: list of [str]
+    :ivar GroupMembersRemoveError.users_not_found:
+        These users were not found in Dropbox.
+    :vartype GroupMembersRemoveError.users_not_found: list of [str]
     """
 
     # Attribute is overwritten below the class definition
@@ -3421,9 +3490,10 @@ class GroupMembersSelector(bb.Struct):
     """
     Argument for selecting a group and a list of users.
 
-    :ivar team.GroupMembersSelector.group: Specify a group.
-    :ivar team.GroupMembersSelector.users: A list of users that are members of
-        ``group``.
+    :ivar GroupMembersSelector.group:
+        Specify a group.
+    :ivar GroupMembersSelector.users:
+        A list of users that are members of ``group``.
     """
 
     __slots__ = [
@@ -3456,12 +3526,12 @@ GroupMembersSelector_validator = bv.Struct(GroupMembersSelector)
 
 class GroupMembersSetAccessTypeArg(GroupMemberSelector):
     """
-    :ivar team.GroupMembersSetAccessTypeArg.access_type: New group access type
-        the user will have.
-    :ivar team.GroupMembersSetAccessTypeArg.return_members: Whether to return
-        the list of members in the group. Note that the default value will cause
-        all the group members to be returned in the response. This may take a
-        long time for large groups.
+    :ivar GroupMembersSetAccessTypeArg.access_type:
+        New group access type the user will have.
+    :ivar GroupMembersSetAccessTypeArg.return_members:
+        Whether to return the list of members in the group. Note that the
+        default value will cause all the group members to be returned in the
+        response. This may take a long time for large groups.
     """
 
     __slots__ = [
@@ -3505,8 +3575,12 @@ class GroupSelector(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.GroupSelector.group_id: Group ID.
-    :ivar str team.GroupSelector.group_external_id: External ID of the group.
+    :ivar GroupSelector.group_id:
+        Group ID.
+    :vartype GroupSelector.group_id: str
+    :ivar GroupSelector.group_external_id:
+        External ID of the group.
+    :vartype GroupSelector.group_external_id: str
     """
 
     _catch_all = None
@@ -3580,15 +3654,16 @@ GroupSelector_validator = bv.Union(GroupSelector)
 
 class GroupUpdateArgs(IncludeMembersArg):
     """
-    :ivar team.GroupUpdateArgs.group: Specify a group.
-    :ivar team.GroupUpdateArgs.new_group_name: Optional argument. Set group name
-        to this if provided.
-    :ivar team.GroupUpdateArgs.new_group_external_id: Optional argument. New
-        group external ID. If the argument is None, the group's external_id
-        won't be updated. If the argument is empty string, the group's external
-        id will be cleared.
-    :ivar team.GroupUpdateArgs.new_group_management_type: Set new group
-        management type, if provided.
+    :ivar GroupUpdateArgs.group:
+        Specify a group.
+    :ivar GroupUpdateArgs.new_group_name:
+        Optional argument. Set group name to this if provided.
+    :ivar GroupUpdateArgs.new_group_external_id:
+        Optional argument. New group external ID. If the argument is None, the
+        group's external_id won't be updated. If the argument is empty string,
+        the group's external id will be cleared.
+    :ivar GroupUpdateArgs.new_group_management_type:
+        Set new group management type, if provided.
     """
 
     __slots__ = [
@@ -3643,12 +3718,12 @@ class GroupUpdateError(GroupSelectorWithTeamGroupError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupUpdateError.group_name_already_used: The requested group
-        name is already being used by another group.
-    :ivar team.GroupUpdateError.group_name_invalid: Group name is empty or has
-        invalid characters.
-    :ivar team.GroupUpdateError.external_id_already_in_use: The requested
-        external ID is already being used by another group.
+    :ivar GroupUpdateError.group_name_already_used:
+        The requested group name is already being used by another group.
+    :ivar GroupUpdateError.group_name_invalid:
+        Group name is empty or has invalid characters.
+    :ivar GroupUpdateError.external_id_already_in_use:
+        The requested external ID is already being used by another group.
     """
 
     # Attribute is overwritten below the class definition
@@ -3693,8 +3768,8 @@ class GroupsGetInfoError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupsGetInfoError.group_not_on_team: The group is not on your
-        team.
+    :ivar GroupsGetInfoError.group_not_on_team:
+        The group is not on your team.
     """
 
     _catch_all = 'other'
@@ -3730,11 +3805,15 @@ class GroupsGetInfoItem(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.GroupsGetInfoItem.id_not_found: An ID that was provided as a
-        parameter to :route:`groups/get_info`, and did not match a corresponding
-        group. The ID can be a group ID, or an external ID, depending on how the
-        method was called.
-    :ivar GroupFullInfo GroupsGetInfoItem.group_info: Info about a group.
+    :ivar GroupsGetInfoItem.id_not_found:
+        An ID that was provided as a parameter to
+        :meth:`dropbox.dropbox_client.Dropbox.team_groups_get_info`, and did not
+        match a corresponding group. The ID can be a group ID, or an external
+        ID, depending on how the method was called.
+    :vartype GroupsGetInfoItem.id_not_found: str
+    :ivar GroupsGetInfoItem.group_info:
+        Info about a group.
+    :vartype GroupsGetInfoItem.group_info: GroupFullInfo
     """
 
     _catch_all = None
@@ -3811,7 +3890,8 @@ GroupsGetInfoItem_validator = bv.Union(GroupsGetInfoItem)
 
 class GroupsListArg(bb.Struct):
     """
-    :ivar team.GroupsListArg.limit: Number of results to return per call.
+    :ivar GroupsListArg.limit:
+        Number of results to return per call.
     """
 
     __slots__ = [
@@ -3836,8 +3916,8 @@ GroupsListArg_validator = bv.Struct(GroupsListArg)
 
 class GroupsListContinueArg(bb.Struct):
     """
-    :ivar team.GroupsListContinueArg.cursor: Indicates from what point to get
-        the next set of groups.
+    :ivar GroupsListContinueArg.cursor:
+        Indicates from what point to get the next set of groups.
     """
 
     __slots__ = [
@@ -3866,7 +3946,8 @@ class GroupsListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupsListContinueError.invalid_cursor: The cursor is invalid.
+    :ivar GroupsListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     _catch_all = 'other'
@@ -3898,11 +3979,13 @@ GroupsListContinueError_validator = bv.Union(GroupsListContinueError)
 
 class GroupsListResult(bb.Struct):
     """
-    :ivar team.GroupsListResult.cursor: Pass the cursor into
+    :ivar GroupsListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_groups_list_continue` to
         obtain the additional groups.
-    :ivar team.GroupsListResult.has_more: Is true if there are additional groups
-        that have not been returned yet. An additional call to
+    :ivar GroupsListResult.has_more:
+        Is true if there are additional groups that have not been returned yet.
+        An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_groups_list_continue` can
         retrieve them.
     """
@@ -3945,9 +4028,10 @@ GroupsListResult_validator = bv.Struct(GroupsListResult)
 
 class GroupsMembersListArg(bb.Struct):
     """
-    :ivar team.GroupsMembersListArg.group: The group whose members are to be
-        listed.
-    :ivar team.GroupsMembersListArg.limit: Number of results to return per call.
+    :ivar GroupsMembersListArg.group:
+        The group whose members are to be listed.
+    :ivar GroupsMembersListArg.limit:
+        Number of results to return per call.
     """
 
     __slots__ = [
@@ -3980,8 +4064,8 @@ GroupsMembersListArg_validator = bv.Struct(GroupsMembersListArg)
 
 class GroupsMembersListContinueArg(bb.Struct):
     """
-    :ivar team.GroupsMembersListContinueArg.cursor: Indicates from what point to
-        get the next set of groups.
+    :ivar GroupsMembersListContinueArg.cursor:
+        Indicates from what point to get the next set of groups.
     """
 
     __slots__ = [
@@ -4010,8 +4094,8 @@ class GroupsMembersListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupsMembersListContinueError.invalid_cursor: The cursor is
-        invalid.
+    :ivar GroupsMembersListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     _catch_all = 'other'
@@ -4043,11 +4127,13 @@ GroupsMembersListContinueError_validator = bv.Union(GroupsMembersListContinueErr
 
 class GroupsMembersListResult(bb.Struct):
     """
-    :ivar team.GroupsMembersListResult.cursor: Pass the cursor into
+    :ivar GroupsMembersListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_groups_members_list_continue`
         to obtain additional group members.
-    :ivar team.GroupsMembersListResult.has_more: Is true if there are additional
-        group members that have not been returned yet. An additional call to
+    :ivar GroupsMembersListResult.has_more:
+        Is true if there are additional group members that have not been
+        returned yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_groups_members_list_continue`
         can retrieve them.
     """
@@ -4094,8 +4180,8 @@ class GroupsPollError(async_.PollError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.GroupsPollError.access_denied: You are not allowed to poll this
-        job.
+    :ivar GroupsPollError.access_denied:
+        You are not allowed to poll this job.
     """
 
     # Attribute is overwritten below the class definition
@@ -4123,9 +4209,12 @@ class GroupsSelector(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [str] team.GroupsSelector.group_ids: List of group IDs.
-    :ivar list of [str] team.GroupsSelector.group_external_ids: List of external
-        IDs of groups.
+    :ivar GroupsSelector.group_ids:
+        List of group IDs.
+    :vartype GroupsSelector.group_ids: list of [str]
+    :ivar GroupsSelector.group_external_ids:
+        List of external IDs of groups.
+    :vartype GroupsSelector.group_external_ids: list of [str]
     """
 
     _catch_all = None
@@ -4205,8 +4294,9 @@ class HasDistinctMemberHomesValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool team.HasDistinctMemberHomesValue.has_distinct_member_homes: Does
-        this team have distinct team member homes.
+    :ivar HasDistinctMemberHomesValue.has_distinct_member_homes:
+        Does this team have distinct team member homes.
+    :vartype HasDistinctMemberHomesValue.has_distinct_member_homes: bool
     """
 
     _catch_all = 'other'
@@ -4265,8 +4355,9 @@ class HasTeamFileEventsValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool team.HasTeamFileEventsValue.enabled: Does this team have file
-        events.
+    :ivar HasTeamFileEventsValue.enabled:
+        Does this team have file events.
+    :vartype HasTeamFileEventsValue.enabled: bool
     """
 
     _catch_all = 'other'
@@ -4325,8 +4416,9 @@ class HasTeamSelectiveSyncValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool team.HasTeamSelectiveSyncValue.has_team_selective_sync: Does this
-        team have team selective sync enabled.
+    :ivar HasTeamSelectiveSyncValue.has_team_selective_sync:
+        Does this team have team selective sync enabled.
+    :vartype HasTeamSelectiveSyncValue.has_team_selective_sync: bool
     """
 
     _catch_all = 'other'
@@ -4385,8 +4477,9 @@ class HasTeamSharedDropboxValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool team.HasTeamSharedDropboxValue.has_team_shared_dropbox: Does this
-        team have a shared team root.
+    :ivar HasTeamSharedDropboxValue.has_team_shared_dropbox:
+        Does this team have a shared team root.
+    :vartype HasTeamSharedDropboxValue.has_team_shared_dropbox: bool
     """
 
     _catch_all = 'other'
@@ -4439,26 +4532,27 @@ HasTeamSharedDropboxValue_validator = bv.Union(HasTeamSharedDropboxValue)
 
 class LegalHoldHeldRevisionMetadata(bb.Struct):
     """
-    :ivar team.LegalHoldHeldRevisionMetadata.new_filename: The held revision
-        filename.
-    :ivar team.LegalHoldHeldRevisionMetadata.original_revision_id: The id of the
-        held revision.
-    :ivar team.LegalHoldHeldRevisionMetadata.original_file_path: The original
-        path of the held revision.
-    :ivar team.LegalHoldHeldRevisionMetadata.server_modified: The last time the
-        file was modified on Dropbox.
-    :ivar team.LegalHoldHeldRevisionMetadata.author_member_id: The member id of
-        the revision's author.
-    :ivar team.LegalHoldHeldRevisionMetadata.author_member_status: The member
-        status of the revision's author.
-    :ivar team.LegalHoldHeldRevisionMetadata.author_email: The email address of
-        the held revision author.
-    :ivar team.LegalHoldHeldRevisionMetadata.file_type: The type of the held
-        revision's file.
-    :ivar team.LegalHoldHeldRevisionMetadata.size: The file size in bytes.
-    :ivar team.LegalHoldHeldRevisionMetadata.content_hash: A hash of the file
-        content. This field can be used to verify data integrity. For more
-        information see our `Content hash
+    :ivar LegalHoldHeldRevisionMetadata.new_filename:
+        The held revision filename.
+    :ivar LegalHoldHeldRevisionMetadata.original_revision_id:
+        The id of the held revision.
+    :ivar LegalHoldHeldRevisionMetadata.original_file_path:
+        The original path of the held revision.
+    :ivar LegalHoldHeldRevisionMetadata.server_modified:
+        The last time the file was modified on Dropbox.
+    :ivar LegalHoldHeldRevisionMetadata.author_member_id:
+        The member id of the revision's author.
+    :ivar LegalHoldHeldRevisionMetadata.author_member_status:
+        The member status of the revision's author.
+    :ivar LegalHoldHeldRevisionMetadata.author_email:
+        The email address of the held revision author.
+    :ivar LegalHoldHeldRevisionMetadata.file_type:
+        The type of the held revision's file.
+    :ivar LegalHoldHeldRevisionMetadata.size:
+        The file size in bytes.
+    :ivar LegalHoldHeldRevisionMetadata.content_hash:
+        A hash of the file content. This field can be used to verify data
+        integrity. For more information see our `Content hash
         <https://www.dropbox.com/developers/reference/content-hash>`_ page.
     """
 
@@ -4556,17 +4650,22 @@ LegalHoldHeldRevisionMetadata_validator = bv.Struct(LegalHoldHeldRevisionMetadat
 
 class LegalHoldPolicy(bb.Struct):
     """
-    :ivar team.LegalHoldPolicy.id: The legal hold id.
-    :ivar team.LegalHoldPolicy.name: Policy name.
-    :ivar team.LegalHoldPolicy.description: A description of the legal hold
-        policy.
-    :ivar team.LegalHoldPolicy.activation_time: The time at which the legal hold
-        was activated.
-    :ivar team.LegalHoldPolicy.members: Team members IDs and number of
-        permanently deleted members under hold.
-    :ivar team.LegalHoldPolicy.status: The current state of the hold.
-    :ivar team.LegalHoldPolicy.start_date: Start date of the legal hold policy.
-    :ivar team.LegalHoldPolicy.end_date: End date of the legal hold policy.
+    :ivar LegalHoldPolicy.id:
+        The legal hold id.
+    :ivar LegalHoldPolicy.name:
+        Policy name.
+    :ivar LegalHoldPolicy.description:
+        A description of the legal hold policy.
+    :ivar LegalHoldPolicy.activation_time:
+        The time at which the legal hold was activated.
+    :ivar LegalHoldPolicy.members:
+        Team members IDs and number of permanently deleted members under hold.
+    :ivar LegalHoldPolicy.status:
+        The current state of the hold.
+    :ivar LegalHoldPolicy.start_date:
+        Start date of the legal hold policy.
+    :ivar LegalHoldPolicy.end_date:
+        End date of the legal hold policy.
     """
 
     __slots__ = [
@@ -4651,12 +4750,18 @@ class LegalHoldStatus(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldStatus.active: The legal hold policy is active.
-    :ivar team.LegalHoldStatus.released: The legal hold policy was released.
-    :ivar team.LegalHoldStatus.activating: The legal hold policy is activating.
-    :ivar team.LegalHoldStatus.updating: The legal hold policy is updating.
-    :ivar team.LegalHoldStatus.exporting: The legal hold policy is exporting.
-    :ivar team.LegalHoldStatus.releasing: The legal hold policy is releasing.
+    :ivar LegalHoldStatus.active:
+        The legal hold policy is active.
+    :ivar LegalHoldStatus.released:
+        The legal hold policy was released.
+    :ivar LegalHoldStatus.activating:
+        The legal hold policy is activating.
+    :ivar LegalHoldStatus.updating:
+        The legal hold policy is updating.
+    :ivar LegalHoldStatus.exporting:
+        The legal hold policy is exporting.
+    :ivar LegalHoldStatus.releasing:
+        The legal hold policy is releasing.
     """
 
     _catch_all = 'other'
@@ -4742,10 +4847,10 @@ class LegalHoldsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsError.unknown_legal_hold_error: There has been an
-        unknown legal hold error.
-    :ivar team.LegalHoldsError.insufficient_permissions: You don't have
-        permissions to perform this action.
+    :ivar LegalHoldsError.unknown_legal_hold_error:
+        There has been an unknown legal hold error.
+    :ivar LegalHoldsError.insufficient_permissions:
+        You don't have permissions to perform this action.
     """
 
     _catch_all = 'other'
@@ -4787,7 +4892,8 @@ LegalHoldsError_validator = bv.Union(LegalHoldsError)
 
 class LegalHoldsGetPolicyArg(bb.Struct):
     """
-    :ivar team.LegalHoldsGetPolicyArg.id: The legal hold Id.
+    :ivar LegalHoldsGetPolicyArg.id:
+        The legal hold Id.
     """
 
     __slots__ = [
@@ -4816,8 +4922,8 @@ class LegalHoldsGetPolicyError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsGetPolicyError.legal_hold_policy_not_found: Legal hold
-        policy does not exist for ``LegalHoldsGetPolicyArg.id``.
+    :ivar LegalHoldsGetPolicyError.legal_hold_policy_not_found:
+        Legal hold policy does not exist for ``LegalHoldsGetPolicyArg.id``.
     """
 
     # Attribute is overwritten below the class definition
@@ -4838,15 +4944,16 @@ LegalHoldsGetPolicyError_validator = bv.Union(LegalHoldsGetPolicyError)
 
 class LegalHoldsListHeldRevisionResult(bb.Struct):
     """
-    :ivar team.LegalHoldsListHeldRevisionResult.entries: List of file entries
-        that under the hold.
-    :ivar team.LegalHoldsListHeldRevisionResult.cursor: The cursor idicates
-        where to continue reading file metadata entries for the next API call.
-        When there are no more entries, the cursor will return none. Pass the
-        cursor into /2/team/legal_holds/list_held_revisions/continue.
-    :ivar team.LegalHoldsListHeldRevisionResult.has_more: True if there are more
-        file entries that haven't been returned. You can retrieve them with a
-        call to /legal_holds/list_held_revisions_continue.
+    :ivar LegalHoldsListHeldRevisionResult.entries:
+        List of file entries that under the hold.
+    :ivar LegalHoldsListHeldRevisionResult.cursor:
+        The cursor idicates where to continue reading file metadata entries for
+        the next API call. When there are no more entries, the cursor will
+        return none. Pass the cursor into
+        /2/team/legal_holds/list_held_revisions/continue.
+    :ivar LegalHoldsListHeldRevisionResult.has_more:
+        True if there are more file entries that haven't been returned. You can
+        retrieve them with a call to /legal_holds/list_held_revisions_continue.
     """
 
     __slots__ = [
@@ -4887,7 +4994,8 @@ LegalHoldsListHeldRevisionResult_validator = bv.Struct(LegalHoldsListHeldRevisio
 
 class LegalHoldsListHeldRevisionsArg(bb.Struct):
     """
-    :ivar team.LegalHoldsListHeldRevisionsArg.id: The legal hold Id.
+    :ivar LegalHoldsListHeldRevisionsArg.id:
+        The legal hold Id.
     """
 
     __slots__ = [
@@ -4912,10 +5020,12 @@ LegalHoldsListHeldRevisionsArg_validator = bv.Struct(LegalHoldsListHeldRevisions
 
 class LegalHoldsListHeldRevisionsContinueArg(bb.Struct):
     """
-    :ivar team.LegalHoldsListHeldRevisionsContinueArg.id: The legal hold Id.
-    :ivar team.LegalHoldsListHeldRevisionsContinueArg.cursor: The cursor
-        idicates where to continue reading file metadata entries for the next
-        API call. When there are no more entries, the cursor will return none.
+    :ivar LegalHoldsListHeldRevisionsContinueArg.id:
+        The legal hold Id.
+    :ivar LegalHoldsListHeldRevisionsContinueArg.cursor:
+        The cursor idicates where to continue reading file metadata entries for
+        the next API call. When there are no more entries, the cursor will
+        return none.
     """
 
     __slots__ = [
@@ -4952,13 +5062,12 @@ class LegalHoldsListHeldRevisionsContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar
-        team.LegalHoldsListHeldRevisionsContinueError.unknown_legal_hold_error:
+    :ivar LegalHoldsListHeldRevisionsContinueError.unknown_legal_hold_error:
         There has been an unknown legal hold error.
-    :ivar team.LegalHoldsListHeldRevisionsContinueError.transient_error:
+    :ivar LegalHoldsListHeldRevisionsContinueError.transient_error:
         Temporary infrastructure failure, please retry.
-    :ivar team.LegalHoldsListHeldRevisionsContinueError.reset: Indicates that
-        the cursor has been invalidated. Call
+    :ivar LegalHoldsListHeldRevisionsContinueError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.team_legal_holds_list_held_revisions_continue`
         again with an empty cursor to obtain a new cursor.
     """
@@ -5016,12 +5125,12 @@ class LegalHoldsListHeldRevisionsError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsListHeldRevisionsError.transient_error: Temporary
-        infrastructure failure, please retry.
-    :ivar team.LegalHoldsListHeldRevisionsError.legal_hold_still_empty: The
-        legal hold is not holding any revisions yet.
-    :ivar team.LegalHoldsListHeldRevisionsError.inactive_legal_hold: Trying to
-        list revisions for an inactive legal hold.
+    :ivar LegalHoldsListHeldRevisionsError.transient_error:
+        Temporary infrastructure failure, please retry.
+    :ivar LegalHoldsListHeldRevisionsError.legal_hold_still_empty:
+        The legal hold is not holding any revisions yet.
+    :ivar LegalHoldsListHeldRevisionsError.inactive_legal_hold:
+        Trying to list revisions for an inactive legal hold.
     """
 
     # Attribute is overwritten below the class definition
@@ -5062,8 +5171,8 @@ LegalHoldsListHeldRevisionsError_validator = bv.Union(LegalHoldsListHeldRevision
 
 class LegalHoldsListPoliciesArg(bb.Struct):
     """
-    :ivar team.LegalHoldsListPoliciesArg.include_released: Whether to return
-        holds that were released.
+    :ivar LegalHoldsListPoliciesArg.include_released:
+        Whether to return holds that were released.
     """
 
     __slots__ = [
@@ -5092,8 +5201,8 @@ class LegalHoldsListPoliciesError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsListPoliciesError.transient_error: Temporary
-        infrastructure failure, please retry.
+    :ivar LegalHoldsListPoliciesError.transient_error:
+        Temporary infrastructure failure, please retry.
     """
 
     # Attribute is overwritten below the class definition
@@ -5136,15 +5245,16 @@ LegalHoldsListPoliciesResult_validator = bv.Struct(LegalHoldsListPoliciesResult)
 
 class LegalHoldsPolicyCreateArg(bb.Struct):
     """
-    :ivar team.LegalHoldsPolicyCreateArg.name: Policy name.
-    :ivar team.LegalHoldsPolicyCreateArg.description: A description of the legal
-        hold policy.
-    :ivar team.LegalHoldsPolicyCreateArg.members: List of team member IDs added
-        to the hold.
-    :ivar team.LegalHoldsPolicyCreateArg.start_date: start date of the legal
-        hold policy.
-    :ivar team.LegalHoldsPolicyCreateArg.end_date: end date of the legal hold
-        policy.
+    :ivar LegalHoldsPolicyCreateArg.name:
+        Policy name.
+    :ivar LegalHoldsPolicyCreateArg.description:
+        A description of the legal hold policy.
+    :ivar LegalHoldsPolicyCreateArg.members:
+        List of team member IDs added to the hold.
+    :ivar LegalHoldsPolicyCreateArg.start_date:
+        start date of the legal hold policy.
+    :ivar LegalHoldsPolicyCreateArg.end_date:
+        end date of the legal hold policy.
     """
 
     __slots__ = [
@@ -5205,23 +5315,23 @@ class LegalHoldsPolicyCreateError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsPolicyCreateError.start_date_is_later_than_end_date:
+    :ivar LegalHoldsPolicyCreateError.start_date_is_later_than_end_date:
         Start date must be earlier than end date.
-    :ivar team.LegalHoldsPolicyCreateError.empty_members_list: The users list
-        must have at least one user.
-    :ivar team.LegalHoldsPolicyCreateError.invalid_members: Some members in the
-        members list are not valid to be placed under legal hold.
-    :ivar
-        team.LegalHoldsPolicyCreateError.number_of_users_on_hold_is_greater_than_hold_limitation:
+    :ivar LegalHoldsPolicyCreateError.empty_members_list:
+        The users list must have at least one user.
+    :ivar LegalHoldsPolicyCreateError.invalid_members:
+        Some members in the members list are not valid to be placed under legal
+        hold.
+    :ivar LegalHoldsPolicyCreateError.number_of_users_on_hold_is_greater_than_hold_limitation:
         You cannot add more than 5 users in a legal hold.
-    :ivar team.LegalHoldsPolicyCreateError.transient_error: Temporary
-        infrastructure failure, please retry.
-    :ivar team.LegalHoldsPolicyCreateError.name_must_be_unique: The name
-        provided is already in use by another legal hold.
-    :ivar team.LegalHoldsPolicyCreateError.team_exceeded_legal_hold_quota: Team
-        exceeded legal hold quota.
-    :ivar team.LegalHoldsPolicyCreateError.invalid_date: The provided date is
-        invalid.
+    :ivar LegalHoldsPolicyCreateError.transient_error:
+        Temporary infrastructure failure, please retry.
+    :ivar LegalHoldsPolicyCreateError.name_must_be_unique:
+        The name provided is already in use by another legal hold.
+    :ivar LegalHoldsPolicyCreateError.team_exceeded_legal_hold_quota:
+        Team exceeded legal hold quota.
+    :ivar LegalHoldsPolicyCreateError.invalid_date:
+        The provided date is invalid.
     """
 
     # Attribute is overwritten below the class definition
@@ -5312,7 +5422,8 @@ LegalHoldsPolicyCreateError_validator = bv.Union(LegalHoldsPolicyCreateError)
 
 class LegalHoldsPolicyReleaseArg(bb.Struct):
     """
-    :ivar team.LegalHoldsPolicyReleaseArg.id: The legal hold Id.
+    :ivar LegalHoldsPolicyReleaseArg.id:
+        The legal hold Id.
     """
 
     __slots__ = [
@@ -5341,13 +5452,12 @@ class LegalHoldsPolicyReleaseError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar
-        team.LegalHoldsPolicyReleaseError.legal_hold_performing_another_operation:
+    :ivar LegalHoldsPolicyReleaseError.legal_hold_performing_another_operation:
         Legal hold is currently performing another operation.
-    :ivar team.LegalHoldsPolicyReleaseError.legal_hold_already_releasing: Legal
-        hold is currently performing a release or is already released.
-    :ivar team.LegalHoldsPolicyReleaseError.legal_hold_policy_not_found: Legal
-        hold policy does not exist for ``LegalHoldsPolicyReleaseArg.id``.
+    :ivar LegalHoldsPolicyReleaseError.legal_hold_already_releasing:
+        Legal hold is currently performing a release or is already released.
+    :ivar LegalHoldsPolicyReleaseError.legal_hold_policy_not_found:
+        Legal hold policy does not exist for ``LegalHoldsPolicyReleaseArg.id``.
     """
 
     # Attribute is overwritten below the class definition
@@ -5388,11 +5498,14 @@ LegalHoldsPolicyReleaseError_validator = bv.Union(LegalHoldsPolicyReleaseError)
 
 class LegalHoldsPolicyUpdateArg(bb.Struct):
     """
-    :ivar team.LegalHoldsPolicyUpdateArg.id: The legal hold Id.
-    :ivar team.LegalHoldsPolicyUpdateArg.name: Policy new name.
-    :ivar team.LegalHoldsPolicyUpdateArg.description: Policy new description.
-    :ivar team.LegalHoldsPolicyUpdateArg.members: List of team member IDs to
-        apply the policy on.
+    :ivar LegalHoldsPolicyUpdateArg.id:
+        The legal hold Id.
+    :ivar LegalHoldsPolicyUpdateArg.name:
+        Policy new name.
+    :ivar LegalHoldsPolicyUpdateArg.description:
+        Policy new description.
+    :ivar LegalHoldsPolicyUpdateArg.members:
+        List of team member IDs to apply the policy on.
     """
 
     __slots__ = [
@@ -5445,24 +5558,23 @@ class LegalHoldsPolicyUpdateError(LegalHoldsError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.LegalHoldsPolicyUpdateError.transient_error: Temporary
-        infrastructure failure, please retry.
-    :ivar team.LegalHoldsPolicyUpdateError.inactive_legal_hold: Trying to
-        release an inactive legal hold.
-    :ivar
-        team.LegalHoldsPolicyUpdateError.legal_hold_performing_another_operation:
+    :ivar LegalHoldsPolicyUpdateError.transient_error:
+        Temporary infrastructure failure, please retry.
+    :ivar LegalHoldsPolicyUpdateError.inactive_legal_hold:
+        Trying to release an inactive legal hold.
+    :ivar LegalHoldsPolicyUpdateError.legal_hold_performing_another_operation:
         Legal hold is currently performing another operation.
-    :ivar team.LegalHoldsPolicyUpdateError.invalid_members: Some members in the
-        members list are not valid to be placed under legal hold.
-    :ivar
-        team.LegalHoldsPolicyUpdateError.number_of_users_on_hold_is_greater_than_hold_limitation:
+    :ivar LegalHoldsPolicyUpdateError.invalid_members:
+        Some members in the members list are not valid to be placed under legal
+        hold.
+    :ivar LegalHoldsPolicyUpdateError.number_of_users_on_hold_is_greater_than_hold_limitation:
         You cannot add more than 5 users in a legal hold.
-    :ivar team.LegalHoldsPolicyUpdateError.empty_members_list: The users list
-        must have at least one user.
-    :ivar team.LegalHoldsPolicyUpdateError.name_must_be_unique: The name
-        provided is already in use by another legal hold.
-    :ivar team.LegalHoldsPolicyUpdateError.legal_hold_policy_not_found: Legal
-        hold policy does not exist for ``LegalHoldsPolicyUpdateArg.id``.
+    :ivar LegalHoldsPolicyUpdateError.empty_members_list:
+        The users list must have at least one user.
+    :ivar LegalHoldsPolicyUpdateError.name_must_be_unique:
+        The name provided is already in use by another legal hold.
+    :ivar LegalHoldsPolicyUpdateError.legal_hold_policy_not_found:
+        Legal hold policy does not exist for ``LegalHoldsPolicyUpdateArg.id``.
     """
 
     # Attribute is overwritten below the class definition
@@ -5553,7 +5665,8 @@ LegalHoldsPolicyUpdateError_validator = bv.Union(LegalHoldsPolicyUpdateError)
 
 class ListMemberAppsArg(bb.Struct):
     """
-    :ivar team.ListMemberAppsArg.team_member_id: The team member id.
+    :ivar ListMemberAppsArg.team_member_id:
+        The team member id.
     """
 
     __slots__ = [
@@ -5585,7 +5698,8 @@ class ListMemberAppsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListMemberAppsError.member_not_found: Member not found.
+    :ivar ListMemberAppsError.member_not_found:
+        Member not found.
     """
 
     _catch_all = 'other'
@@ -5617,8 +5731,8 @@ ListMemberAppsError_validator = bv.Union(ListMemberAppsError)
 
 class ListMemberAppsResult(bb.Struct):
     """
-    :ivar team.ListMemberAppsResult.linked_api_apps: List of third party
-        applications linked by this team member.
+    :ivar ListMemberAppsResult.linked_api_apps:
+        List of third party applications linked by this team member.
     """
 
     __slots__ = [
@@ -5643,13 +5757,14 @@ ListMemberAppsResult_validator = bv.Struct(ListMemberAppsResult)
 
 class ListMemberDevicesArg(bb.Struct):
     """
-    :ivar team.ListMemberDevicesArg.team_member_id: The team's member id.
-    :ivar team.ListMemberDevicesArg.include_web_sessions: Whether to list web
-        sessions of the team's member.
-    :ivar team.ListMemberDevicesArg.include_desktop_clients: Whether to list
-        linked desktop devices of the team's member.
-    :ivar team.ListMemberDevicesArg.include_mobile_clients: Whether to list
-        linked mobile devices of the team's member.
+    :ivar ListMemberDevicesArg.team_member_id:
+        The team's member id.
+    :ivar ListMemberDevicesArg.include_web_sessions:
+        Whether to list web sessions of the team's member.
+    :ivar ListMemberDevicesArg.include_desktop_clients:
+        Whether to list linked desktop devices of the team's member.
+    :ivar ListMemberDevicesArg.include_mobile_clients:
+        Whether to list linked mobile devices of the team's member.
     """
 
     __slots__ = [
@@ -5702,7 +5817,8 @@ class ListMemberDevicesError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListMemberDevicesError.member_not_found: Member not found.
+    :ivar ListMemberDevicesError.member_not_found:
+        Member not found.
     """
 
     _catch_all = 'other'
@@ -5734,12 +5850,12 @@ ListMemberDevicesError_validator = bv.Union(ListMemberDevicesError)
 
 class ListMemberDevicesResult(bb.Struct):
     """
-    :ivar team.ListMemberDevicesResult.active_web_sessions: List of web sessions
-        made by this team member.
-    :ivar team.ListMemberDevicesResult.desktop_client_sessions: List of desktop
-        clients used by this team member.
-    :ivar team.ListMemberDevicesResult.mobile_client_sessions: List of mobile
-        client used by this team member.
+    :ivar ListMemberDevicesResult.active_web_sessions:
+        List of web sessions made by this team member.
+    :ivar ListMemberDevicesResult.desktop_client_sessions:
+        List of desktop clients used by this team member.
+    :ivar ListMemberDevicesResult.mobile_client_sessions:
+        List of mobile client used by this team member.
     """
 
     __slots__ = [
@@ -5783,7 +5899,8 @@ class ListMembersAppsArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`.
 
-    :ivar team.ListMembersAppsArg.cursor: At the first call to the
+    :ivar ListMembersAppsArg.cursor:
+        At the first call to the
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`
         the cursor shouldn't be passed. Then, if the result of the call includes
         a cursor, the following requests should include the received cursors in
@@ -5819,8 +5936,8 @@ class ListMembersAppsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListMembersAppsError.reset: Indicates that the cursor has been
-        invalidated. Call
+    :ivar ListMembersAppsError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`
         again with an empty cursor to obtain a new cursor.
     """
@@ -5857,13 +5974,14 @@ class ListMembersAppsResult(bb.Struct):
     Information returned by
     :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`.
 
-    :ivar team.ListMembersAppsResult.apps: The linked applications of each
-        member of the team.
-    :ivar team.ListMembersAppsResult.has_more: If true, then there are more apps
-        available. Pass the cursor to
+    :ivar ListMembersAppsResult.apps:
+        The linked applications of each member of the team.
+    :ivar ListMembersAppsResult.has_more:
+        If true, then there are more apps available. Pass the cursor to
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`
         to retrieve the rest.
-    :ivar team.ListMembersAppsResult.cursor: Pass the cursor into
+    :ivar ListMembersAppsResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_members_linked_apps`
         to receive the next sub list of team's applications.
     """
@@ -5906,17 +6024,18 @@ ListMembersAppsResult_validator = bv.Struct(ListMembersAppsResult)
 
 class ListMembersDevicesArg(bb.Struct):
     """
-    :ivar team.ListMembersDevicesArg.cursor: At the first call to the
+    :ivar ListMembersDevicesArg.cursor:
+        At the first call to the
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_members_devices`
         the cursor shouldn't be passed. Then, if the result of the call includes
         a cursor, the following requests should include the received cursors in
         order to receive the next sub list of team devices.
-    :ivar team.ListMembersDevicesArg.include_web_sessions: Whether to list web
-        sessions of the team members.
-    :ivar team.ListMembersDevicesArg.include_desktop_clients: Whether to list
-        desktop clients of the team members.
-    :ivar team.ListMembersDevicesArg.include_mobile_clients: Whether to list
-        mobile clients of the team members.
+    :ivar ListMembersDevicesArg.include_web_sessions:
+        Whether to list web sessions of the team members.
+    :ivar ListMembersDevicesArg.include_desktop_clients:
+        Whether to list desktop clients of the team members.
+    :ivar ListMembersDevicesArg.include_mobile_clients:
+        Whether to list mobile clients of the team members.
     """
 
     __slots__ = [
@@ -5969,8 +6088,8 @@ class ListMembersDevicesError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListMembersDevicesError.reset: Indicates that the cursor has been
-        invalidated. Call
+    :ivar ListMembersDevicesError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_members_devices`
         again with an empty cursor to obtain a new cursor.
     """
@@ -6004,13 +6123,14 @@ ListMembersDevicesError_validator = bv.Union(ListMembersDevicesError)
 
 class ListMembersDevicesResult(bb.Struct):
     """
-    :ivar team.ListMembersDevicesResult.devices: The devices of each member of
-        the team.
-    :ivar team.ListMembersDevicesResult.has_more: If true, then there are more
-        devices available. Pass the cursor to
+    :ivar ListMembersDevicesResult.devices:
+        The devices of each member of the team.
+    :ivar ListMembersDevicesResult.has_more:
+        If true, then there are more devices available. Pass the cursor to
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_members_devices`
         to retrieve the rest.
-    :ivar team.ListMembersDevicesResult.cursor: Pass the cursor into
+    :ivar ListMembersDevicesResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_members_devices`
         to receive the next sub list of team's devices.
     """
@@ -6056,7 +6176,8 @@ class ListTeamAppsArg(bb.Struct):
     Arguments for
     :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`.
 
-    :ivar team.ListTeamAppsArg.cursor: At the first call to the
+    :ivar ListTeamAppsArg.cursor:
+        At the first call to the
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`
         the cursor shouldn't be passed. Then, if the result of the call includes
         a cursor, the following requests should include the received cursors in
@@ -6092,8 +6213,8 @@ class ListTeamAppsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListTeamAppsError.reset: Indicates that the cursor has been
-        invalidated. Call
+    :ivar ListTeamAppsError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`
         again with an empty cursor to obtain a new cursor.
     """
@@ -6130,13 +6251,14 @@ class ListTeamAppsResult(bb.Struct):
     Information returned by
     :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`.
 
-    :ivar team.ListTeamAppsResult.apps: The linked applications of each member
-        of the team.
-    :ivar team.ListTeamAppsResult.has_more: If true, then there are more apps
-        available. Pass the cursor to
+    :ivar ListTeamAppsResult.apps:
+        The linked applications of each member of the team.
+    :ivar ListTeamAppsResult.has_more:
+        If true, then there are more apps available. Pass the cursor to
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`
         to retrieve the rest.
-    :ivar team.ListTeamAppsResult.cursor: Pass the cursor into
+    :ivar ListTeamAppsResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_linked_apps_list_team_linked_apps`
         to receive the next sub list of team's applications.
     """
@@ -6179,17 +6301,18 @@ ListTeamAppsResult_validator = bv.Struct(ListTeamAppsResult)
 
 class ListTeamDevicesArg(bb.Struct):
     """
-    :ivar team.ListTeamDevicesArg.cursor: At the first call to the
+    :ivar ListTeamDevicesArg.cursor:
+        At the first call to the
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_team_devices`
         the cursor shouldn't be passed. Then, if the result of the call includes
         a cursor, the following requests should include the received cursors in
         order to receive the next sub list of team devices.
-    :ivar team.ListTeamDevicesArg.include_web_sessions: Whether to list web
-        sessions of the team members.
-    :ivar team.ListTeamDevicesArg.include_desktop_clients: Whether to list
-        desktop clients of the team members.
-    :ivar team.ListTeamDevicesArg.include_mobile_clients: Whether to list mobile
-        clients of the team members.
+    :ivar ListTeamDevicesArg.include_web_sessions:
+        Whether to list web sessions of the team members.
+    :ivar ListTeamDevicesArg.include_desktop_clients:
+        Whether to list desktop clients of the team members.
+    :ivar ListTeamDevicesArg.include_mobile_clients:
+        Whether to list mobile clients of the team members.
     """
 
     __slots__ = [
@@ -6242,8 +6365,8 @@ class ListTeamDevicesError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.ListTeamDevicesError.reset: Indicates that the cursor has been
-        invalidated. Call
+    :ivar ListTeamDevicesError.reset:
+        Indicates that the cursor has been invalidated. Call
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_team_devices`
         again with an empty cursor to obtain a new cursor.
     """
@@ -6277,13 +6400,14 @@ ListTeamDevicesError_validator = bv.Union(ListTeamDevicesError)
 
 class ListTeamDevicesResult(bb.Struct):
     """
-    :ivar team.ListTeamDevicesResult.devices: The devices of each member of the
-        team.
-    :ivar team.ListTeamDevicesResult.has_more: If true, then there are more
-        devices available. Pass the cursor to
+    :ivar ListTeamDevicesResult.devices:
+        The devices of each member of the team.
+    :ivar ListTeamDevicesResult.has_more:
+        If true, then there are more devices available. Pass the cursor to
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_team_devices` to
         retrieve the rest.
-    :ivar team.ListTeamDevicesResult.cursor: Pass the cursor into
+    :ivar ListTeamDevicesResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_devices_list_team_devices` to
         receive the next sub list of team's devices.
     """
@@ -6328,8 +6452,10 @@ class MemberAccess(bb.Struct):
     """
     Specify access type a member should have when joined to a group.
 
-    :ivar team.MemberAccess.user: Identity of a user.
-    :ivar team.MemberAccess.access_type: Access type.
+    :ivar MemberAccess.user:
+        Identity of a user.
+    :ivar MemberAccess.access_type:
+        Access type.
     """
 
     __slots__ = [
@@ -6362,19 +6488,22 @@ MemberAccess_validator = bv.Struct(MemberAccess)
 
 class MemberAddArgBase(bb.Struct):
     """
-    :ivar team.MemberAddArgBase.member_given_name: Member's first name.
-    :ivar team.MemberAddArgBase.member_surname: Member's last name.
-    :ivar team.MemberAddArgBase.member_external_id: External ID for member.
-    :ivar team.MemberAddArgBase.member_persistent_id: Persistent ID for member.
-        This field is only available to teams using persistent ID SAML
-        configuration.
-    :ivar team.MemberAddArgBase.send_welcome_email: Whether to send a welcome
-        email to the member. If send_welcome_email is false, no email invitation
-        will be sent to the user. This may be useful for apps using single
-        sign-on (SSO) flows for onboarding that want to handle announcements
-        themselves.
-    :ivar team.MemberAddArgBase.is_directory_restricted: Whether a user is
-        directory restricted.
+    :ivar MemberAddArgBase.member_given_name:
+        Member's first name.
+    :ivar MemberAddArgBase.member_surname:
+        Member's last name.
+    :ivar MemberAddArgBase.member_external_id:
+        External ID for member.
+    :ivar MemberAddArgBase.member_persistent_id:
+        Persistent ID for member. This field is only available to teams using
+        persistent ID SAML configuration.
+    :ivar MemberAddArgBase.send_welcome_email:
+        Whether to send a welcome email to the member. If send_welcome_email is
+        false, no email invitation will be sent to the user. This may be useful
+        for apps using single sign-on (SSO) flows for onboarding that want to
+        handle announcements themselves.
+    :ivar MemberAddArgBase.is_directory_restricted:
+        Whether a user is directory restricted.
     """
 
     __slots__ = [
@@ -6487,32 +6616,43 @@ class MemberAddResultBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.MemberAddResultBase.team_license_limit: Team is already full.
-        The organization has no available licenses.
-    :ivar str team.MemberAddResultBase.free_team_member_limit_reached: Team is
-        already full. The free team member limit has been reached.
-    :ivar str team.MemberAddResultBase.user_already_on_team: User is already on
-        this team. The provided email address is associated with a user who is
-        already a member of (including in recoverable state) or invited to the
+    :ivar MemberAddResultBase.team_license_limit:
+        Team is already full. The organization has no available licenses.
+    :vartype MemberAddResultBase.team_license_limit: str
+    :ivar MemberAddResultBase.free_team_member_limit_reached:
+        Team is already full. The free team member limit has been reached.
+    :vartype MemberAddResultBase.free_team_member_limit_reached: str
+    :ivar MemberAddResultBase.user_already_on_team:
+        User is already on this team. The provided email address is associated
+        with a user who is already a member of (including in recoverable state)
+        or invited to the team.
+    :vartype MemberAddResultBase.user_already_on_team: str
+    :ivar MemberAddResultBase.user_on_another_team:
+        User is already on another team. The provided email address is
+        associated with a user that is already a member or invited to another
         team.
-    :ivar str team.MemberAddResultBase.user_on_another_team: User is already on
-        another team. The provided email address is associated with a user that
-        is already a member or invited to another team.
-    :ivar str team.MemberAddResultBase.user_already_paired: User is already
-        paired.
-    :ivar str team.MemberAddResultBase.user_migration_failed: User migration has
-        failed.
-    :ivar str team.MemberAddResultBase.duplicate_external_member_id: A user with
-        the given external member ID already exists on the team (including in
-        recoverable state).
-    :ivar str team.MemberAddResultBase.duplicate_member_persistent_id: A user
-        with the given persistent ID already exists on the team (including in
-        recoverable state).
-    :ivar str team.MemberAddResultBase.persistent_id_disabled: Persistent ID is
-        only available to teams with persistent ID SAML configuration. Please
-        contact Dropbox for more information.
-    :ivar str team.MemberAddResultBase.user_creation_failed: User creation has
-        failed.
+    :vartype MemberAddResultBase.user_on_another_team: str
+    :ivar MemberAddResultBase.user_already_paired:
+        User is already paired.
+    :vartype MemberAddResultBase.user_already_paired: str
+    :ivar MemberAddResultBase.user_migration_failed:
+        User migration has failed.
+    :vartype MemberAddResultBase.user_migration_failed: str
+    :ivar MemberAddResultBase.duplicate_external_member_id:
+        A user with the given external member ID already exists on the team
+        (including in recoverable state).
+    :vartype MemberAddResultBase.duplicate_external_member_id: str
+    :ivar MemberAddResultBase.duplicate_member_persistent_id:
+        A user with the given persistent ID already exists on the team
+        (including in recoverable state).
+    :vartype MemberAddResultBase.duplicate_member_persistent_id: str
+    :ivar MemberAddResultBase.persistent_id_disabled:
+        Persistent ID is only available to teams with persistent ID SAML
+        configuration. Please contact Dropbox for more information.
+    :vartype MemberAddResultBase.persistent_id_disabled: str
+    :ivar MemberAddResultBase.user_creation_failed:
+        User creation has failed.
+    :vartype MemberAddResultBase.user_creation_failed: str
     """
 
     _catch_all = None
@@ -6850,8 +6990,9 @@ class MemberAddResult(MemberAddResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar TeamMemberInfo MemberAddResult.success: Describes a user that was
-        successfully added to the team.
+    :ivar MemberAddResult.success:
+        Describes a user that was successfully added to the team.
+    :vartype MemberAddResult.success: TeamMemberInfo
     """
 
     @classmethod
@@ -6937,8 +7078,9 @@ class MemberAddV2Result(MemberAddResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar TeamMemberInfoV2 MemberAddV2Result.success: Describes a user that was
-        successfully added to the team.
+    :ivar MemberAddV2Result.success:
+        Describes a user that was successfully added to the team.
+    :vartype MemberAddV2Result.success: TeamMemberInfoV2
     """
 
     _catch_all = 'other'
@@ -6993,13 +7135,14 @@ class MemberDevices(bb.Struct):
     """
     Information on devices of a team's member.
 
-    :ivar team.MemberDevices.team_member_id: The member unique Id.
-    :ivar team.MemberDevices.web_sessions: List of web sessions made by this
-        team member.
-    :ivar team.MemberDevices.desktop_clients: List of desktop clients by this
-        team member.
-    :ivar team.MemberDevices.mobile_clients: List of mobile clients by this team
-        member.
+    :ivar MemberDevices.team_member_id:
+        The member unique Id.
+    :ivar MemberDevices.web_sessions:
+        List of web sessions made by this team member.
+    :ivar MemberDevices.desktop_clients:
+        List of desktop clients by this team member.
+    :ivar MemberDevices.mobile_clients:
+        List of mobile clients by this team member.
     """
 
     __slots__ = [
@@ -7050,9 +7193,10 @@ class MemberLinkedApps(bb.Struct):
     """
     Information on linked applications of a team member.
 
-    :ivar team.MemberLinkedApps.team_member_id: The member unique Id.
-    :ivar team.MemberLinkedApps.linked_api_apps: List of third party
-        applications linked by this team member.
+    :ivar MemberLinkedApps.team_member_id:
+        The member unique Id.
+    :ivar MemberLinkedApps.linked_api_apps:
+        List of third party applications linked by this team member.
     """
 
     __slots__ = [
@@ -7087,36 +7231,42 @@ class MemberProfile(bb.Struct):
     """
     Basic member profile.
 
-    :ivar team.MemberProfile.team_member_id: ID of user as a member of a team.
-    :ivar team.MemberProfile.external_id: External ID that a team can attach to
-        the user. An application using the API may find it easier to use their
-        own IDs instead of Dropbox IDs like account_id or team_member_id.
-    :ivar team.MemberProfile.account_id: A user's account identifier.
-    :ivar team.MemberProfile.email: Email address of user.
-    :ivar team.MemberProfile.email_verified: Is true if the user's email is
-        verified to be owned by the user.
-    :ivar team.MemberProfile.secondary_emails: Secondary emails of a user.
-    :ivar team.MemberProfile.status: The user's status as a member of a specific
-        team.
-    :ivar team.MemberProfile.name: Representations for a person's name.
-    :ivar team.MemberProfile.membership_type: The user's membership type: full
-        (normal team member) vs limited (does not use a license; no access to
-        the team's shared quota).
-    :ivar team.MemberProfile.invited_on: The date and time the user was invited
-        to the team (contains value only when the member's status matches
-        ``TeamMemberStatus.invited``).
-    :ivar team.MemberProfile.joined_on: The date and time the user joined as a
-        member of a specific team.
-    :ivar team.MemberProfile.suspended_on: The date and time the user was
-        suspended from the team (contains value only when the member's status
-        matches ``TeamMemberStatus.suspended``).
-    :ivar team.MemberProfile.persistent_id: Persistent ID that a team can attach
-        to the user. The persistent ID is unique ID to be used for SAML
-        authentication.
-    :ivar team.MemberProfile.is_directory_restricted: Whether the user is a
-        directory restricted user.
-    :ivar team.MemberProfile.profile_photo_url: URL for the photo representing
-        the user, if one is set.
+    :ivar MemberProfile.team_member_id:
+        ID of user as a member of a team.
+    :ivar MemberProfile.external_id:
+        External ID that a team can attach to the user. An application using the
+        API may find it easier to use their own IDs instead of Dropbox IDs like
+        account_id or team_member_id.
+    :ivar MemberProfile.account_id:
+        A user's account identifier.
+    :ivar MemberProfile.email:
+        Email address of user.
+    :ivar MemberProfile.email_verified:
+        Is true if the user's email is verified to be owned by the user.
+    :ivar MemberProfile.secondary_emails:
+        Secondary emails of a user.
+    :ivar MemberProfile.status:
+        The user's status as a member of a specific team.
+    :ivar MemberProfile.name:
+        Representations for a person's name.
+    :ivar MemberProfile.membership_type:
+        The user's membership type: full (normal team member) vs limited (does
+        not use a license; no access to the team's shared quota).
+    :ivar MemberProfile.invited_on:
+        The date and time the user was invited to the team (contains value only
+        when the member's status matches ``TeamMemberStatus.invited``).
+    :ivar MemberProfile.joined_on:
+        The date and time the user joined as a member of a specific team.
+    :ivar MemberProfile.suspended_on:
+        The date and time the user was suspended from the team (contains value
+        only when the member's status matches ``TeamMemberStatus.suspended``).
+    :ivar MemberProfile.persistent_id:
+        Persistent ID that a team can attach to the user. The persistent ID is
+        unique ID to be used for SAML authentication.
+    :ivar MemberProfile.is_directory_restricted:
+        Whether the user is a directory restricted user.
+    :ivar MemberProfile.profile_photo_url:
+        URL for the photo representing the user, if one is set.
     """
 
     __slots__ = [
@@ -7260,9 +7410,9 @@ class UserSelectorError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.UserSelectorError.user_not_found: No matching user found. The
-        provided team_member_id, email, or external_id does not exist on this
-        team.
+    :ivar UserSelectorError.user_not_found:
+        No matching user found. The provided team_member_id, email, or
+        external_id does not exist on this team.
     """
 
     _catch_all = None
@@ -7288,8 +7438,8 @@ class MemberSelectorError(UserSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MemberSelectorError.user_not_in_team: The user is not a member of
-        the team.
+    :ivar MemberSelectorError.user_not_in_team:
+        The user is not a member of the team.
     """
 
     # Attribute is overwritten below the class definition
@@ -7310,8 +7460,8 @@ MemberSelectorError_validator = bv.Union(MemberSelectorError)
 
 class MembersAddArgBase(bb.Struct):
     """
-    :ivar team.MembersAddArgBase.force_async: Whether to force the add to happen
-        asynchronously.
+    :ivar MembersAddArgBase.force_async:
+        Whether to force the add to happen asynchronously.
     """
 
     __slots__ = [
@@ -7336,8 +7486,8 @@ MembersAddArgBase_validator = bv.Struct(MembersAddArgBase)
 
 class MembersAddArg(MembersAddArgBase):
     """
-    :ivar team.MembersAddArg.new_members: Details of new members to be added to
-        the team.
+    :ivar MembersAddArg.new_members:
+        Details of new members to be added to the team.
     """
 
     __slots__ = [
@@ -7368,12 +7518,16 @@ class MembersAddJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [MemberAddResult] team.MembersAddJobStatus.complete: The
-        asynchronous job has finished. For each member that was specified in the
-        parameter :type:`MembersAddArg` that was provided to
-        :route:`members/add`, a corresponding item is returned in this list.
-    :ivar str team.MembersAddJobStatus.failed: The asynchronous job returned an
-        error. The string contains an error message.
+    :ivar MembersAddJobStatus.complete:
+        The asynchronous job has finished. For each member that was specified in
+        the parameter :class:`MembersAddArg` that was provided to
+        :meth:`dropbox.dropbox_client.Dropbox.team_members_add`, a corresponding
+        item is returned in this list.
+    :vartype MembersAddJobStatus.complete: list of [MemberAddResult]
+    :ivar MembersAddJobStatus.failed:
+        The asynchronous job returned an error. The string contains an error
+        message.
+    :vartype MembersAddJobStatus.failed: str
     """
 
     @classmethod
@@ -7453,12 +7607,16 @@ class MembersAddJobStatusV2Result(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [MemberAddV2Result] team.MembersAddJobStatusV2Result.complete:
+    :ivar MembersAddJobStatusV2Result.complete:
         The asynchronous job has finished. For each member that was specified in
-        the parameter :type:`MembersAddArg` that was provided to
-        :route:`members/add:2`, a corresponding item is returned in this list.
-    :ivar str team.MembersAddJobStatusV2Result.failed: The asynchronous job
-        returned an error. The string contains an error message.
+        the parameter :class:`MembersAddArg` that was provided to
+        :meth:`dropbox.dropbox_client.Dropbox.team_members_add`, a corresponding
+        item is returned in this list.
+    :vartype MembersAddJobStatusV2Result.complete: list of [MemberAddV2Result]
+    :ivar MembersAddJobStatusV2Result.failed:
+        The asynchronous job returned an error. The string contains an error
+        message.
+    :vartype MembersAddJobStatusV2Result.failed: str
     """
 
     _catch_all = 'other'
@@ -7640,8 +7798,8 @@ MembersAddLaunchV2Result_validator = bv.Union(MembersAddLaunchV2Result)
 
 class MembersAddV2Arg(MembersAddArgBase):
     """
-    :ivar team.MembersAddV2Arg.new_members: Details of new members to be added
-        to the team.
+    :ivar MembersAddV2Arg.new_members:
+        Details of new members to be added to the team.
     """
 
     __slots__ = [
@@ -7671,8 +7829,8 @@ class MembersDeactivateBaseArg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify the user account.
 
-    :ivar team.MembersDeactivateBaseArg.user: Identity of user to
-        remove/suspend/have their files moved.
+    :ivar MembersDeactivateBaseArg.user:
+        Identity of user to remove/suspend/have their files moved.
     """
 
     __slots__ = [
@@ -7697,10 +7855,10 @@ MembersDeactivateBaseArg_validator = bv.Struct(MembersDeactivateBaseArg)
 
 class MembersDataTransferArg(MembersDeactivateBaseArg):
     """
-    :ivar team.MembersDataTransferArg.transfer_dest_id: Files from the deleted
-        member account will be transferred to this user.
-    :ivar team.MembersDataTransferArg.transfer_admin_id: Errors during the
-        transfer process will be sent via email to this user.
+    :ivar MembersDataTransferArg.transfer_dest_id:
+        Files from the deleted member account will be transferred to this user.
+    :ivar MembersDataTransferArg.transfer_admin_id:
+        Errors during the transfer process will be sent via email to this user.
     """
 
     __slots__ = [
@@ -7735,8 +7893,9 @@ MembersDataTransferArg_validator = bv.Struct(MembersDataTransferArg)
 
 class MembersDeactivateArg(MembersDeactivateBaseArg):
     """
-    :ivar team.MembersDeactivateArg.wipe_data: If provided, controls if the
-        user's data will be deleted on their linked devices.
+    :ivar MembersDeactivateArg.wipe_data:
+        If provided, controls if the user's data will be deleted on their linked
+        devices.
     """
 
     __slots__ = [
@@ -7767,8 +7926,8 @@ class MembersDeactivateError(UserSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersDeactivateError.user_not_in_team: The user is not a member
-        of the team.
+    :ivar MembersDeactivateError.user_not_in_team:
+        The user is not a member of the team.
     """
 
     _catch_all = 'other'
@@ -7804,12 +7963,11 @@ class MembersPermanentlyDeleteFilesError(MembersDeactivateError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersPermanentlyDeleteFilesError.transfer_in_progress: Cannot
-        permanently delete files while it's being transferred.
-    :ivar team.MembersPermanentlyDeleteFilesError.already_transferred: Cannot
-        permanently delete files that have already been transferred.
-    :ivar
-        team.MembersPermanentlyDeleteFilesError.already_transferred_or_deleted:
+    :ivar MembersPermanentlyDeleteFilesError.transfer_in_progress:
+        Cannot permanently delete files while it's being transferred.
+    :ivar MembersPermanentlyDeleteFilesError.already_transferred:
+        Cannot permanently delete files that have already been transferred.
+    :ivar MembersPermanentlyDeleteFilesError.already_transferred_or_deleted:
         Cannot permanently delete files that have already been transferred or
         deleted.
     """
@@ -7856,8 +8014,8 @@ class MembersDeleteFormerMemberFilesError(MembersPermanentlyDeleteFilesError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersDeleteFormerMemberFilesError.user_not_removed: User has
-        not been removed from the team.
+    :ivar MembersDeleteFormerMemberFilesError.user_not_removed:
+        User has not been removed from the team.
     """
 
     # Attribute is overwritten below the class definition
@@ -7878,8 +8036,8 @@ MembersDeleteFormerMemberFilesError_validator = bv.Union(MembersDeleteFormerMemb
 
 class MembersDeleteProfilePhotoArg(bb.Struct):
     """
-    :ivar team.MembersDeleteProfilePhotoArg.user: Identity of the user whose
-        profile photo will be deleted.
+    :ivar MembersDeleteProfilePhotoArg.user:
+        Identity of the user whose profile photo will be deleted.
     """
 
     __slots__ = [
@@ -7908,8 +8066,8 @@ class MembersDeleteProfilePhotoError(MemberSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersDeleteProfilePhotoError.set_profile_disallowed: Modifying
-        deleted users is not allowed.
+    :ivar MembersDeleteProfilePhotoError.set_profile_disallowed:
+        Modifying deleted users is not allowed.
     """
 
     _catch_all = 'other'
@@ -7944,8 +8102,8 @@ class MembersFormerMemberArg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify a former team member.
 
-    :ivar team.MembersFormerMemberArg.user: Identity of user whose files will be
-        permanently deleted.
+    :ivar MembersFormerMemberArg.user:
+        Identity of user whose files will be permanently deleted.
     """
 
     __slots__ = [
@@ -7973,7 +8131,8 @@ class MembersGetAvailableTeamMemberRolesResult(bb.Struct):
     Available TeamMemberRole for the connected team. To be used with
     :meth:`dropbox.dropbox_client.Dropbox.team_members_set_admin_permissions`.
 
-    :ivar team.MembersGetAvailableTeamMemberRolesResult.roles: Available roles.
+    :ivar MembersGetAvailableTeamMemberRolesResult.roles:
+        Available roles.
     """
 
     __slots__ = [
@@ -7998,7 +8157,8 @@ MembersGetAvailableTeamMemberRolesResult_validator = bv.Struct(MembersGetAvailab
 
 class MembersGetInfoArgs(bb.Struct):
     """
-    :ivar team.MembersGetInfoArgs.members: List of team members.
+    :ivar MembersGetInfoArgs.members:
+        List of team members.
     """
 
     __slots__ = [
@@ -8051,11 +8211,13 @@ class MembersGetInfoItemBase(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.MembersGetInfoItemBase.id_not_found: An ID that was provided
-        as a parameter to :route:`members/get_info` or
-        :route:`members/get_info:2`, and did not match a corresponding user.
-        This might be a team_member_id, an email, or an external ID, depending
-        on how the method was called.
+    :ivar MembersGetInfoItemBase.id_not_found:
+        An ID that was provided as a parameter to
+        :meth:`dropbox.dropbox_client.Dropbox.team_members_get_info` or
+        :meth:`dropbox.dropbox_client.Dropbox.team_members_get_info`, and did
+        not match a corresponding user. This might be a team_member_id, an
+        email, or an external ID, depending on how the method was called.
+    :vartype MembersGetInfoItemBase.id_not_found: str
     """
 
     _catch_all = None
@@ -8109,8 +8271,9 @@ class MembersGetInfoItem(MembersGetInfoItemBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar TeamMemberInfo MembersGetInfoItem.member_info: Info about a team
-        member.
+    :ivar MembersGetInfoItem.member_info:
+        Info about a team member.
+    :vartype MembersGetInfoItem.member_info: TeamMemberInfo
     """
 
     @classmethod
@@ -8158,8 +8321,9 @@ class MembersGetInfoItemV2(MembersGetInfoItemBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar TeamMemberInfoV2 MembersGetInfoItemV2.member_info: Info about a team
-        member.
+    :ivar MembersGetInfoItemV2.member_info:
+        Info about a team member.
+    :vartype MembersGetInfoItemV2.member_info: TeamMemberInfoV2
     """
 
     _catch_all = 'other'
@@ -8212,7 +8376,8 @@ MembersGetInfoItemV2_validator = bv.Union(MembersGetInfoItemV2)
 
 class MembersGetInfoV2Arg(bb.Struct):
     """
-    :ivar team.MembersGetInfoV2Arg.members: List of team members.
+    :ivar MembersGetInfoV2Arg.members:
+        List of team members.
     """
 
     __slots__ = [
@@ -8237,7 +8402,8 @@ MembersGetInfoV2Arg_validator = bv.Struct(MembersGetInfoV2Arg)
 
 class MembersGetInfoV2Result(bb.Struct):
     """
-    :ivar team.MembersGetInfoV2Result.members_info: List of team members info.
+    :ivar MembersGetInfoV2Result.members_info:
+        List of team members info.
     """
 
     __slots__ = [
@@ -8262,10 +8428,10 @@ MembersGetInfoV2Result_validator = bv.Struct(MembersGetInfoV2Result)
 
 class MembersInfo(bb.Struct):
     """
-    :ivar team.MembersInfo.team_member_ids: Team member IDs of the users under
-        this hold.
-    :ivar team.MembersInfo.permanently_deleted_users: The number of permanently
-        deleted users that were under this hold.
+    :ivar MembersInfo.team_member_ids:
+        Team member IDs of the users under this hold.
+    :ivar MembersInfo.permanently_deleted_users:
+        The number of permanently deleted users that were under this hold.
     """
 
     __slots__ = [
@@ -8298,9 +8464,10 @@ MembersInfo_validator = bv.Struct(MembersInfo)
 
 class MembersListArg(bb.Struct):
     """
-    :ivar team.MembersListArg.limit: Number of results to return per call.
-    :ivar team.MembersListArg.include_removed: Whether to return removed
-        members.
+    :ivar MembersListArg.limit:
+        Number of results to return per call.
+    :ivar MembersListArg.include_removed:
+        Whether to return removed members.
     """
 
     __slots__ = [
@@ -8333,8 +8500,8 @@ MembersListArg_validator = bv.Struct(MembersListArg)
 
 class MembersListContinueArg(bb.Struct):
     """
-    :ivar team.MembersListContinueArg.cursor: Indicates from what point to get
-        the next set of members.
+    :ivar MembersListContinueArg.cursor:
+        Indicates from what point to get the next set of members.
     """
 
     __slots__ = [
@@ -8363,7 +8530,8 @@ class MembersListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersListContinueError.invalid_cursor: The cursor is invalid.
+    :ivar MembersListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     _catch_all = 'other'
@@ -8419,12 +8587,15 @@ MembersListError_validator = bv.Union(MembersListError)
 
 class MembersListResult(bb.Struct):
     """
-    :ivar team.MembersListResult.members: List of team members.
-    :ivar team.MembersListResult.cursor: Pass the cursor into
+    :ivar MembersListResult.members:
+        List of team members.
+    :ivar MembersListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_members_list_continue` to
         obtain the additional members.
-    :ivar team.MembersListResult.has_more: Is true if there are additional team
-        members that have not been returned yet. An additional call to
+    :ivar MembersListResult.has_more:
+        Is true if there are additional team members that have not been returned
+        yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_members_list_continue` can
         retrieve them.
     """
@@ -8467,12 +8638,15 @@ MembersListResult_validator = bv.Struct(MembersListResult)
 
 class MembersListV2Result(bb.Struct):
     """
-    :ivar team.MembersListV2Result.members: List of team members.
-    :ivar team.MembersListV2Result.cursor: Pass the cursor into
+    :ivar MembersListV2Result.members:
+        List of team members.
+    :ivar MembersListV2Result.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_members_list_continue` to
         obtain the additional members.
-    :ivar team.MembersListV2Result.has_more: Is true if there are additional
-        team members that have not been returned yet. An additional call to
+    :ivar MembersListV2Result.has_more:
+        Is true if there are additional team members that have not been returned
+        yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_members_list_continue` can
         retrieve them.
     """
@@ -8518,7 +8692,8 @@ class MembersRecoverArg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify the user account.
 
-    :ivar team.MembersRecoverArg.user: Identity of user to recover.
+    :ivar MembersRecoverArg.user:
+        Identity of user to recover.
     """
 
     __slots__ = [
@@ -8547,12 +8722,12 @@ class MembersRecoverError(UserSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersRecoverError.user_unrecoverable: The user is not
-        recoverable.
-    :ivar team.MembersRecoverError.user_not_in_team: The user is not a member of
-        the team.
-    :ivar team.MembersRecoverError.team_license_limit: Team is full. The
-        organization has no available licenses.
+    :ivar MembersRecoverError.user_unrecoverable:
+        The user is not recoverable.
+    :ivar MembersRecoverError.user_not_in_team:
+        The user is not a member of the team.
+    :ivar MembersRecoverError.team_license_limit:
+        Team is full. The organization has no available licenses.
     """
 
     _catch_all = 'other'
@@ -8604,27 +8779,29 @@ MembersRecoverError_validator = bv.Union(MembersRecoverError)
 
 class MembersRemoveArg(MembersDeactivateArg):
     """
-    :ivar team.MembersRemoveArg.transfer_dest_id: If provided, files from the
-        deleted member account will be transferred to this user.
-    :ivar team.MembersRemoveArg.transfer_admin_id: If provided, errors during
-        the transfer process will be sent via email to this user. If the
-        transfer_dest_id argument was provided, then this argument must be
-        provided as well.
-    :ivar team.MembersRemoveArg.keep_account: Downgrade the member to a Basic
-        account. The user will retain the email address associated with their
-        Dropbox account and data in their account that is not restricted to team
-        members. In order to keep the account the argument ``wipe_data`` should
-        be set to ``False``.
-    :ivar team.MembersRemoveArg.retain_team_shares: If provided, allows removed
-        users to keep access to Dropbox folders (not Dropbox Paper folders)
-        already explicitly shared with them (not via a group) when they are
-        downgraded to a Basic account. Users will not retain access to folders
-        that do not allow external sharing. In order to keep the sharing
-        relationships, the arguments ``wipe_data`` should be set to ``False``
-        and ``keep_account`` should be set to ``True``.
-    :ivar team.MembersRemoveArg.permanently_delete_files: Permanently delete the
-        data in the deleted member's account. After permanent deletion, the data
-        is no longer available to be transferred to a different user.
+    :ivar MembersRemoveArg.transfer_dest_id:
+        If provided, files from the deleted member account will be transferred
+        to this user.
+    :ivar MembersRemoveArg.transfer_admin_id:
+        If provided, errors during the transfer process will be sent via email
+        to this user. If the transfer_dest_id argument was provided, then this
+        argument must be provided as well.
+    :ivar MembersRemoveArg.keep_account:
+        Downgrade the member to a Basic account. The user will retain the email
+        address associated with their Dropbox account and data in their account
+        that is not restricted to team members. In order to keep the account the
+        argument ``wipe_data`` should be set to ``False``.
+    :ivar MembersRemoveArg.retain_team_shares:
+        If provided, allows removed users to keep access to Dropbox folders (not
+        Dropbox Paper folders) already explicitly shared with them (not via a
+        group) when they are downgraded to a Basic account. Users will not
+        retain access to folders that do not allow external sharing. In order to
+        keep the sharing relationships, the arguments ``wipe_data`` should be
+        set to ``False`` and ``keep_account`` should be set to ``True``.
+    :ivar MembersRemoveArg.permanently_delete_files:
+        Permanently delete the data in the deleted member's account. After
+        permanent deletion, the data is no longer available to be transferred to
+        a different user.
     """
 
     __slots__ = [
@@ -8689,27 +8866,25 @@ class MembersTransferFilesError(MembersPermanentlyDeleteFilesError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar
-        team.MembersTransferFilesError.removed_and_transfer_dest_should_differ:
+    :ivar MembersTransferFilesError.removed_and_transfer_dest_should_differ:
         Expected removed user and transfer_dest user to be different.
-    :ivar
-        team.MembersTransferFilesError.removed_and_transfer_admin_should_differ:
+    :ivar MembersTransferFilesError.removed_and_transfer_admin_should_differ:
         Expected removed user and transfer_admin user to be different.
-    :ivar team.MembersTransferFilesError.transfer_dest_user_not_found: No
-        matching user found for the argument transfer_dest_id.
-    :ivar team.MembersTransferFilesError.transfer_dest_user_not_in_team: The
-        provided transfer_dest_id does not exist on this team.
-    :ivar team.MembersTransferFilesError.transfer_admin_user_not_in_team: The
-        provided transfer_admin_id does not exist on this team.
-    :ivar team.MembersTransferFilesError.transfer_admin_user_not_found: No
-        matching user found for the argument transfer_admin_id.
-    :ivar team.MembersTransferFilesError.unspecified_transfer_admin_id: The
-        transfer_admin_id argument must be provided when file transfer is
+    :ivar MembersTransferFilesError.transfer_dest_user_not_found:
+        No matching user found for the argument transfer_dest_id.
+    :ivar MembersTransferFilesError.transfer_dest_user_not_in_team:
+        The provided transfer_dest_id does not exist on this team.
+    :ivar MembersTransferFilesError.transfer_admin_user_not_in_team:
+        The provided transfer_admin_id does not exist on this team.
+    :ivar MembersTransferFilesError.transfer_admin_user_not_found:
+        No matching user found for the argument transfer_admin_id.
+    :ivar MembersTransferFilesError.unspecified_transfer_admin_id:
+        The transfer_admin_id argument must be provided when file transfer is
         requested.
-    :ivar team.MembersTransferFilesError.transfer_admin_is_not_admin: Specified
-        transfer_admin user is not a team admin.
-    :ivar team.MembersTransferFilesError.recipient_not_verified: The recipient
-        user's email is not verified.
+    :ivar MembersTransferFilesError.transfer_admin_is_not_admin:
+        Specified transfer_admin user is not a team admin.
+    :ivar MembersTransferFilesError.recipient_not_verified:
+        The recipient user's email is not verified.
     """
 
     # Attribute is overwritten below the class definition
@@ -8814,45 +8989,46 @@ class MembersRemoveError(MembersTransferFilesError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersRemoveError.remove_last_admin: The user is the last admin
-        of the team, so it cannot be removed from it.
-    :ivar team.MembersRemoveError.cannot_keep_account_and_transfer: Cannot keep
-        account and transfer the data to another user at the same time.
-    :ivar team.MembersRemoveError.cannot_keep_account_and_delete_data: Cannot
-        keep account and delete the data at the same time. To keep the account
-        the argument wipe_data should be set to ``False``.
-    :ivar team.MembersRemoveError.cannot_keep_account_and_permanently_delete:
+    :ivar MembersRemoveError.remove_last_admin:
+        The user is the last admin of the team, so it cannot be removed from it.
+    :ivar MembersRemoveError.cannot_keep_account_and_transfer:
+        Cannot keep account and transfer the data to another user at the same
+        time.
+    :ivar MembersRemoveError.cannot_keep_account_and_delete_data:
+        Cannot keep account and delete the data at the same time. To keep the
+        account the argument wipe_data should be set to ``False``.
+    :ivar MembersRemoveError.cannot_keep_account_and_permanently_delete:
         Cannot keep account and permanently delete the data at the same time. To
         keep the account the argument permanently_delete_files should be set to
         ``False``.
-    :ivar team.MembersRemoveError.email_address_too_long_to_be_disabled: The
-        email address of the user is too long to be disabled.
-    :ivar team.MembersRemoveError.cannot_keep_invited_user_account: Cannot keep
-        account of an invited user.
-    :ivar team.MembersRemoveError.cannot_retain_shares_when_data_wiped: Cannot
-        retain team shares when the user's data is marked for deletion on their
-        linked devices. The argument wipe_data should be set to ``False``.
-    :ivar team.MembersRemoveError.cannot_retain_shares_when_no_account_kept: The
-        user's account must be kept in order to retain team shares. The argument
-        keep_account should be set to ``True``.
-    :ivar
-        team.MembersRemoveError.cannot_retain_shares_when_team_external_sharing_off:
+    :ivar MembersRemoveError.email_address_too_long_to_be_disabled:
+        The email address of the user is too long to be disabled.
+    :ivar MembersRemoveError.cannot_keep_invited_user_account:
+        Cannot keep account of an invited user.
+    :ivar MembersRemoveError.cannot_retain_shares_when_data_wiped:
+        Cannot retain team shares when the user's data is marked for deletion on
+        their linked devices. The argument wipe_data should be set to ``False``.
+    :ivar MembersRemoveError.cannot_retain_shares_when_no_account_kept:
+        The user's account must be kept in order to retain team shares. The
+        argument keep_account should be set to ``True``.
+    :ivar MembersRemoveError.cannot_retain_shares_when_team_external_sharing_off:
         Externally sharing files, folders, and links must be enabled in team
         settings in order to retain team shares for the user.
-    :ivar team.MembersRemoveError.cannot_keep_account: Only a team admin, can
-        convert this account to a Basic account.
-    :ivar team.MembersRemoveError.cannot_keep_account_under_legal_hold: This
-        user content is currently being held. To convert this member's account
-        to a Basic account, you'll first need to remove them from the hold.
-    :ivar team.MembersRemoveError.cannot_keep_account_required_to_sign_tos: To
-        convert this member to a Basic account, they'll first need to sign in to
-        Dropbox and agree to the terms of service.
-    :ivar team.MembersRemoveError.cannot_permanently_delete_and_transfer: Cannot
-        permanently delete files and transfer the data to another user at the
-        same time.
-    :ivar team.MembersRemoveError.member_is_transfer_destination: This user is
-        the active destination of an in-progress file transfer. Wait for the
-        transfer to complete before removing this member.
+    :ivar MembersRemoveError.cannot_keep_account:
+        Only a team admin, can convert this account to a Basic account.
+    :ivar MembersRemoveError.cannot_keep_account_under_legal_hold:
+        This user content is currently being held. To convert this member's
+        account to a Basic account, you'll first need to remove them from the
+        hold.
+    :ivar MembersRemoveError.cannot_keep_account_required_to_sign_tos:
+        To convert this member to a Basic account, they'll first need to sign in
+        to Dropbox and agree to the terms of service.
+    :ivar MembersRemoveError.cannot_permanently_delete_and_transfer:
+        Cannot permanently delete files and transfer the data to another user at
+        the same time.
+    :ivar MembersRemoveError.member_is_transfer_destination:
+        This user is the active destination of an in-progress file transfer.
+        Wait for the transfer to complete before removing this member.
     """
 
     # Attribute is overwritten below the class definition
@@ -9030,11 +9206,11 @@ class MembersSetPermissions2Arg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify the user account.
 
-    :ivar team.MembersSetPermissions2Arg.user: Identity of user whose role will
-        be set.
-    :ivar team.MembersSetPermissions2Arg.new_roles: The new roles for the
-        member. Send empty list to make user member only. For now, only up to
-        one role is allowed.
+    :ivar MembersSetPermissions2Arg.user:
+        Identity of user whose role will be set.
+    :ivar MembersSetPermissions2Arg.new_roles:
+        The new roles for the member. Send empty list to make user member only.
+        For now, only up to one role is allowed.
     """
 
     __slots__ = [
@@ -9071,16 +9247,16 @@ class MembersSetPermissions2Error(UserSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersSetPermissions2Error.last_admin: Cannot remove the admin
-        setting of the last admin.
-    :ivar team.MembersSetPermissions2Error.user_not_in_team: The user is not a
-        member of the team.
-    :ivar team.MembersSetPermissions2Error.cannot_set_permissions: Cannot
-        remove/grant permissions. This can happen if the team member is
+    :ivar MembersSetPermissions2Error.last_admin:
+        Cannot remove the admin setting of the last admin.
+    :ivar MembersSetPermissions2Error.user_not_in_team:
+        The user is not a member of the team.
+    :ivar MembersSetPermissions2Error.cannot_set_permissions:
+        Cannot remove/grant permissions. This can happen if the team member is
         suspended.
-    :ivar team.MembersSetPermissions2Error.role_not_found: No matching role
-        found. At least one of the provided new_roles does not exist on this
-        team.
+    :ivar MembersSetPermissions2Error.role_not_found:
+        No matching role found. At least one of the provided new_roles does not
+        exist on this team.
     """
 
     _catch_all = 'other'
@@ -9142,10 +9318,10 @@ MembersSetPermissions2Error_validator = bv.Union(MembersSetPermissions2Error)
 
 class MembersSetPermissions2Result(bb.Struct):
     """
-    :ivar team.MembersSetPermissions2Result.team_member_id: The member ID of the
-        user to which the change was applied.
-    :ivar team.MembersSetPermissions2Result.roles: The roles after the change.
-        Empty in case the user become a non-admin.
+    :ivar MembersSetPermissions2Result.team_member_id:
+        The member ID of the user to which the change was applied.
+    :ivar MembersSetPermissions2Result.roles:
+        The roles after the change. Empty in case the user become a non-admin.
     """
 
     __slots__ = [
@@ -9181,9 +9357,10 @@ class MembersSetPermissionsArg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify the user account.
 
-    :ivar team.MembersSetPermissionsArg.user: Identity of user whose role will
-        be set.
-    :ivar team.MembersSetPermissionsArg.new_role: The new role of the member.
+    :ivar MembersSetPermissionsArg.user:
+        Identity of user whose role will be set.
+    :ivar MembersSetPermissionsArg.new_role:
+        The new role of the member.
     """
 
     __slots__ = [
@@ -9220,14 +9397,14 @@ class MembersSetPermissionsError(UserSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersSetPermissionsError.last_admin: Cannot remove the admin
-        setting of the last admin.
-    :ivar team.MembersSetPermissionsError.user_not_in_team: The user is not a
-        member of the team.
-    :ivar team.MembersSetPermissionsError.cannot_set_permissions: Cannot
-        remove/grant permissions.
-    :ivar team.MembersSetPermissionsError.team_license_limit: Team is full. The
-        organization has no available licenses.
+    :ivar MembersSetPermissionsError.last_admin:
+        Cannot remove the admin setting of the last admin.
+    :ivar MembersSetPermissionsError.user_not_in_team:
+        The user is not a member of the team.
+    :ivar MembersSetPermissionsError.cannot_set_permissions:
+        Cannot remove/grant permissions.
+    :ivar MembersSetPermissionsError.team_license_limit:
+        Team is full. The organization has no available licenses.
     """
 
     _catch_all = 'other'
@@ -9289,9 +9466,10 @@ MembersSetPermissionsError_validator = bv.Union(MembersSetPermissionsError)
 
 class MembersSetPermissionsResult(bb.Struct):
     """
-    :ivar team.MembersSetPermissionsResult.team_member_id: The member ID of the
-        user to which the change was applied.
-    :ivar team.MembersSetPermissionsResult.role: The role after the change.
+    :ivar MembersSetPermissionsResult.team_member_id:
+        The member ID of the user to which the change was applied.
+    :ivar MembersSetPermissionsResult.role:
+        The role after the change.
     """
 
     __slots__ = [
@@ -9328,16 +9506,21 @@ class MembersSetProfileArg(bb.Struct):
     identify the user account. At least one of new_email, new_external_id,
     new_given_name, and/or new_surname must be provided.
 
-    :ivar team.MembersSetProfileArg.user: Identity of user whose profile will be
-        set.
-    :ivar team.MembersSetProfileArg.new_email: New email for member.
-    :ivar team.MembersSetProfileArg.new_external_id: New external ID for member.
-    :ivar team.MembersSetProfileArg.new_given_name: New given name for member.
-    :ivar team.MembersSetProfileArg.new_surname: New surname for member.
-    :ivar team.MembersSetProfileArg.new_persistent_id: New persistent ID. This
-        field only available to teams using persistent ID SAML configuration.
-    :ivar team.MembersSetProfileArg.new_is_directory_restricted: New value for
-        whether the user is a directory restricted user.
+    :ivar MembersSetProfileArg.user:
+        Identity of user whose profile will be set.
+    :ivar MembersSetProfileArg.new_email:
+        New email for member.
+    :ivar MembersSetProfileArg.new_external_id:
+        New external ID for member.
+    :ivar MembersSetProfileArg.new_given_name:
+        New given name for member.
+    :ivar MembersSetProfileArg.new_surname:
+        New surname for member.
+    :ivar MembersSetProfileArg.new_persistent_id:
+        New persistent ID. This field only available to teams using persistent
+        ID SAML configuration.
+    :ivar MembersSetProfileArg.new_is_directory_restricted:
+        New value for whether the user is a directory restricted user.
     """
 
     __slots__ = [
@@ -9414,25 +9597,26 @@ class MembersSetProfileError(MemberSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersSetProfileError.external_id_and_new_external_id_unsafe: It
-        is unsafe to use both external_id and new_external_id.
-    :ivar team.MembersSetProfileError.no_new_data_specified: None of new_email,
-        new_given_name, new_surname, or new_external_id are specified.
-    :ivar team.MembersSetProfileError.email_reserved_for_other_user: Email is
-        already reserved for another user.
-    :ivar team.MembersSetProfileError.external_id_used_by_other_user: The
-        external ID is already in use by another team member.
-    :ivar team.MembersSetProfileError.set_profile_disallowed: Modifying deleted
-        users is not allowed.
-    :ivar team.MembersSetProfileError.param_cannot_be_empty: Parameter new_email
-        cannot be empty.
-    :ivar team.MembersSetProfileError.persistent_id_disabled: Persistent ID is
-        only available to teams with persistent ID SAML configuration. Please
-        contact Dropbox for more information.
-    :ivar team.MembersSetProfileError.persistent_id_used_by_other_user: The
-        persistent ID is already in use by another team member.
-    :ivar team.MembersSetProfileError.directory_restricted_off: Directory
-        Restrictions option is not available.
+    :ivar MembersSetProfileError.external_id_and_new_external_id_unsafe:
+        It is unsafe to use both external_id and new_external_id.
+    :ivar MembersSetProfileError.no_new_data_specified:
+        None of new_email, new_given_name, new_surname, or new_external_id are
+        specified.
+    :ivar MembersSetProfileError.email_reserved_for_other_user:
+        Email is already reserved for another user.
+    :ivar MembersSetProfileError.external_id_used_by_other_user:
+        The external ID is already in use by another team member.
+    :ivar MembersSetProfileError.set_profile_disallowed:
+        Modifying deleted users is not allowed.
+    :ivar MembersSetProfileError.param_cannot_be_empty:
+        Parameter new_email cannot be empty.
+    :ivar MembersSetProfileError.persistent_id_disabled:
+        Persistent ID is only available to teams with persistent ID SAML
+        configuration. Please contact Dropbox for more information.
+    :ivar MembersSetProfileError.persistent_id_used_by_other_user:
+        The persistent ID is already in use by another team member.
+    :ivar MembersSetProfileError.directory_restricted_off:
+        Directory Restrictions option is not available.
     """
 
     _catch_all = 'other'
@@ -9544,10 +9728,10 @@ MembersSetProfileError_validator = bv.Union(MembersSetProfileError)
 
 class MembersSetProfilePhotoArg(bb.Struct):
     """
-    :ivar team.MembersSetProfilePhotoArg.user: Identity of the user whose
-        profile photo will be set.
-    :ivar team.MembersSetProfilePhotoArg.photo: Image to set as the member's new
-        profile photo.
+    :ivar MembersSetProfilePhotoArg.user:
+        Identity of the user whose profile photo will be set.
+    :ivar MembersSetProfilePhotoArg.photo:
+        Image to set as the member's new profile photo.
     """
 
     __slots__ = [
@@ -9584,8 +9768,8 @@ class MembersSetProfilePhotoError(MemberSelectorError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersSetProfilePhotoError.set_profile_disallowed: Modifying
-        deleted users is not allowed.
+    :ivar MembersSetProfilePhotoError.set_profile_disallowed:
+        Modifying deleted users is not allowed.
     """
 
     _catch_all = 'other'
@@ -9650,12 +9834,12 @@ class MembersSuspendError(MembersDeactivateError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersSuspendError.suspend_inactive_user: The user is not
-        active, so it cannot be suspended.
-    :ivar team.MembersSuspendError.suspend_last_admin: The user is the last
-        admin of the team, so it cannot be suspended.
-    :ivar team.MembersSuspendError.team_license_limit: Team is full. The
-        organization has no available licenses.
+    :ivar MembersSuspendError.suspend_inactive_user:
+        The user is not active, so it cannot be suspended.
+    :ivar MembersSuspendError.suspend_last_admin:
+        The user is the last admin of the team, so it cannot be suspended.
+    :ivar MembersSuspendError.team_license_limit:
+        Team is full. The organization has no available licenses.
     """
 
     # Attribute is overwritten below the class definition
@@ -9700,17 +9884,14 @@ class MembersTransferFormerMembersFilesError(MembersTransferFilesError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar
-        team.MembersTransferFormerMembersFilesError.user_data_is_being_transferred:
+    :ivar MembersTransferFormerMembersFilesError.user_data_is_being_transferred:
         The user's data is being transferred. Please wait some time before
         retrying.
-    :ivar team.MembersTransferFormerMembersFilesError.user_not_removed: No
-        matching removed user found for the argument user.
-    :ivar
-        team.MembersTransferFormerMembersFilesError.user_data_cannot_be_transferred:
+    :ivar MembersTransferFormerMembersFilesError.user_not_removed:
+        No matching removed user found for the argument user.
+    :ivar MembersTransferFormerMembersFilesError.user_data_cannot_be_transferred:
         User files aren't transferable anymore.
-    :ivar
-        team.MembersTransferFormerMembersFilesError.user_data_already_transferred:
+    :ivar MembersTransferFormerMembersFilesError.user_data_already_transferred:
         User's data has already been transferred to another user.
     """
 
@@ -9765,7 +9946,8 @@ class MembersUnsuspendArg(bb.Struct):
     Exactly one of team_member_id, email, or external_id must be provided to
     identify the user account.
 
-    :ivar team.MembersUnsuspendArg.user: Identity of user to unsuspend.
+    :ivar MembersUnsuspendArg.user:
+        Identity of user to unsuspend.
     """
 
     __slots__ = [
@@ -9794,10 +9976,10 @@ class MembersUnsuspendError(MembersDeactivateError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MembersUnsuspendError.unsuspend_non_suspended_member: The user is
-        unsuspended, so it cannot be unsuspended again.
-    :ivar team.MembersUnsuspendError.team_license_limit: Team is full. The
-        organization has no available licenses.
+    :ivar MembersUnsuspendError.unsuspend_non_suspended_member:
+        The user is unsuspended, so it cannot be unsuspended again.
+    :ivar MembersUnsuspendError.team_license_limit:
+        Team is full. The organization has no available licenses.
     """
 
     # Attribute is overwritten below the class definition
@@ -9832,13 +10014,16 @@ class MobileClientPlatform(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.MobileClientPlatform.iphone: Official Dropbox iPhone client.
-    :ivar team.MobileClientPlatform.ipad: Official Dropbox iPad client.
-    :ivar team.MobileClientPlatform.android: Official Dropbox Android client.
-    :ivar team.MobileClientPlatform.windows_phone: Official Dropbox Windows
-        phone client.
-    :ivar team.MobileClientPlatform.blackberry: Official Dropbox Blackberry
-        client.
+    :ivar MobileClientPlatform.iphone:
+        Official Dropbox iPhone client.
+    :ivar MobileClientPlatform.ipad:
+        Official Dropbox iPad client.
+    :ivar MobileClientPlatform.android:
+        Official Dropbox Android client.
+    :ivar MobileClientPlatform.windows_phone:
+        Official Dropbox Windows phone client.
+    :ivar MobileClientPlatform.blackberry:
+        Official Dropbox Blackberry client.
     """
 
     _catch_all = 'other'
@@ -9912,12 +10097,16 @@ class MobileClientSession(DeviceSession):
     """
     Information about linked Dropbox mobile client sessions.
 
-    :ivar team.MobileClientSession.device_name: The device name.
-    :ivar team.MobileClientSession.client_type: The mobile application type.
-    :ivar team.MobileClientSession.client_version: The dropbox client version.
-    :ivar team.MobileClientSession.os_version: The hosting OS version.
-    :ivar team.MobileClientSession.last_carrier: last carrier used by the
-        device.
+    :ivar MobileClientSession.device_name:
+        The device name.
+    :ivar MobileClientSession.client_type:
+        The mobile application type.
+    :ivar MobileClientSession.client_version:
+        The dropbox client version.
+    :ivar MobileClientSession.os_version:
+        The hosting OS version.
+    :ivar MobileClientSession.last_carrier:
+        last carrier used by the device.
     """
 
     __slots__ = [
@@ -9986,14 +10175,18 @@ class NamespaceMetadata(bb.Struct):
     """
     Properties of a namespace.
 
-    :ivar team.NamespaceMetadata.name: The name of this namespace.
-    :ivar team.NamespaceMetadata.namespace_id: The ID of this namespace.
-    :ivar team.NamespaceMetadata.namespace_type: The type of this namespace.
-    :ivar team.NamespaceMetadata.team_member_id: If this is a team member or app
-        folder, the ID of the owning team member. Otherwise, this field is not
-        present.
-    :ivar team.NamespaceMetadata.quota_limit: The quota limit in bytes for this
-        namespace tree. Only applicable to team folders.
+    :ivar NamespaceMetadata.name:
+        The name of this namespace.
+    :ivar NamespaceMetadata.namespace_id:
+        The ID of this namespace.
+    :ivar NamespaceMetadata.namespace_type:
+        The type of this namespace.
+    :ivar NamespaceMetadata.team_member_id:
+        If this is a team member or app folder, the ID of the owning team
+        member. Otherwise, this field is not present.
+    :ivar NamespaceMetadata.quota_limit:
+        The quota limit in bytes for this namespace tree. Only applicable to
+        team folders.
     """
 
     __slots__ = [
@@ -10054,11 +10247,16 @@ class NamespaceType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.NamespaceType.app_folder: App sandbox folder.
-    :ivar team.NamespaceType.shared_folder: Shared folder.
-    :ivar team.NamespaceType.team_folder: Top-level team-owned folder.
-    :ivar team.NamespaceType.team_member_folder: Team member's home folder.
-    :ivar team.NamespaceType.team_member_root: Team member's root folder.
+    :ivar NamespaceType.app_folder:
+        App sandbox folder.
+    :ivar NamespaceType.shared_folder:
+        Shared folder.
+    :ivar NamespaceType.team_folder:
+        Top-level team-owned folder.
+    :ivar NamespaceType.team_member_folder:
+        Team member's home folder.
+    :ivar NamespaceType.team_member_root:
+        Team member's root folder.
     """
 
     _catch_all = 'other'
@@ -10136,10 +10334,12 @@ class RemoveCustomQuotaResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserSelectorArg RemoveCustomQuotaResult.success: Successfully removed
-        user.
-    :ivar UserSelectorArg RemoveCustomQuotaResult.invalid_user: Invalid user
-        (not in team).
+    :ivar RemoveCustomQuotaResult.success:
+        Successfully removed user.
+    :vartype RemoveCustomQuotaResult.success: UserSelectorArg
+    :ivar RemoveCustomQuotaResult.invalid_user:
+        Invalid user (not in team).
+    :vartype RemoveCustomQuotaResult.invalid_user: UserSelectorArg
     """
 
     _catch_all = 'other'
@@ -10223,10 +10423,10 @@ RemoveCustomQuotaResult_validator = bv.Union(RemoveCustomQuotaResult)
 
 class RemovedStatus(bb.Struct):
     """
-    :ivar team.RemovedStatus.is_recoverable: True if the removed team member is
-        recoverable.
-    :ivar team.RemovedStatus.is_disconnected: True if the team member's account
-        was converted to individual account.
+    :ivar RemovedStatus.is_recoverable:
+        True if the removed team member is recoverable.
+    :ivar RemovedStatus.is_disconnected:
+        True if the team member's account was converted to individual account.
     """
 
     __slots__ = [
@@ -10268,12 +10468,17 @@ class ResendSecondaryEmailResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.ResendSecondaryEmailResult.success: A verification email was
-        successfully sent to the secondary email address.
-    :ivar str team.ResendSecondaryEmailResult.not_pending: This secondary email
-        address is not pending for the user.
-    :ivar str team.ResendSecondaryEmailResult.rate_limited: Too many emails are
-        being sent to this email address. Please try again later.
+    :ivar ResendSecondaryEmailResult.success:
+        A verification email was successfully sent to the secondary email
+        address.
+    :vartype ResendSecondaryEmailResult.success: str
+    :ivar ResendSecondaryEmailResult.not_pending:
+        This secondary email address is not pending for the user.
+    :vartype ResendSecondaryEmailResult.not_pending: str
+    :ivar ResendSecondaryEmailResult.rate_limited:
+        Too many emails are being sent to this email address. Please try again
+        later.
+    :vartype ResendSecondaryEmailResult.rate_limited: str
     """
 
     _catch_all = 'other'
@@ -10390,8 +10595,8 @@ ResendSecondaryEmailResult_validator = bv.Union(ResendSecondaryEmailResult)
 
 class ResendVerificationEmailArg(bb.Struct):
     """
-    :ivar team.ResendVerificationEmailArg.emails_to_resend: List of users and
-        secondary emails to resend verification emails to.
+    :ivar ResendVerificationEmailArg.emails_to_resend:
+        List of users and secondary emails to resend verification emails to.
     """
 
     __slots__ = [
@@ -10441,9 +10646,10 @@ ResendVerificationEmailResult_validator = bv.Struct(ResendVerificationEmailResul
 
 class RevokeDesktopClientArg(DeviceSessionArg):
     """
-    :ivar team.RevokeDesktopClientArg.delete_on_unlink: Whether to delete all
-        files of the account (this is possible only if supported by the desktop
-        client and  will be made the next time the client access the account).
+    :ivar RevokeDesktopClientArg.delete_on_unlink:
+        Whether to delete all files of the account (this is possible only if
+        supported by the desktop client and  will be made the next time the
+        client access the account).
     """
 
     __slots__ = [
@@ -10476,12 +10682,15 @@ class RevokeDeviceSessionArg(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar DeviceSessionArg RevokeDeviceSessionArg.web_session: End an active
-        session.
-    :ivar RevokeDesktopClientArg RevokeDeviceSessionArg.desktop_client: Unlink a
-        linked desktop device.
-    :ivar DeviceSessionArg RevokeDeviceSessionArg.mobile_client: Unlink a linked
-        mobile device.
+    :ivar RevokeDeviceSessionArg.web_session:
+        End an active session.
+    :vartype RevokeDeviceSessionArg.web_session: DeviceSessionArg
+    :ivar RevokeDeviceSessionArg.desktop_client:
+        Unlink a linked desktop device.
+    :vartype RevokeDeviceSessionArg.desktop_client: RevokeDesktopClientArg
+    :ivar RevokeDeviceSessionArg.mobile_client:
+        Unlink a linked mobile device.
+    :vartype RevokeDeviceSessionArg.mobile_client: DeviceSessionArg
     """
 
     _catch_all = None
@@ -10658,9 +10867,10 @@ class RevokeDeviceSessionError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.RevokeDeviceSessionError.device_session_not_found: Device session
-        not found.
-    :ivar team.RevokeDeviceSessionError.member_not_found: Member not found.
+    :ivar RevokeDeviceSessionError.device_session_not_found:
+        Device session not found.
+    :ivar RevokeDeviceSessionError.member_not_found:
+        Member not found.
     """
 
     _catch_all = 'other'
@@ -10702,10 +10912,10 @@ RevokeDeviceSessionError_validator = bv.Union(RevokeDeviceSessionError)
 
 class RevokeDeviceSessionStatus(bb.Struct):
     """
-    :ivar team.RevokeDeviceSessionStatus.success: Result of the revoking
-        request.
-    :ivar team.RevokeDeviceSessionStatus.error_type: The error cause in case of
-        a failure.
+    :ivar RevokeDeviceSessionStatus.success:
+        Result of the revoking request.
+    :ivar RevokeDeviceSessionStatus.error_type:
+        The error cause in case of a failure.
     """
 
     __slots__ = [
@@ -10738,12 +10948,13 @@ RevokeDeviceSessionStatus_validator = bv.Struct(RevokeDeviceSessionStatus)
 
 class RevokeLinkedApiAppArg(bb.Struct):
     """
-    :ivar team.RevokeLinkedApiAppArg.app_id: The application's unique id.
-    :ivar team.RevokeLinkedApiAppArg.team_member_id: The unique id of the member
-        owning the device.
-    :ivar team.RevokeLinkedApiAppArg.keep_app_folder: Field is deprecated. This
-        flag is not longer supported, the application dedicated folder (in case
-        the application uses one) will be kept.
+    :ivar RevokeLinkedApiAppArg.app_id:
+        The application's unique id.
+    :ivar RevokeLinkedApiAppArg.team_member_id:
+        The unique id of the member owning the device.
+    :ivar RevokeLinkedApiAppArg.keep_app_folder:
+        Field is deprecated. This flag is not longer supported, the application
+        dedicated folder (in case the application uses one) will be kept.
     """
 
     __slots__ = [
@@ -10862,10 +11073,12 @@ class RevokeLinkedAppError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.RevokeLinkedAppError.app_not_found: Application not found.
-    :ivar team.RevokeLinkedAppError.member_not_found: Member not found.
-    :ivar team.RevokeLinkedAppError.app_folder_removal_not_supported: App folder
-        removal is not supported.
+    :ivar RevokeLinkedAppError.app_not_found:
+        Application not found.
+    :ivar RevokeLinkedAppError.member_not_found:
+        Member not found.
+    :ivar RevokeLinkedAppError.app_folder_removal_not_supported:
+        App folder removal is not supported.
     """
 
     _catch_all = 'other'
@@ -10917,9 +11130,10 @@ RevokeLinkedAppError_validator = bv.Union(RevokeLinkedAppError)
 
 class RevokeLinkedAppStatus(bb.Struct):
     """
-    :ivar team.RevokeLinkedAppStatus.success: Result of the revoking request.
-    :ivar team.RevokeLinkedAppStatus.error_type: The error cause in case of a
-        failure.
+    :ivar RevokeLinkedAppStatus.success:
+        Result of the revoking request.
+    :ivar RevokeLinkedAppStatus.error_type:
+        The error cause in case of a failure.
     """
 
     __slots__ = [
@@ -10952,8 +11166,8 @@ RevokeLinkedAppStatus_validator = bv.Struct(RevokeLinkedAppStatus)
 
 class SetCustomQuotaArg(bb.Struct):
     """
-    :ivar team.SetCustomQuotaArg.users_and_quotas: List of users and their
-        custom quotas.
+    :ivar SetCustomQuotaArg.users_and_quotas:
+        List of users and their custom quotas.
     """
 
     __slots__ = [
@@ -10984,8 +11198,9 @@ class SetCustomQuotaError(CustomQuotaError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.SetCustomQuotaError.some_users_are_excluded: Some of the users
-        are on the excluded users list and can't have custom quota set.
+    :ivar SetCustomQuotaError.some_users_are_excluded:
+        Some of the users are on the excluded users list and can't have custom
+        quota set.
     """
 
     # Attribute is overwritten below the class definition
@@ -11009,10 +11224,11 @@ class SharingAllowlistAddArgs(bb.Struct):
     Structure representing Approve List entries. Domain and emails are
     supported. At least one entry of any supported type is required.
 
-    :ivar team.SharingAllowlistAddArgs.domains: List of domains represented by
-        valid string representation (RFC-1034/5).
-    :ivar team.SharingAllowlistAddArgs.emails: List of emails represented by
-        valid string representation (RFC-5322/822).
+    :ivar SharingAllowlistAddArgs.domains:
+        List of domains represented by valid string representation (RFC-1034/5).
+    :ivar SharingAllowlistAddArgs.emails:
+        List of emails represented by valid string representation
+        (RFC-5322/822).
     """
 
     __slots__ = [
@@ -11049,17 +11265,20 @@ class SharingAllowlistAddError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.SharingAllowlistAddError.malformed_entry: One of provided
-        values is not valid.
-    :ivar team.SharingAllowlistAddError.no_entries_provided: Neither single
-        domain nor email provided.
-    :ivar team.SharingAllowlistAddError.too_many_entries_provided: Too many
-        entries provided within one call.
-    :ivar team.SharingAllowlistAddError.team_limit_reached: Team entries limit
-        reached.
-    :ivar team.SharingAllowlistAddError.unknown_error: Unknown error.
-    :ivar str team.SharingAllowlistAddError.entries_already_exist: Entries
-        already exists.
+    :ivar SharingAllowlistAddError.malformed_entry:
+        One of provided values is not valid.
+    :vartype SharingAllowlistAddError.malformed_entry: str
+    :ivar SharingAllowlistAddError.no_entries_provided:
+        Neither single domain nor email provided.
+    :ivar SharingAllowlistAddError.too_many_entries_provided:
+        Too many entries provided within one call.
+    :ivar SharingAllowlistAddError.team_limit_reached:
+        Team entries limit reached.
+    :ivar SharingAllowlistAddError.unknown_error:
+        Unknown error.
+    :ivar SharingAllowlistAddError.entries_already_exist:
+        Entries already exists.
+    :vartype SharingAllowlistAddError.entries_already_exist: str
     """
 
     _catch_all = 'other'
@@ -11202,8 +11421,8 @@ SharingAllowlistAddResponse_validator = bv.Struct(SharingAllowlistAddResponse)
 
 class SharingAllowlistListArg(bb.Struct):
     """
-    :ivar team.SharingAllowlistListArg.limit: The number of entries to fetch at
-        one time.
+    :ivar SharingAllowlistListArg.limit:
+        The number of entries to fetch at one time.
     """
 
     __slots__ = [
@@ -11228,8 +11447,8 @@ SharingAllowlistListArg_validator = bv.Struct(SharingAllowlistListArg)
 
 class SharingAllowlistListContinueArg(bb.Struct):
     """
-    :ivar team.SharingAllowlistListContinueArg.cursor: The cursor returned from
-        a previous call to
+    :ivar SharingAllowlistListContinueArg.cursor:
+        The cursor returned from a previous call to
         :meth:`dropbox.dropbox_client.Dropbox.team_sharing_allowlist_list` or
         :meth:`dropbox.dropbox_client.Dropbox.team_sharing_allowlist_list_continue`.
     """
@@ -11260,8 +11479,8 @@ class SharingAllowlistListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.SharingAllowlistListContinueError.invalid_cursor: Provided cursor
-        is not valid.
+    :ivar SharingAllowlistListContinueError.invalid_cursor:
+        Provided cursor is not valid.
     """
 
     _catch_all = 'other'
@@ -11312,15 +11531,16 @@ SharingAllowlistListError_validator = bv.Struct(SharingAllowlistListError)
 
 class SharingAllowlistListResponse(bb.Struct):
     """
-    :ivar team.SharingAllowlistListResponse.domains: List of domains represented
-        by valid string representation (RFC-1034/5).
-    :ivar team.SharingAllowlistListResponse.emails: List of emails represented
-        by valid string representation (RFC-5322/822).
-    :ivar team.SharingAllowlistListResponse.cursor: If this is nonempty, there
-        are more entries that can be fetched with
+    :ivar SharingAllowlistListResponse.domains:
+        List of domains represented by valid string representation (RFC-1034/5).
+    :ivar SharingAllowlistListResponse.emails:
+        List of emails represented by valid string representation
+        (RFC-5322/822).
+    :ivar SharingAllowlistListResponse.cursor:
+        If this is nonempty, there are more entries that can be fetched with
         :meth:`dropbox.dropbox_client.Dropbox.team_sharing_allowlist_list_continue`.
-    :ivar team.SharingAllowlistListResponse.has_more: if true indicates that
-        more entries can be fetched with
+    :ivar SharingAllowlistListResponse.has_more:
+        if true indicates that more entries can be fetched with
         :meth:`dropbox.dropbox_client.Dropbox.team_sharing_allowlist_list_continue`.
     """
 
@@ -11370,10 +11590,11 @@ SharingAllowlistListResponse_validator = bv.Struct(SharingAllowlistListResponse)
 
 class SharingAllowlistRemoveArgs(bb.Struct):
     """
-    :ivar team.SharingAllowlistRemoveArgs.domains: List of domains represented
-        by valid string representation (RFC-1034/5).
-    :ivar team.SharingAllowlistRemoveArgs.emails: List of emails represented by
-        valid string representation (RFC-5322/822).
+    :ivar SharingAllowlistRemoveArgs.domains:
+        List of domains represented by valid string representation (RFC-1034/5).
+    :ivar SharingAllowlistRemoveArgs.emails:
+        List of emails represented by valid string representation
+        (RFC-5322/822).
     """
 
     __slots__ = [
@@ -11410,15 +11631,18 @@ class SharingAllowlistRemoveError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.SharingAllowlistRemoveError.malformed_entry: One of provided
-        values is not valid.
-    :ivar str team.SharingAllowlistRemoveError.entries_do_not_exist: One or more
-        provided values do not exist.
-    :ivar team.SharingAllowlistRemoveError.no_entries_provided: Neither single
-        domain nor email provided.
-    :ivar team.SharingAllowlistRemoveError.too_many_entries_provided: Too many
-        entries provided within one call.
-    :ivar team.SharingAllowlistRemoveError.unknown_error: Unknown error.
+    :ivar SharingAllowlistRemoveError.malformed_entry:
+        One of provided values is not valid.
+    :vartype SharingAllowlistRemoveError.malformed_entry: str
+    :ivar SharingAllowlistRemoveError.entries_do_not_exist:
+        One or more provided values do not exist.
+    :vartype SharingAllowlistRemoveError.entries_do_not_exist: str
+    :ivar SharingAllowlistRemoveError.no_entries_provided:
+        Neither single domain nor email provided.
+    :ivar SharingAllowlistRemoveError.too_many_entries_provided:
+        Too many entries provided within one call.
+    :ivar SharingAllowlistRemoveError.unknown_error:
+        Unknown error.
     """
 
     _catch_all = 'other'
@@ -11553,10 +11777,12 @@ class StorageBucket(bb.Struct):
     """
     Describes the number of users in a specific storage bucket.
 
-    :ivar team.StorageBucket.bucket: The name of the storage bucket. For
-        example, '1G' is a bucket of users with storage size up to 1 Giga.
-    :ivar team.StorageBucket.users: The number of people whose storage is in the
-        range of this storage bucket.
+    :ivar StorageBucket.bucket:
+        The name of the storage bucket. For example, '1G' is a bucket of users
+        with storage size up to 1 Giga.
+    :ivar StorageBucket.users:
+        The number of people whose storage is in the range of this storage
+        bucket.
     """
 
     __slots__ = [
@@ -11593,10 +11819,11 @@ class TeamFolderAccessError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderAccessError.invalid_team_folder_id: The team folder ID
-        is invalid.
-    :ivar team.TeamFolderAccessError.no_access: The authenticated app does not
-        have permission to manage that team folder.
+    :ivar TeamFolderAccessError.invalid_team_folder_id:
+        The team folder ID is invalid.
+    :ivar TeamFolderAccessError.no_access:
+        The authenticated app does not have permission to manage that team
+        folder.
     """
 
     _catch_all = 'other'
@@ -11650,7 +11877,8 @@ TeamFolderActivateError_validator = bv.Union(TeamFolderActivateError)
 
 class TeamFolderIdArg(bb.Struct):
     """
-    :ivar team.TeamFolderIdArg.team_folder_id: The ID of the team folder.
+    :ivar TeamFolderIdArg.team_folder_id:
+        The ID of the team folder.
     """
 
     __slots__ = [
@@ -11675,8 +11903,8 @@ TeamFolderIdArg_validator = bv.Struct(TeamFolderIdArg)
 
 class TeamFolderArchiveArg(TeamFolderIdArg):
     """
-    :ivar team.TeamFolderArchiveArg.force_async_off: Whether to force the
-        archive to happen synchronously.
+    :ivar TeamFolderArchiveArg.force_async_off:
+        Whether to force the archive to happen synchronously.
     """
 
     __slots__ = [
@@ -11719,12 +11947,14 @@ class TeamFolderArchiveJobStatus(async_.PollResultBase):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar TeamFolderMetadata TeamFolderArchiveJobStatus.complete: The archive
-        job has finished. The value is the metadata for the resulting team
-        folder.
-    :ivar TeamFolderArchiveError TeamFolderArchiveJobStatus.failed: Error
-        occurred while performing an asynchronous job from
+    :ivar TeamFolderArchiveJobStatus.complete:
+        The archive job has finished. The value is the metadata for the
+        resulting team folder.
+    :vartype TeamFolderArchiveJobStatus.complete: TeamFolderMetadata
+    :ivar TeamFolderArchiveJobStatus.failed:
+        Error occurred while performing an asynchronous job from
         :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_archive`.
+    :vartype TeamFolderArchiveJobStatus.failed: TeamFolderArchiveError
     """
 
     @classmethod
@@ -11839,10 +12069,11 @@ TeamFolderArchiveLaunch_validator = bv.Union(TeamFolderArchiveLaunch)
 
 class TeamFolderCreateArg(bb.Struct):
     """
-    :ivar team.TeamFolderCreateArg.name: Name for the new team folder.
-    :ivar team.TeamFolderCreateArg.sync_setting: The sync setting to apply to
-        this team folder. Only permitted if the team has team selective sync
-        enabled.
+    :ivar TeamFolderCreateArg.name:
+        Name for the new team folder.
+    :ivar TeamFolderCreateArg.sync_setting:
+        The sync setting to apply to this team folder. Only permitted if the
+        team has team selective sync enabled.
     """
 
     __slots__ = [
@@ -11879,16 +12110,18 @@ class TeamFolderCreateError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderCreateError.invalid_folder_name: The provided name
-        cannot be used.
-    :ivar team.TeamFolderCreateError.folder_name_already_used: There is already
-        a team folder with the provided name.
-    :ivar team.TeamFolderCreateError.folder_name_reserved: The provided name
-        cannot be used because it is reserved.
-    :ivar SyncSettingsError TeamFolderCreateError.sync_settings_error: An error
-        occurred setting the sync settings.
-    :ivar team.TeamFolderCreateError.folder_count_limit_exceeded: The team has
-        reached the maximum number of team folders allowed by its plan.
+    :ivar TeamFolderCreateError.invalid_folder_name:
+        The provided name cannot be used.
+    :ivar TeamFolderCreateError.folder_name_already_used:
+        There is already a team folder with the provided name.
+    :ivar TeamFolderCreateError.folder_name_reserved:
+        The provided name cannot be used because it is reserved.
+    :ivar TeamFolderCreateError.sync_settings_error:
+        An error occurred setting the sync settings.
+    :vartype TeamFolderCreateError.sync_settings_error: files.SyncSettingsError
+    :ivar TeamFolderCreateError.folder_count_limit_exceeded:
+        The team has reached the maximum number of team folders allowed by its
+        plan.
     """
 
     _catch_all = 'other'
@@ -11985,11 +12218,14 @@ class TeamFolderGetInfoItem(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str team.TeamFolderGetInfoItem.id_not_found: An ID that was provided
-        as a parameter to :route:`team_folder/get_info` did not match any of the
-        team's team folders.
-    :ivar TeamFolderMetadata TeamFolderGetInfoItem.team_folder_metadata:
+    :ivar TeamFolderGetInfoItem.id_not_found:
+        An ID that was provided as a parameter to
+        :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_get_info` did not
+        match any of the team's team folders.
+    :vartype TeamFolderGetInfoItem.id_not_found: str
+    :ivar TeamFolderGetInfoItem.team_folder_metadata:
         Properties of a team folder.
+    :vartype TeamFolderGetInfoItem.team_folder_metadata: TeamFolderMetadata
     """
 
     _catch_all = None
@@ -12065,7 +12301,8 @@ TeamFolderGetInfoItem_validator = bv.Union(TeamFolderGetInfoItem)
 
 class TeamFolderIdListArg(bb.Struct):
     """
-    :ivar team.TeamFolderIdListArg.team_folder_ids: The list of team folder IDs.
+    :ivar TeamFolderIdListArg.team_folder_ids:
+        The list of team folder IDs.
     """
 
     __slots__ = [
@@ -12094,12 +12331,12 @@ class TeamFolderInvalidStatusError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderInvalidStatusError.active: The folder is active and the
-        operation did not succeed.
-    :ivar team.TeamFolderInvalidStatusError.archived: The folder is archived and
-        the operation did not succeed.
-    :ivar team.TeamFolderInvalidStatusError.archive_in_progress: The folder is
-        being archived and the operation did not succeed.
+    :ivar TeamFolderInvalidStatusError.active:
+        The folder is active and the operation did not succeed.
+    :ivar TeamFolderInvalidStatusError.archived:
+        The folder is archived and the operation did not succeed.
+    :ivar TeamFolderInvalidStatusError.archive_in_progress:
+        The folder is being archived and the operation did not succeed.
     """
 
     _catch_all = 'other'
@@ -12151,8 +12388,8 @@ TeamFolderInvalidStatusError_validator = bv.Union(TeamFolderInvalidStatusError)
 
 class TeamFolderListArg(bb.Struct):
     """
-    :ivar team.TeamFolderListArg.limit: The maximum number of results to return
-        per request.
+    :ivar TeamFolderListArg.limit:
+        The maximum number of results to return per request.
     """
 
     __slots__ = [
@@ -12177,8 +12414,8 @@ TeamFolderListArg_validator = bv.Struct(TeamFolderListArg)
 
 class TeamFolderListContinueArg(bb.Struct):
     """
-    :ivar team.TeamFolderListContinueArg.cursor: Indicates from what point to
-        get the next set of team folders.
+    :ivar TeamFolderListContinueArg.cursor:
+        Indicates from what point to get the next set of team folders.
     """
 
     __slots__ = [
@@ -12207,8 +12444,8 @@ class TeamFolderListContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderListContinueError.invalid_cursor: The cursor is
-        invalid.
+    :ivar TeamFolderListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     _catch_all = 'other'
@@ -12265,13 +12502,15 @@ class TeamFolderListResult(bb.Struct):
     Result for :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_list` and
     :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_list_continue`.
 
-    :ivar team.TeamFolderListResult.team_folders: List of all team folders in
-        the authenticated team.
-    :ivar team.TeamFolderListResult.cursor: Pass the cursor into
+    :ivar TeamFolderListResult.team_folders:
+        List of all team folders in the authenticated team.
+    :ivar TeamFolderListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_list_continue` to
         obtain additional team folders.
-    :ivar team.TeamFolderListResult.has_more: Is true if there are additional
-        team folders that have not been returned yet. An additional call to
+    :ivar TeamFolderListResult.has_more:
+        Is true if there are additional team folders that have not been returned
+        yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_team_folder_list_continue`
         can retrieve them.
     """
@@ -12316,17 +12555,20 @@ class TeamFolderMetadata(bb.Struct):
     """
     Properties of a team folder.
 
-    :ivar team.TeamFolderMetadata.team_folder_id: The ID of the team folder.
-    :ivar team.TeamFolderMetadata.name: The name of the team folder.
-    :ivar team.TeamFolderMetadata.status: The status of the team folder.
-    :ivar team.TeamFolderMetadata.is_team_shared_dropbox: True if this team
-        folder is a shared team root.
-    :ivar team.TeamFolderMetadata.sync_setting: The sync setting applied to this
-        team folder.
-    :ivar team.TeamFolderMetadata.content_sync_settings: Sync settings applied
-        to contents of this team folder.
-    :ivar team.TeamFolderMetadata.quota_limit: The quota limit in bytes for this
-        team folder namespace tree.
+    :ivar TeamFolderMetadata.team_folder_id:
+        The ID of the team folder.
+    :ivar TeamFolderMetadata.name:
+        The name of the team folder.
+    :ivar TeamFolderMetadata.status:
+        The status of the team folder.
+    :ivar TeamFolderMetadata.is_team_shared_dropbox:
+        True if this team folder is a shared team root.
+    :ivar TeamFolderMetadata.sync_setting:
+        The sync setting applied to this team folder.
+    :ivar TeamFolderMetadata.content_sync_settings:
+        Sync settings applied to contents of this team folder.
+    :ivar TeamFolderMetadata.quota_limit:
+        The quota limit in bytes for this team folder namespace tree.
     """
 
     __slots__ = [
@@ -12411,7 +12653,8 @@ TeamFolderPermanentlyDeleteError_validator = bv.Union(TeamFolderPermanentlyDelet
 
 class TeamFolderRenameArg(TeamFolderIdArg):
     """
-    :ivar team.TeamFolderRenameArg.name: New team folder name.
+    :ivar TeamFolderRenameArg.name:
+        New team folder name.
     """
 
     __slots__ = [
@@ -12442,12 +12685,12 @@ class TeamFolderRenameError(BaseTeamFolderError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderRenameError.invalid_folder_name: The provided folder
-        name cannot be used.
-    :ivar team.TeamFolderRenameError.folder_name_already_used: There is already
-        a team folder with the same name.
-    :ivar team.TeamFolderRenameError.folder_name_reserved: The provided name
-        cannot be used because it is reserved.
+    :ivar TeamFolderRenameError.invalid_folder_name:
+        The provided folder name cannot be used.
+    :ivar TeamFolderRenameError.folder_name_already_used:
+        There is already a team folder with the same name.
+    :ivar TeamFolderRenameError.folder_name_reserved:
+        The provided name cannot be used because it is reserved.
     """
 
     # Attribute is overwritten below the class definition
@@ -12504,15 +12747,16 @@ class TeamFolderStatus(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderStatus.active: The team folder and sub-folders are
-        available to all members.
-    :ivar team.TeamFolderStatus.archived: The team folder is archived and is not
-        accessible outside of the team folder manager.
-    :ivar team.TeamFolderStatus.archive_in_progress: The team folder is in the
-        process of being archived and is not accessible outside of the team
+    :ivar TeamFolderStatus.active:
+        The team folder and sub-folders are available to all members.
+    :ivar TeamFolderStatus.archived:
+        The team folder is archived and is not accessible outside of the team
         folder manager.
-    :ivar team.TeamFolderStatus.inactive: The team folder is unmounted and can
-        be restored.
+    :ivar TeamFolderStatus.archive_in_progress:
+        The team folder is in the process of being archived and is not
+        accessible outside of the team folder manager.
+    :ivar TeamFolderStatus.inactive:
+        The team folder is unmounted and can be restored.
     """
 
     _catch_all = 'other'
@@ -12578,8 +12822,8 @@ class TeamFolderTeamSharedDropboxError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamFolderTeamSharedDropboxError.disallowed: This action is not
-        allowed for a shared team root.
+    :ivar TeamFolderTeamSharedDropboxError.disallowed:
+        This action is not allowed for a shared team root.
     """
 
     _catch_all = 'other'
@@ -12611,11 +12855,11 @@ TeamFolderTeamSharedDropboxError_validator = bv.Union(TeamFolderTeamSharedDropbo
 
 class TeamFolderUpdateSyncSettingsArg(TeamFolderIdArg):
     """
-    :ivar team.TeamFolderUpdateSyncSettingsArg.sync_setting: Sync setting to
-        apply to the team folder itself. Only meaningful if the team folder is
-        not a shared team root.
-    :ivar team.TeamFolderUpdateSyncSettingsArg.content_sync_settings: Sync
-        settings to apply to contents of this team folder.
+    :ivar TeamFolderUpdateSyncSettingsArg.sync_setting:
+        Sync setting to apply to the team folder itself. Only meaningful if the
+        team folder is not a shared team root.
+    :ivar TeamFolderUpdateSyncSettingsArg.content_sync_settings:
+        Sync settings to apply to contents of this team folder.
     """
 
     __slots__ = [
@@ -12654,9 +12898,9 @@ class TeamFolderUpdateSyncSettingsError(BaseTeamFolderError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar SyncSettingsError
-        TeamFolderUpdateSyncSettingsError.sync_settings_error: An error occurred
-        setting the sync settings.
+    :ivar TeamFolderUpdateSyncSettingsError.sync_settings_error:
+        An error occurred setting the sync settings.
+    :vartype TeamFolderUpdateSyncSettingsError.sync_settings_error: files.SyncSettingsError
     """
 
     @classmethod
@@ -12697,14 +12941,17 @@ TeamFolderUpdateSyncSettingsError_validator = bv.Union(TeamFolderUpdateSyncSetti
 
 class TeamGetInfoResult(bb.Struct):
     """
-    :ivar team.TeamGetInfoResult.name: The name of the team.
-    :ivar team.TeamGetInfoResult.team_id: The ID of the team.
-    :ivar team.TeamGetInfoResult.num_licensed_users: The number of licenses
-        available to the team.
-    :ivar team.TeamGetInfoResult.num_provisioned_users: The number of accounts
-        that have been invited or are already active members of the team.
-    :ivar team.TeamGetInfoResult.num_used_licenses: The number of licenses used
-        on the team.
+    :ivar TeamGetInfoResult.name:
+        The name of the team.
+    :ivar TeamGetInfoResult.team_id:
+        The ID of the team.
+    :ivar TeamGetInfoResult.num_licensed_users:
+        The number of licenses available to the team.
+    :ivar TeamGetInfoResult.num_provisioned_users:
+        The number of accounts that have been invited or are already active
+        members of the team.
+    :ivar TeamGetInfoResult.num_used_licenses:
+        The number of licenses used on the team.
     """
 
     __slots__ = [
@@ -12771,8 +13018,10 @@ class TeamMemberInfo(bb.Struct):
     """
     Information about a team member.
 
-    :ivar team.TeamMemberInfo.profile: Profile of a user as a member of a team.
-    :ivar team.TeamMemberInfo.role: The user's role in the team.
+    :ivar TeamMemberInfo.profile:
+        Profile of a user as a member of a team.
+    :ivar TeamMemberInfo.role:
+        The user's role in the team.
     """
 
     __slots__ = [
@@ -12807,9 +13056,10 @@ class TeamMemberInfoV2(bb.Struct):
     """
     Information about a team member.
 
-    :ivar team.TeamMemberInfoV2.profile: Profile of a user as a member of a
-        team.
-    :ivar team.TeamMemberInfoV2.roles: The user's roles in the team.
+    :ivar TeamMemberInfoV2.profile:
+        Profile of a user as a member of a team.
+    :ivar TeamMemberInfoV2.roles:
+        The user's roles in the team.
     """
 
     __slots__ = [
@@ -12845,8 +13095,8 @@ class TeamMemberInfoV2Result(bb.Struct):
     Information about a team member, after the change, like at
     :meth:`dropbox.dropbox_client.Dropbox.team_members_set_profile`.
 
-    :ivar team.TeamMemberInfoV2Result.member_info: Member info, after the
-        change.
+    :ivar TeamMemberInfoV2Result.member_info:
+        Member info, after the change.
     """
 
     __slots__ = [
@@ -12873,12 +13123,12 @@ class TeamMemberProfile(MemberProfile):
     """
     Profile of a user as a member of a team.
 
-    :ivar team.TeamMemberProfile.groups: List of group IDs of groups that the
-        user belongs to.
-    :ivar team.TeamMemberProfile.member_folder_id: The namespace id of the
-        user's member folder.
-    :ivar team.TeamMemberProfile.root_folder_id: The namespace id of the user's
-        root folder.
+    :ivar TeamMemberProfile.groups:
+        List of group IDs of groups that the user belongs to.
+    :ivar TeamMemberProfile.member_folder_id:
+        The namespace id of the user's member folder.
+    :ivar TeamMemberProfile.root_folder_id:
+        The namespace id of the user's root folder.
     """
 
     __slots__ = [
@@ -12952,11 +13202,13 @@ class TeamMemberRole(bb.Struct):
     A role which can be attached to a team member. This replaces AdminTier; each
     AdminTier corresponds to a new TeamMemberRole with a matching name.
 
-    :ivar team.TeamMemberRole.role_id: A string containing encoded role ID. For
-        roles defined by Dropbox, this is the same across all teams.
-    :ivar team.TeamMemberRole.name: The role display name.
-    :ivar team.TeamMemberRole.description: Role description. Describes which
-        permissions come with this role.
+    :ivar TeamMemberRole.role_id:
+        A string containing encoded role ID. For roles defined by Dropbox, this
+        is the same across all teams.
+    :ivar TeamMemberRole.name:
+        The role display name.
+    :ivar TeamMemberRole.description:
+        Role description. Describes which permissions come with this role.
     """
 
     __slots__ = [
@@ -13003,15 +13255,17 @@ class TeamMemberStatus(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamMemberStatus.active: User has successfully joined the team.
-    :ivar team.TeamMemberStatus.invited: User has been invited to a team, but
-        has not joined the team yet.
-    :ivar team.TeamMemberStatus.suspended: User is no longer a member of the
-        team, but the account can be un-suspended, re-establishing the user as a
-        team member.
-    :ivar RemovedStatus TeamMemberStatus.removed: User is no longer a member of
-        the team. Removed users are only listed when include_removed is true in
-        members/list.
+    :ivar TeamMemberStatus.active:
+        User has successfully joined the team.
+    :ivar TeamMemberStatus.invited:
+        User has been invited to a team, but has not joined the team yet.
+    :ivar TeamMemberStatus.suspended:
+        User is no longer a member of the team, but the account can be
+        un-suspended, re-establishing the user as a team member.
+    :ivar TeamMemberStatus.removed:
+        User is no longer a member of the team. Removed users are only listed
+        when include_removed is true in members/list.
+    :vartype TeamMemberStatus.removed: RemovedStatus
     """
 
     _catch_all = None
@@ -13089,11 +13343,12 @@ class TeamMembershipType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamMembershipType.full: User uses a license and has full access
-        to team resources like the shared quota.
-    :ivar team.TeamMembershipType.limited: Field is deprecated. User does not
-        have access to the shared quota and team admins have restricted
-        administrative control.
+    :ivar TeamMembershipType.full:
+        User uses a license and has full access to team resources like the
+        shared quota.
+    :ivar TeamMembershipType.limited:
+        Field is deprecated. User does not have access to the shared quota and
+        team admins have restricted administrative control.
     """
 
     _catch_all = None
@@ -13125,8 +13380,8 @@ TeamMembershipType_validator = bv.Union(TeamMembershipType)
 
 class TeamNamespacesListArg(bb.Struct):
     """
-    :ivar team.TeamNamespacesListArg.limit: Field is deprecated. Specifying a
-        value here has no effect.
+    :ivar TeamNamespacesListArg.limit:
+        Field is deprecated. Specifying a value here has no effect.
     """
 
     __slots__ = [
@@ -13151,8 +13406,9 @@ TeamNamespacesListArg_validator = bv.Struct(TeamNamespacesListArg)
 
 class TeamNamespacesListContinueArg(bb.Struct):
     """
-    :ivar team.TeamNamespacesListContinueArg.cursor: Indicates from what point
-        to get the next set of team-accessible namespaces.
+    :ivar TeamNamespacesListContinueArg.cursor:
+        Indicates from what point to get the next set of team-accessible
+        namespaces.
     """
 
     __slots__ = [
@@ -13181,8 +13437,8 @@ class TeamNamespacesListError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamNamespacesListError.invalid_arg: Argument passed in is
-        invalid.
+    :ivar TeamNamespacesListError.invalid_arg:
+        Argument passed in is invalid.
     """
 
     _catch_all = 'other'
@@ -13218,8 +13474,8 @@ class TeamNamespacesListContinueError(TeamNamespacesListError):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamNamespacesListContinueError.invalid_cursor: The cursor is
-        invalid.
+    :ivar TeamNamespacesListContinueError.invalid_cursor:
+        The cursor is invalid.
     """
 
     # Attribute is overwritten below the class definition
@@ -13242,14 +13498,16 @@ class TeamNamespacesListResult(bb.Struct):
     """
     Result for :meth:`dropbox.dropbox_client.Dropbox.team_namespaces_list`.
 
-    :ivar team.TeamNamespacesListResult.namespaces: List of all namespaces the
-        team can access.
-    :ivar team.TeamNamespacesListResult.cursor: Pass the cursor into
+    :ivar TeamNamespacesListResult.namespaces:
+        List of all namespaces the team can access.
+    :ivar TeamNamespacesListResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_namespaces_list_continue` to
         obtain additional namespaces. Note that duplicate namespaces may be
         returned.
-    :ivar team.TeamNamespacesListResult.has_more: Is true if there are
-        additional namespaces that have not been returned yet.
+    :ivar TeamNamespacesListResult.has_more:
+        Is true if there are additional namespaces that have not been returned
+        yet.
     """
 
     __slots__ = [
@@ -13294,14 +13552,15 @@ class TeamReportFailureReason(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TeamReportFailureReason.temporary_error: We couldn't create the
-        report, but we think this was a fluke. Everything should work if you try
-        it again.
-    :ivar team.TeamReportFailureReason.many_reports_at_once: Too many other
-        reports are being created right now. Try creating this report again once
-        the others finish.
-    :ivar team.TeamReportFailureReason.too_much_data: We couldn't create the
-        report. Try creating the report again with less data.
+    :ivar TeamReportFailureReason.temporary_error:
+        We couldn't create the report, but we think this was a fluke. Everything
+        should work if you try it again.
+    :ivar TeamReportFailureReason.many_reports_at_once:
+        Too many other reports are being created right now. Try creating this
+        report again once the others finish.
+    :ivar TeamReportFailureReason.too_much_data:
+        We couldn't create the report. Try creating the report again with less
+        data.
     """
 
     _catch_all = 'other'
@@ -13360,13 +13619,13 @@ class TokenGetAuthenticatedAdminError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.TokenGetAuthenticatedAdminError.mapping_not_found: The current
-        token is not associated with a team admin, because mappings were not
-        recorded when the token was created. Consider re-authorizing a new
-        access token to record its authenticating admin.
-    :ivar team.TokenGetAuthenticatedAdminError.admin_not_active: Either the team
-        admin that authorized this token is no longer an active member of the
-        team or no longer a team admin.
+    :ivar TokenGetAuthenticatedAdminError.mapping_not_found:
+        The current token is not associated with a team admin, because mappings
+        were not recorded when the token was created. Consider re-authorizing a
+        new access token to record its authenticating admin.
+    :ivar TokenGetAuthenticatedAdminError.admin_not_active:
+        Either the team admin that authorized this token is no longer an active
+        member of the team or no longer a team admin.
     """
 
     _catch_all = 'other'
@@ -13411,8 +13670,8 @@ class TokenGetAuthenticatedAdminResult(bb.Struct):
     Results for
     :meth:`dropbox.dropbox_client.Dropbox.team_token_get_authenticated_admin`.
 
-    :ivar team.TokenGetAuthenticatedAdminResult.admin_profile: The admin who
-        authorized the token.
+    :ivar TokenGetAuthenticatedAdminResult.admin_profile:
+        The admin who authorized the token.
     """
 
     __slots__ = [
@@ -13443,11 +13702,12 @@ class UploadApiRateLimitValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team.UploadApiRateLimitValue.unlimited: This team has unlimited upload
-        API quota. So far both server version account and legacy account type
-        have unlimited monthly upload api quota.
-    :ivar int team.UploadApiRateLimitValue.limit: The number of upload API calls
-        allowed per month.
+    :ivar UploadApiRateLimitValue.unlimited:
+        This team has unlimited upload API quota. So far both server version
+        account and legacy account type have unlimited monthly upload api quota.
+    :ivar UploadApiRateLimitValue.limit:
+        The number of upload API calls allowed per month.
+    :vartype UploadApiRateLimitValue.limit: int
     """
 
     _catch_all = 'other'
@@ -13519,14 +13779,19 @@ class UserAddResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserSecondaryEmailsResult UserAddResult.success: Describes a user and
-        the results for each attempt to add a secondary email.
-    :ivar UserSelectorArg UserAddResult.invalid_user: Specified user is not a
-        valid target for adding secondary emails.
-    :ivar UserSelectorArg UserAddResult.unverified: Secondary emails can only be
-        added to verified users.
-    :ivar UserSelectorArg UserAddResult.placeholder_user: Secondary emails
-        cannot be added to placeholder users.
+    :ivar UserAddResult.success:
+        Describes a user and the results for each attempt to add a secondary
+        email.
+    :vartype UserAddResult.success: UserSecondaryEmailsResult
+    :ivar UserAddResult.invalid_user:
+        Specified user is not a valid target for adding secondary emails.
+    :vartype UserAddResult.invalid_user: UserSelectorArg
+    :ivar UserAddResult.unverified:
+        Secondary emails can only be added to verified users.
+    :vartype UserAddResult.unverified: UserSelectorArg
+    :ivar UserAddResult.placeholder_user:
+        Secondary emails cannot be added to placeholder users.
+    :vartype UserAddResult.placeholder_user: UserSelectorArg
     """
 
     _catch_all = 'other'
@@ -13779,10 +14044,13 @@ class UserDeleteResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserDeleteEmailsResult UserDeleteResult.success: Describes a user and
-        the results for each attempt to delete a secondary email.
-    :ivar UserSelectorArg UserDeleteResult.invalid_user: Specified user is not a
-        valid target for deleting secondary emails.
+    :ivar UserDeleteResult.success:
+        Describes a user and the results for each attempt to delete a secondary
+        email.
+    :vartype UserDeleteResult.success: UserDeleteEmailsResult
+    :ivar UserDeleteResult.invalid_user:
+        Specified user is not a valid target for deleting secondary emails.
+    :vartype UserDeleteResult.invalid_user: UserSelectorArg
     """
 
     _catch_all = 'other'
@@ -13906,10 +14174,13 @@ class UserResendResult(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserResendEmailsResult UserResendResult.success: Describes a user and
-        the results for each attempt to resend verification emails.
-    :ivar UserSelectorArg UserResendResult.invalid_user: Specified user is not a
-        valid target for resending verification emails.
+    :ivar UserResendResult.success:
+        Describes a user and the results for each attempt to resend verification
+        emails.
+    :vartype UserResendResult.success: UserResendEmailsResult
+    :ivar UserResendResult.invalid_user:
+        Specified user is not a valid target for resending verification emails.
+    :vartype UserResendResult.invalid_user: UserSelectorArg
     """
 
     _catch_all = 'other'
@@ -14168,11 +14439,15 @@ class UsersSelectorArg(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar list of [str] team.UsersSelectorArg.team_member_ids: List of member
-        IDs.
-    :ivar list of [str] team.UsersSelectorArg.external_ids: List of external
-        user IDs.
-    :ivar list of [str] team.UsersSelectorArg.emails: List of email addresses.
+    :ivar UsersSelectorArg.team_member_ids:
+        List of member IDs.
+    :vartype UsersSelectorArg.team_member_ids: list of [str]
+    :ivar UsersSelectorArg.external_ids:
+        List of external user IDs.
+    :vartype UsersSelectorArg.external_ids: list of [str]
+    :ivar UsersSelectorArg.emails:
+        List of email addresses.
+    :vartype UsersSelectorArg.emails: list of [str]
     """
 
     _catch_all = None

--- a/dropbox/team_common.py
+++ b/dropbox/team_common.py
@@ -17,12 +17,12 @@ class GroupManagementType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_common.GroupManagementType.user_managed: A group which is managed
-        by selected users.
-    :ivar team_common.GroupManagementType.company_managed: A group which is
-        managed by team admins only.
-    :ivar team_common.GroupManagementType.system_managed: A group which is
-        managed automatically by Dropbox.
+    :ivar GroupManagementType.user_managed:
+        A group which is managed by selected users.
+    :ivar GroupManagementType.company_managed:
+        A group which is managed by team admins only.
+    :ivar GroupManagementType.system_managed:
+        A group which is managed automatically by Dropbox.
     """
 
     _catch_all = 'other'
@@ -76,12 +76,13 @@ class GroupSummary(bb.Struct):
     """
     Information about a group.
 
-    :ivar team_common.GroupSummary.group_external_id: External ID of group. This
-        is an arbitrary ID that an admin can attach to a group.
-    :ivar team_common.GroupSummary.member_count: The number of members in the
-        group.
-    :ivar team_common.GroupSummary.group_management_type: Who is allowed to
-        manage the group.
+    :ivar GroupSummary.group_external_id:
+        External ID of group. This is an arbitrary ID that an admin can attach
+        to a group.
+    :ivar GroupSummary.member_count:
+        The number of members in the group.
+    :ivar GroupSummary.group_management_type:
+        Who is allowed to manage the group.
     """
 
     __slots__ = [
@@ -144,11 +145,11 @@ class GroupType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_common.GroupType.team: A group to which team members are
-        automatically added. Applicable to `team folders
-        <https://www.dropbox.com/help/986>`_ only.
-    :ivar team_common.GroupType.user_managed: A group is created and managed by
-        a user.
+    :ivar GroupType.team:
+        A group to which team members are automatically added. Applicable to
+        `team folders <https://www.dropbox.com/help/986>`_ only.
+    :ivar GroupType.user_managed:
+        A group is created and managed by a user.
     """
 
     _catch_all = 'other'
@@ -196,14 +197,14 @@ class MemberSpaceLimitType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_common.MemberSpaceLimitType.off: The team member does not have
-        imposed space limit.
-    :ivar team_common.MemberSpaceLimitType.alert_only: The team member has soft
-        imposed space limit - the limit is used for display and for
-        notifications.
-    :ivar team_common.MemberSpaceLimitType.stop_sync: The team member has hard
-        imposed space limit - Dropbox file sync will stop after the limit is
-        reached.
+    :ivar MemberSpaceLimitType.off:
+        The team member does not have imposed space limit.
+    :ivar MemberSpaceLimitType.alert_only:
+        The team member has soft imposed space limit - the limit is used for
+        display and for notifications.
+    :ivar MemberSpaceLimitType.stop_sync:
+        The team member has hard imposed space limit - Dropbox file sync will
+        stop after the limit is reached.
     """
 
     _catch_all = 'other'
@@ -257,8 +258,10 @@ class TimeRange(bb.Struct):
     """
     Time range.
 
-    :ivar team_common.TimeRange.start_time: Optional starting time (inclusive).
-    :ivar team_common.TimeRange.end_time: Optional ending time (exclusive).
+    :ivar TimeRange.start_time:
+        Optional starting time (inclusive).
+    :ivar TimeRange.end_time:
+        Optional ending time (exclusive).
     """
 
     __slots__ = [

--- a/dropbox/team_log.py
+++ b/dropbox/team_log.py
@@ -24,16 +24,24 @@ class AccessMethodLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar WebSessionLogInfo AccessMethodLogInfo.admin_console: Admin console
-        session details.
-    :ivar ApiSessionLogInfo AccessMethodLogInfo.api: Api session details.
-    :ivar WebSessionLogInfo AccessMethodLogInfo.content_manager: Content manager
-        session details.
-    :ivar SessionLogInfo AccessMethodLogInfo.end_user: End user session details.
-    :ivar WebSessionLogInfo AccessMethodLogInfo.enterprise_console: Enterprise
-        console session details.
-    :ivar WebSessionLogInfo AccessMethodLogInfo.sign_in_as: Sign in as session
-        details.
+    :ivar AccessMethodLogInfo.admin_console:
+        Admin console session details.
+    :vartype AccessMethodLogInfo.admin_console: WebSessionLogInfo
+    :ivar AccessMethodLogInfo.api:
+        Api session details.
+    :vartype AccessMethodLogInfo.api: ApiSessionLogInfo
+    :ivar AccessMethodLogInfo.content_manager:
+        Content manager session details.
+    :vartype AccessMethodLogInfo.content_manager: WebSessionLogInfo
+    :ivar AccessMethodLogInfo.end_user:
+        End user session details.
+    :vartype AccessMethodLogInfo.end_user: SessionLogInfo
+    :ivar AccessMethodLogInfo.enterprise_console:
+        Enterprise console session details.
+    :vartype AccessMethodLogInfo.enterprise_console: WebSessionLogInfo
+    :ivar AccessMethodLogInfo.sign_in_as:
+        Sign in as session details.
+    :vartype AccessMethodLogInfo.sign_in_as: WebSessionLogInfo
     """
 
     _catch_all = 'other'
@@ -287,9 +295,9 @@ class AccountCaptureChangeAvailabilityDetails(bb.Struct):
     """
     Granted/revoked option to enable account capture on team domains.
 
-    :ivar team_log.AccountCaptureChangeAvailabilityDetails.new_value: New
-        account capture availabilty value.
-    :ivar team_log.AccountCaptureChangeAvailabilityDetails.previous_value:
+    :ivar AccountCaptureChangeAvailabilityDetails.new_value:
+        New account capture availabilty value.
+    :ivar AccountCaptureChangeAvailabilityDetails.previous_value:
         Previous account capture availabilty value. Might be missing due to
         historical data gap.
     """
@@ -348,10 +356,11 @@ class AccountCaptureChangePolicyDetails(bb.Struct):
     """
     Changed account capture setting on team domain.
 
-    :ivar team_log.AccountCaptureChangePolicyDetails.new_value: New account
-        capture policy.
-    :ivar team_log.AccountCaptureChangePolicyDetails.previous_value: Previous
-        account capture policy. Might be missing due to historical data gap.
+    :ivar AccountCaptureChangePolicyDetails.new_value:
+        New account capture policy.
+    :ivar AccountCaptureChangePolicyDetails.previous_value:
+        Previous account capture policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -408,7 +417,8 @@ class AccountCaptureMigrateAccountDetails(bb.Struct):
     """
     Account-captured user migrated account to team.
 
-    :ivar team_log.AccountCaptureMigrateAccountDetails.domain_name: Domain name.
+    :ivar AccountCaptureMigrateAccountDetails.domain_name:
+        Domain name.
     """
 
     __slots__ = [
@@ -457,10 +467,9 @@ class AccountCaptureNotificationEmailsSentDetails(bb.Struct):
     """
     Sent account capture email to all unmanaged members.
 
-    :ivar team_log.AccountCaptureNotificationEmailsSentDetails.domain_name:
+    :ivar AccountCaptureNotificationEmailsSentDetails.domain_name:
         Domain name.
-    :ivar
-        team_log.AccountCaptureNotificationEmailsSentDetails.notification_type:
+    :ivar AccountCaptureNotificationEmailsSentDetails.notification_type:
         Account-capture email notification type.
     """
 
@@ -616,8 +625,8 @@ class AccountCaptureRelinquishAccountDetails(bb.Struct):
     """
     Account-captured user changed account email to personal email.
 
-    :ivar team_log.AccountCaptureRelinquishAccountDetails.domain_name: Domain
-        name.
+    :ivar AccountCaptureRelinquishAccountDetails.domain_name:
+        Domain name.
     """
 
     __slots__ = [
@@ -666,10 +675,10 @@ class AccountLockOrUnlockedDetails(bb.Struct):
     """
     Unlocked/locked account after failed sign in attempts.
 
-    :ivar team_log.AccountLockOrUnlockedDetails.previous_value: The previous
-        account status.
-    :ivar team_log.AccountLockOrUnlockedDetails.new_value: The new account
-        status.
+    :ivar AccountLockOrUnlockedDetails.previous_value:
+        The previous account status.
+    :ivar AccountLockOrUnlockedDetails.new_value:
+        The new account status.
     """
 
     __slots__ = [
@@ -775,12 +784,15 @@ class ActionDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar MemberRemoveActionType ActionDetails.remove_action: Define how the
-        user was removed from the team.
-    :ivar TeamInviteDetails ActionDetails.team_invite_details: Additional
-        information relevant when someone is invited to the team
-    :ivar JoinTeamDetails ActionDetails.team_join_details: Additional
-        information relevant when a new member joins the team.
+    :ivar ActionDetails.remove_action:
+        Define how the user was removed from the team.
+    :vartype ActionDetails.remove_action: MemberRemoveActionType
+    :ivar ActionDetails.team_invite_details:
+        Additional information relevant when someone is invited to the team
+    :vartype ActionDetails.team_invite_details: TeamInviteDetails
+    :ivar ActionDetails.team_join_details:
+        Additional information relevant when a new member joins the team.
+    :vartype ActionDetails.team_join_details: JoinTeamDetails
     """
 
     _catch_all = 'other'
@@ -901,12 +913,22 @@ class ActorLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar UserLogInfo ActorLogInfo.admin: The admin who did the action.
-    :ivar team_log.ActorLogInfo.anonymous: Anonymous actor.
-    :ivar AppLogInfo ActorLogInfo.app: The application who did the action.
-    :ivar team_log.ActorLogInfo.dropbox: Action done by Dropbox.
-    :ivar ResellerLogInfo ActorLogInfo.reseller: Action done by reseller.
-    :ivar UserLogInfo ActorLogInfo.user: The user who did the action.
+    :ivar ActorLogInfo.admin:
+        The admin who did the action.
+    :vartype ActorLogInfo.admin: UserLogInfo
+    :ivar ActorLogInfo.anonymous:
+        Anonymous actor.
+    :ivar ActorLogInfo.app:
+        The application who did the action.
+    :vartype ActorLogInfo.app: AppLogInfo
+    :ivar ActorLogInfo.dropbox:
+        Action done by Dropbox.
+    :ivar ActorLogInfo.reseller:
+        Action done by reseller.
+    :vartype ActorLogInfo.reseller: ResellerLogInfo
+    :ivar ActorLogInfo.user:
+        The user who did the action.
+    :vartype ActorLogInfo.user: UserLogInfo
     """
 
     _catch_all = 'other'
@@ -1074,8 +1096,10 @@ class AddonAssignedDetails(bb.Struct):
     """
     Add-on Assigned.
 
-    :ivar team_log.AddonAssignedDetails.user_name: User's name.
-    :ivar team_log.AddonAssignedDetails.addon_name: Add-on name.
+    :ivar AddonAssignedDetails.user_name:
+        User's name.
+    :ivar AddonAssignedDetails.addon_name:
+        Add-on name.
     """
 
     __slots__ = [
@@ -1132,7 +1156,8 @@ class AddonLogInfo(bb.Struct):
     """
     Add-on logged information
 
-    :ivar team_log.AddonLogInfo.addon_name: Add-on name.
+    :ivar AddonLogInfo.addon_name:
+        Add-on name.
     """
 
     __slots__ = [
@@ -1159,8 +1184,10 @@ class AddonRemovedDetails(bb.Struct):
     """
     Add-on Removed.
 
-    :ivar team_log.AddonRemovedDetails.user_name: User's name.
-    :ivar team_log.AddonRemovedDetails.addon_name: Add-on name.
+    :ivar AddonRemovedDetails.user_name:
+        User's name.
+    :ivar AddonRemovedDetails.addon_name:
+        Add-on name.
     """
 
     __slots__ = [
@@ -1465,15 +1492,17 @@ class AdminAlertingAlertConfiguration(bb.Struct):
     """
     Alert configurations
 
-    :ivar team_log.AdminAlertingAlertConfiguration.alert_state: Alert state.
-    :ivar team_log.AdminAlertingAlertConfiguration.sensitivity_level:
+    :ivar AdminAlertingAlertConfiguration.alert_state:
+        Alert state.
+    :ivar AdminAlertingAlertConfiguration.sensitivity_level:
         Sensitivity level.
-    :ivar team_log.AdminAlertingAlertConfiguration.recipients_settings:
+    :ivar AdminAlertingAlertConfiguration.recipients_settings:
         Recipient settings.
-    :ivar team_log.AdminAlertingAlertConfiguration.text: Text.
-    :ivar team_log.AdminAlertingAlertConfiguration.excluded_file_extensions:
+    :ivar AdminAlertingAlertConfiguration.text:
+        Text.
+    :ivar AdminAlertingAlertConfiguration.excluded_file_extensions:
         Excluded file extensions.
-    :ivar team_log.AdminAlertingAlertConfiguration.malware_exclusion_state:
+    :ivar AdminAlertingAlertConfiguration.malware_exclusion_state:
         Malware exclusion list state.
     """
 
@@ -1627,17 +1656,18 @@ class AdminAlertingAlertStateChangedDetails(bb.Struct):
     """
     Changed an alert state.
 
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.alert_name: Alert name.
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.alert_severity: Alert
-        severity.
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.alert_category: Alert
-        category.
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.alert_instance_id:
+    :ivar AdminAlertingAlertStateChangedDetails.alert_name:
+        Alert name.
+    :ivar AdminAlertingAlertStateChangedDetails.alert_severity:
+        Alert severity.
+    :ivar AdminAlertingAlertStateChangedDetails.alert_category:
+        Alert category.
+    :ivar AdminAlertingAlertStateChangedDetails.alert_instance_id:
         Alert ID.
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.previous_value: Alert
-        state before the change.
-    :ivar team_log.AdminAlertingAlertStateChangedDetails.new_value: Alert state
-        after the change.
+    :ivar AdminAlertingAlertStateChangedDetails.previous_value:
+        Alert state before the change.
+    :ivar AdminAlertingAlertStateChangedDetails.new_value:
+        Alert state after the change.
     """
 
     __slots__ = [
@@ -1772,12 +1802,12 @@ class AdminAlertingChangedAlertConfigDetails(bb.Struct):
     """
     Changed an alert setting.
 
-    :ivar team_log.AdminAlertingChangedAlertConfigDetails.alert_name: Alert
-        Name.
-    :ivar team_log.AdminAlertingChangedAlertConfigDetails.previous_alert_config:
+    :ivar AdminAlertingChangedAlertConfigDetails.alert_name:
+        Alert Name.
+    :ivar AdminAlertingChangedAlertConfigDetails.previous_alert_config:
         Previous alert configuration.
-    :ivar team_log.AdminAlertingChangedAlertConfigDetails.new_alert_config: New
-        alert configuration.
+    :ivar AdminAlertingChangedAlertConfigDetails.new_alert_config:
+        New alert configuration.
     """
 
     __slots__ = [
@@ -1842,13 +1872,14 @@ class AdminAlertingTriggeredAlertDetails(bb.Struct):
     """
     Triggered security alert.
 
-    :ivar team_log.AdminAlertingTriggeredAlertDetails.alert_name: Alert name.
-    :ivar team_log.AdminAlertingTriggeredAlertDetails.alert_severity: Alert
-        severity.
-    :ivar team_log.AdminAlertingTriggeredAlertDetails.alert_category: Alert
-        category.
-    :ivar team_log.AdminAlertingTriggeredAlertDetails.alert_instance_id: Alert
-        ID.
+    :ivar AdminAlertingTriggeredAlertDetails.alert_name:
+        Alert name.
+    :ivar AdminAlertingTriggeredAlertDetails.alert_severity:
+        Alert severity.
+    :ivar AdminAlertingTriggeredAlertDetails.alert_category:
+        Alert category.
+    :ivar AdminAlertingTriggeredAlertDetails.alert_instance_id:
+        Alert ID.
     """
 
     __slots__ = [
@@ -2019,8 +2050,10 @@ class AdminEmailRemindersChangedDetails(bb.Struct):
     """
     Changed admin reminder settings for requests to join the team.
 
-    :ivar team_log.AdminEmailRemindersChangedDetails.new_value: To.
-    :ivar team_log.AdminEmailRemindersChangedDetails.previous_value: From.
+    :ivar AdminEmailRemindersChangedDetails.new_value:
+        To.
+    :ivar AdminEmailRemindersChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -2344,10 +2377,9 @@ class AiThirdPartySharingDropboxBasePolicyChangedDetails(bb.Struct):
     """
     Changed AI third party sharing policy for team.
 
-    :ivar team_log.AiThirdPartySharingDropboxBasePolicyChangedDetails.new_value:
+    :ivar AiThirdPartySharingDropboxBasePolicyChangedDetails.new_value:
         To.
-    :ivar
-        team_log.AiThirdPartySharingDropboxBasePolicyChangedDetails.previous_value:
+    :ivar AiThirdPartySharingDropboxBasePolicyChangedDetails.previous_value:
         From.
     """
 
@@ -2551,7 +2583,8 @@ class ApiSessionLogInfo(bb.Struct):
     """
     Api session.
 
-    :ivar team_log.ApiSessionLogInfo.request_id: Api request ID.
+    :ivar ApiSessionLogInfo.request_id:
+        Api request ID.
     """
 
     __slots__ = [
@@ -2578,8 +2611,8 @@ class AppBlockedByPermissionsDetails(bb.Struct):
     """
     Failed to connect app for member.
 
-    :ivar team_log.AppBlockedByPermissionsDetails.app_info: Relevant application
-        details.
+    :ivar AppBlockedByPermissionsDetails.app_info:
+        Relevant application details.
     """
 
     __slots__ = [
@@ -2628,7 +2661,8 @@ class AppLinkTeamDetails(bb.Struct):
     """
     Linked app for team.
 
-    :ivar team_log.AppLinkTeamDetails.app_info: Relevant application details.
+    :ivar AppLinkTeamDetails.app_info:
+        Relevant application details.
     """
 
     __slots__ = [
@@ -2677,7 +2711,8 @@ class AppLinkUserDetails(bb.Struct):
     """
     Linked app for member.
 
-    :ivar team_log.AppLinkUserDetails.app_info: Relevant application details.
+    :ivar AppLinkUserDetails.app_info:
+        Relevant application details.
     """
 
     __slots__ = [
@@ -2726,8 +2761,10 @@ class AppLogInfo(bb.Struct):
     """
     App's logged information.
 
-    :ivar team_log.AppLogInfo.app_id: App unique ID.
-    :ivar team_log.AppLogInfo.display_name: App display name.
+    :ivar AppLogInfo.app_id:
+        App unique ID.
+    :ivar AppLogInfo.display_name:
+        App display name.
     """
 
     __slots__ = [
@@ -2762,11 +2799,14 @@ class AppPermissionsChangedDetails(bb.Struct):
     """
     Changed app permissions.
 
-    :ivar team_log.AppPermissionsChangedDetails.app_name: Name of the app.
-    :ivar team_log.AppPermissionsChangedDetails.permission: Permission that was
-        changed.
-    :ivar team_log.AppPermissionsChangedDetails.previous_value: Previous policy.
-    :ivar team_log.AppPermissionsChangedDetails.new_value: New policy.
+    :ivar AppPermissionsChangedDetails.app_name:
+        Name of the app.
+    :ivar AppPermissionsChangedDetails.permission:
+        Permission that was changed.
+    :ivar AppPermissionsChangedDetails.previous_value:
+        Previous policy.
+    :ivar AppPermissionsChangedDetails.new_value:
+        New policy.
     """
 
     __slots__ = [
@@ -2839,7 +2879,8 @@ class AppUnlinkTeamDetails(bb.Struct):
     """
     Unlinked app for team.
 
-    :ivar team_log.AppUnlinkTeamDetails.app_info: Relevant application details.
+    :ivar AppUnlinkTeamDetails.app_info:
+        Relevant application details.
     """
 
     __slots__ = [
@@ -2888,7 +2929,8 @@ class AppUnlinkUserDetails(bb.Struct):
     """
     Unlinked app for member.
 
-    :ivar team_log.AppUnlinkUserDetails.app_info: Relevant application details.
+    :ivar AppUnlinkUserDetails.app_info:
+        Relevant application details.
     """
 
     __slots__ = [
@@ -2937,10 +2979,11 @@ class AppleLoginChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled Apple login for team.
 
-    :ivar team_log.AppleLoginChangePolicyDetails.new_value: New Apple login
-        policy.
-    :ivar team_log.AppleLoginChangePolicyDetails.previous_value: Previous Apple
-        login policy. Might be missing due to historical data gap.
+    :ivar AppleLoginChangePolicyDetails.new_value:
+        New Apple login policy.
+    :ivar AppleLoginChangePolicyDetails.previous_value:
+        Previous Apple login policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -3097,13 +3140,21 @@ class AssetLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar FileLogInfo AssetLogInfo.file: File's details.
-    :ivar FolderLogInfo AssetLogInfo.folder: Folder's details.
-    :ivar PaperDocumentLogInfo AssetLogInfo.paper_document: Paper document's
-        details.
-    :ivar PaperFolderLogInfo AssetLogInfo.paper_folder: Paper folder's details.
-    :ivar ShowcaseDocumentLogInfo AssetLogInfo.showcase_document: Showcase
-        document's details.
+    :ivar AssetLogInfo.file:
+        File's details.
+    :vartype AssetLogInfo.file: FileLogInfo
+    :ivar AssetLogInfo.folder:
+        Folder's details.
+    :vartype AssetLogInfo.folder: FolderLogInfo
+    :ivar AssetLogInfo.paper_document:
+        Paper document's details.
+    :vartype AssetLogInfo.paper_document: PaperDocumentLogInfo
+    :ivar AssetLogInfo.paper_folder:
+        Paper folder's details.
+    :vartype AssetLogInfo.paper_folder: PaperFolderLogInfo
+    :ivar AssetLogInfo.showcase_document:
+        Showcase document's details.
+    :vartype AssetLogInfo.showcase_document: ShowcaseDocumentLogInfo
     """
 
     _catch_all = 'other'
@@ -3408,10 +3459,12 @@ class BinderAddPageDetails(bb.Struct):
     """
     Added Binder page.
 
-    :ivar team_log.BinderAddPageDetails.event_uuid: Event unique identifier.
-    :ivar team_log.BinderAddPageDetails.doc_title: Title of the Binder doc.
-    :ivar team_log.BinderAddPageDetails.binder_item_name: Name of the Binder
-        page/section.
+    :ivar BinderAddPageDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderAddPageDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderAddPageDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3476,10 +3529,12 @@ class BinderAddSectionDetails(bb.Struct):
     """
     Added Binder section.
 
-    :ivar team_log.BinderAddSectionDetails.event_uuid: Event unique identifier.
-    :ivar team_log.BinderAddSectionDetails.doc_title: Title of the Binder doc.
-    :ivar team_log.BinderAddSectionDetails.binder_item_name: Name of the Binder
-        page/section.
+    :ivar BinderAddSectionDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderAddSectionDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderAddSectionDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3544,10 +3599,12 @@ class BinderRemovePageDetails(bb.Struct):
     """
     Removed Binder page.
 
-    :ivar team_log.BinderRemovePageDetails.event_uuid: Event unique identifier.
-    :ivar team_log.BinderRemovePageDetails.doc_title: Title of the Binder doc.
-    :ivar team_log.BinderRemovePageDetails.binder_item_name: Name of the Binder
-        page/section.
+    :ivar BinderRemovePageDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderRemovePageDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderRemovePageDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3612,12 +3669,12 @@ class BinderRemoveSectionDetails(bb.Struct):
     """
     Removed Binder section.
 
-    :ivar team_log.BinderRemoveSectionDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.BinderRemoveSectionDetails.doc_title: Title of the Binder
-        doc.
-    :ivar team_log.BinderRemoveSectionDetails.binder_item_name: Name of the
-        Binder page/section.
+    :ivar BinderRemoveSectionDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderRemoveSectionDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderRemoveSectionDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3682,12 +3739,14 @@ class BinderRenamePageDetails(bb.Struct):
     """
     Renamed Binder page.
 
-    :ivar team_log.BinderRenamePageDetails.event_uuid: Event unique identifier.
-    :ivar team_log.BinderRenamePageDetails.doc_title: Title of the Binder doc.
-    :ivar team_log.BinderRenamePageDetails.binder_item_name: Name of the Binder
-        page/section.
-    :ivar team_log.BinderRenamePageDetails.previous_binder_item_name: Previous
-        name of the Binder page/section.
+    :ivar BinderRenamePageDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderRenamePageDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderRenamePageDetails.binder_item_name:
+        Name of the Binder page/section.
+    :ivar BinderRenamePageDetails.previous_binder_item_name:
+        Previous name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3760,13 +3819,13 @@ class BinderRenameSectionDetails(bb.Struct):
     """
     Renamed Binder section.
 
-    :ivar team_log.BinderRenameSectionDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.BinderRenameSectionDetails.doc_title: Title of the Binder
-        doc.
-    :ivar team_log.BinderRenameSectionDetails.binder_item_name: Name of the
-        Binder page/section.
-    :ivar team_log.BinderRenameSectionDetails.previous_binder_item_name:
+    :ivar BinderRenameSectionDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderRenameSectionDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderRenameSectionDetails.binder_item_name:
+        Name of the Binder page/section.
+    :ivar BinderRenameSectionDetails.previous_binder_item_name:
         Previous name of the Binder page/section.
     """
 
@@ -3840,10 +3899,12 @@ class BinderReorderPageDetails(bb.Struct):
     """
     Reordered Binder page.
 
-    :ivar team_log.BinderReorderPageDetails.event_uuid: Event unique identifier.
-    :ivar team_log.BinderReorderPageDetails.doc_title: Title of the Binder doc.
-    :ivar team_log.BinderReorderPageDetails.binder_item_name: Name of the Binder
-        page/section.
+    :ivar BinderReorderPageDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderReorderPageDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderReorderPageDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -3908,12 +3969,12 @@ class BinderReorderSectionDetails(bb.Struct):
     """
     Reordered Binder section.
 
-    :ivar team_log.BinderReorderSectionDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.BinderReorderSectionDetails.doc_title: Title of the Binder
-        doc.
-    :ivar team_log.BinderReorderSectionDetails.binder_item_name: Name of the
-        Binder page/section.
+    :ivar BinderReorderSectionDetails.event_uuid:
+        Event unique identifier.
+    :ivar BinderReorderSectionDetails.doc_title:
+        Title of the Binder doc.
+    :ivar BinderReorderSectionDetails.binder_item_name:
+        Name of the Binder page/section.
     """
 
     __slots__ = [
@@ -4024,10 +4085,10 @@ class CameraUploadsPolicyChangedDetails(bb.Struct):
     """
     Changed camera uploads setting for team.
 
-    :ivar team_log.CameraUploadsPolicyChangedDetails.new_value: New camera
-        uploads setting.
-    :ivar team_log.CameraUploadsPolicyChangedDetails.previous_value: Previous
-        camera uploads setting.
+    :ivar CameraUploadsPolicyChangedDetails.new_value:
+        New camera uploads setting.
+    :ivar CameraUploadsPolicyChangedDetails.previous_value:
+        Previous camera uploads setting.
     """
 
     __slots__ = [
@@ -4130,8 +4191,10 @@ class CaptureTeamSpacePolicyChangedDetails(bb.Struct):
     """
     Changed Capture team space policy for team.
 
-    :ivar team_log.CaptureTeamSpacePolicyChangedDetails.new_value: To.
-    :ivar team_log.CaptureTeamSpacePolicyChangedDetails.previous_value: From.
+    :ivar CaptureTeamSpacePolicyChangedDetails.new_value:
+        To.
+    :ivar CaptureTeamSpacePolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -4244,8 +4307,10 @@ class CaptureTranscriptPolicyChangedDetails(bb.Struct):
     """
     Changed Capture transcription policy for team.
 
-    :ivar team_log.CaptureTranscriptPolicyChangedDetails.new_value: To.
-    :ivar team_log.CaptureTranscriptPolicyChangedDetails.previous_value: From.
+    :ivar CaptureTranscriptPolicyChangedDetails.new_value:
+        To.
+    :ivar CaptureTranscriptPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -4302,13 +4367,20 @@ class Certificate(bb.Struct):
     """
     Certificate details.
 
-    :ivar team_log.Certificate.subject: Certificate subject.
-    :ivar team_log.Certificate.issuer: Certificate issuer.
-    :ivar team_log.Certificate.issue_date: Certificate issue date.
-    :ivar team_log.Certificate.expiration_date: Certificate expiration date.
-    :ivar team_log.Certificate.serial_number: Certificate serial number.
-    :ivar team_log.Certificate.sha1_fingerprint: Certificate sha1 fingerprint.
-    :ivar team_log.Certificate.common_name: Certificate common name.
+    :ivar Certificate.subject:
+        Certificate subject.
+    :ivar Certificate.issuer:
+        Certificate issuer.
+    :ivar Certificate.issue_date:
+        Certificate issue date.
+    :ivar Certificate.expiration_date:
+        Certificate expiration date.
+    :ivar Certificate.serial_number:
+        Certificate serial number.
+    :ivar Certificate.sha1_fingerprint:
+        Certificate sha1 fingerprint.
+    :ivar Certificate.common_name:
+        Certificate common name.
     """
 
     __slots__ = [
@@ -4430,12 +4502,12 @@ class ChangedEnterpriseAdminRoleDetails(bb.Struct):
     """
     Changed enterprise admin role.
 
-    :ivar team_log.ChangedEnterpriseAdminRoleDetails.previous_value: The
-        member&#x2019s previous enterprise admin role.
-    :ivar team_log.ChangedEnterpriseAdminRoleDetails.new_value: The
-        member&#x2019s new enterprise admin role.
-    :ivar team_log.ChangedEnterpriseAdminRoleDetails.team_name: The name of the
-        member&#x2019s team.
+    :ivar ChangedEnterpriseAdminRoleDetails.previous_value:
+        The member&#x2019s previous enterprise admin role.
+    :ivar ChangedEnterpriseAdminRoleDetails.new_value:
+        The member&#x2019s new enterprise admin role.
+    :ivar ChangedEnterpriseAdminRoleDetails.team_name:
+        The name of the member&#x2019s team.
     """
 
     __slots__ = [
@@ -4500,14 +4572,14 @@ class ChangedEnterpriseConnectedTeamStatusDetails(bb.Struct):
     """
     Changed enterprise-connected team status.
 
-    :ivar team_log.ChangedEnterpriseConnectedTeamStatusDetails.action: The
-        preformed change in the team&#x2019s connection status.
-    :ivar team_log.ChangedEnterpriseConnectedTeamStatusDetails.additional_info:
+    :ivar ChangedEnterpriseConnectedTeamStatusDetails.action:
+        The preformed change in the team&#x2019s connection status.
+    :ivar ChangedEnterpriseConnectedTeamStatusDetails.additional_info:
         Additional information about the organization or team.
-    :ivar team_log.ChangedEnterpriseConnectedTeamStatusDetails.previous_value:
+    :ivar ChangedEnterpriseConnectedTeamStatusDetails.previous_value:
         Previous request state.
-    :ivar team_log.ChangedEnterpriseConnectedTeamStatusDetails.new_value: New
-        request state.
+    :ivar ChangedEnterpriseConnectedTeamStatusDetails.new_value:
+        New request state.
     """
 
     __slots__ = [
@@ -4580,12 +4652,12 @@ class ClassificationChangePolicyDetails(bb.Struct):
     """
     Changed classification policy for team.
 
-    :ivar team_log.ClassificationChangePolicyDetails.previous_value: Previous
-        classification policy.
-    :ivar team_log.ClassificationChangePolicyDetails.new_value: New
-        classification policy.
-    :ivar team_log.ClassificationChangePolicyDetails.classification_type: Policy
-        type.
+    :ivar ClassificationChangePolicyDetails.previous_value:
+        Previous classification policy.
+    :ivar ClassificationChangePolicyDetails.new_value:
+        New classification policy.
+    :ivar ClassificationChangePolicyDetails.classification_type:
+        Policy type.
     """
 
     __slots__ = [
@@ -4668,8 +4740,8 @@ class ClassificationCreateReportFailDetails(bb.Struct):
     """
     Couldn't create Classification report.
 
-    :ivar team_log.ClassificationCreateReportFailDetails.failure_reason: Failure
-        reason.
+    :ivar ClassificationCreateReportFailDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -4852,7 +4924,8 @@ class CollectionShareDetails(bb.Struct):
     """
     Shared album.
 
-    :ivar team_log.CollectionShareDetails.album_name: Album name.
+    :ivar CollectionShareDetails.album_name:
+        Album name.
     """
 
     __slots__ = [
@@ -4957,10 +5030,10 @@ class ComputerBackupPolicyChangedDetails(bb.Struct):
     """
     Changed computer backup policy for team.
 
-    :ivar team_log.ComputerBackupPolicyChangedDetails.new_value: New computer
-        backup policy.
-    :ivar team_log.ComputerBackupPolicyChangedDetails.previous_value: Previous
-        computer backup policy.
+    :ivar ComputerBackupPolicyChangedDetails.new_value:
+        New computer backup policy.
+    :ivar ComputerBackupPolicyChangedDetails.previous_value:
+        Previous computer backup policy.
     """
 
     __slots__ = [
@@ -5017,7 +5090,8 @@ class ConnectedTeamName(bb.Struct):
     """
     The name of the team
 
-    :ivar team_log.ConnectedTeamName.team: The name of the team.
+    :ivar ConnectedTeamName.team:
+        The name of the team.
     """
 
     __slots__ = [
@@ -5044,9 +5118,9 @@ class ContentAdministrationPolicyChangedDetails(bb.Struct):
     """
     Changed content management setting.
 
-    :ivar team_log.ContentAdministrationPolicyChangedDetails.new_value: New
-        content administration policy.
-    :ivar team_log.ContentAdministrationPolicyChangedDetails.previous_value:
+    :ivar ContentAdministrationPolicyChangedDetails.new_value:
+        New content administration policy.
+    :ivar ContentAdministrationPolicyChangedDetails.previous_value:
         Previous content administration policy.
     """
 
@@ -5104,17 +5178,15 @@ class ContentDeletionProtectionChangePolicyDetails(bb.Struct):
     """
     Changed content deletion protection policy for team.
 
-    :ivar team_log.ContentDeletionProtectionChangePolicyDetails.new_value: New
-        content deletion protection policy.
-    :ivar
-        team_log.ContentDeletionProtectionChangePolicyDetails.new_threshold_bytes:
+    :ivar ContentDeletionProtectionChangePolicyDetails.new_value:
+        New content deletion protection policy.
+    :ivar ContentDeletionProtectionChangePolicyDetails.new_threshold_bytes:
         New threshold value in bytes (only present when new policy is
         on_above_threshold).
-    :ivar team_log.ContentDeletionProtectionChangePolicyDetails.previous_value:
+    :ivar ContentDeletionProtectionChangePolicyDetails.previous_value:
         Previous content deletion protection policy. Might be missing due to
         historical data gap.
-    :ivar
-        team_log.ContentDeletionProtectionChangePolicyDetails.previous_threshold_bytes:
+    :ivar ContentDeletionProtectionChangePolicyDetails.previous_threshold_bytes:
         Previous threshold value in bytes (only present when previous policy was
         on_above_threshold).
     """
@@ -5295,16 +5367,22 @@ class ContextLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_log.ContextLogInfo.anonymous: Anonymous context.
-    :ivar NonTeamMemberLogInfo ContextLogInfo.non_team_member: Action was done
-        on behalf of a non team member.
-    :ivar TeamLogInfo ContextLogInfo.organization_team: Action was done on
-        behalf of a team that's part of an organization.
-    :ivar team_log.ContextLogInfo.team: Action was done on behalf of the team.
-    :ivar TeamMemberLogInfo ContextLogInfo.team_member: Action was done on
-        behalf of a team member.
-    :ivar TrustedNonTeamMemberLogInfo ContextLogInfo.trusted_non_team_member:
+    :ivar ContextLogInfo.anonymous:
+        Anonymous context.
+    :ivar ContextLogInfo.non_team_member:
+        Action was done on behalf of a non team member.
+    :vartype ContextLogInfo.non_team_member: NonTeamMemberLogInfo
+    :ivar ContextLogInfo.organization_team:
+        Action was done on behalf of a team that's part of an organization.
+    :vartype ContextLogInfo.organization_team: TeamLogInfo
+    :ivar ContextLogInfo.team:
+        Action was done on behalf of the team.
+    :ivar ContextLogInfo.team_member:
+        Action was done on behalf of a team member.
+    :vartype ContextLogInfo.team_member: TeamMemberLogInfo
+    :ivar ContextLogInfo.trusted_non_team_member:
         Action was done on behalf of a trusted non team member.
+    :vartype ContextLogInfo.trusted_non_team_member: TrustedNonTeamMemberLogInfo
     """
 
     _catch_all = 'other'
@@ -5512,10 +5590,10 @@ class CreateTeamInviteLinkDetails(bb.Struct):
     """
     Created team invite link.
 
-    :ivar team_log.CreateTeamInviteLinkDetails.link_url: The invite link url
-        that was created.
-    :ivar team_log.CreateTeamInviteLinkDetails.expiry_date: The expiration date
-        of the invite link.
+    :ivar CreateTeamInviteLinkDetails.link_url:
+        The invite link url that was created.
+    :ivar CreateTeamInviteLinkDetails.expiry_date:
+        The expiration date of the invite link.
     """
 
     __slots__ = [
@@ -5572,14 +5650,14 @@ class DashAddedCommentToStackDetails(bb.Struct):
     """
     Added a comment to a stack.
 
-    :ivar team_log.DashAddedCommentToStackDetails.stack_name: The name of the
-        stack where the comment exists.
-    :ivar team_log.DashAddedCommentToStackDetails.stack_item_name: The name of
-        the stack item that the comment is tied to.
-    :ivar team_log.DashAddedCommentToStackDetails.comment_text: The text of the
-        comment.
-    :ivar team_log.DashAddedCommentToStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashAddedCommentToStackDetails.stack_name:
+        The name of the stack where the comment exists.
+    :ivar DashAddedCommentToStackDetails.stack_item_name:
+        The name of the stack item that the comment is tied to.
+    :ivar DashAddedCommentToStackDetails.comment_text:
+        The text of the comment.
+    :ivar DashAddedCommentToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -5652,10 +5730,10 @@ class DashAddedConnectorDetails(bb.Struct):
     """
     Connected to a user connector.
 
-    :ivar team_log.DashAddedConnectorDetails.connector_name: The name of the
-        Connector.
-    :ivar team_log.DashAddedConnectorDetails.connector_status: The status of the
-        Connector.
+    :ivar DashAddedConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashAddedConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -5712,12 +5790,12 @@ class DashAddedLinkToStackDetails(bb.Struct):
     """
     Added a link to a stack.
 
-    :ivar team_log.DashAddedLinkToStackDetails.stack_name: The name of the
-        stack.
-    :ivar team_log.DashAddedLinkToStackDetails.stack_item_link: The link to the
-        item in the stack.
-    :ivar team_log.DashAddedLinkToStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashAddedLinkToStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashAddedLinkToStackDetails.stack_item_link:
+        The link to the item in the stack.
+    :ivar DashAddedLinkToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -5782,8 +5860,8 @@ class DashAddedTeamEmailDomainAllowlistDetails(bb.Struct):
     """
     Admin added an email domain to the team allowlist.
 
-    :ivar team_log.DashAddedTeamEmailDomainAllowlistDetails.email_domain: The
-        email domain that gets added/removed from the team allowlist.
+    :ivar DashAddedTeamEmailDomainAllowlistDetails.email_domain:
+        The email domain that gets added/removed from the team allowlist.
     """
 
     __slots__ = [
@@ -5832,10 +5910,10 @@ class DashAdminAddedOrgWideConnectorDetails(bb.Struct):
     """
     Admin added an admin connector.
 
-    :ivar team_log.DashAdminAddedOrgWideConnectorDetails.connector_name: The
-        name of the Connector.
-    :ivar team_log.DashAdminAddedOrgWideConnectorDetails.connector_status: The
-        status of the Connector.
+    :ivar DashAdminAddedOrgWideConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashAdminAddedOrgWideConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -5892,10 +5970,10 @@ class DashAdminDisabledConnectorDetails(bb.Struct):
     """
     Admin disabled a user connector.
 
-    :ivar team_log.DashAdminDisabledConnectorDetails.connector_name: The name of
-        the Connector.
-    :ivar team_log.DashAdminDisabledConnectorDetails.connector_status: The
-        status of the Connector.
+    :ivar DashAdminDisabledConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashAdminDisabledConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -5952,10 +6030,10 @@ class DashAdminEnabledConnectorDetails(bb.Struct):
     """
     Admin enabled a user connector.
 
-    :ivar team_log.DashAdminEnabledConnectorDetails.connector_name: The name of
-        the Connector.
-    :ivar team_log.DashAdminEnabledConnectorDetails.connector_status: The status
-        of the Connector.
+    :ivar DashAdminEnabledConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashAdminEnabledConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -6012,10 +6090,10 @@ class DashAdminRemovedOrgWideConnectorDetails(bb.Struct):
     """
     Admin removed an admin connector.
 
-    :ivar team_log.DashAdminRemovedOrgWideConnectorDetails.connector_name: The
-        name of the Connector.
-    :ivar team_log.DashAdminRemovedOrgWideConnectorDetails.connector_status: The
-        status of the Connector.
+    :ivar DashAdminRemovedOrgWideConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashAdminRemovedOrgWideConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -6072,9 +6150,10 @@ class DashArchivedStackDetails(bb.Struct):
     """
     Archived a stack.
 
-    :ivar team_log.DashArchivedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashArchivedStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashArchivedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashArchivedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6131,10 +6210,10 @@ class DashChangedAudienceOfSharedLinkToStackDetails(bb.Struct):
     """
     Changed the audience of a shared link to a stack.
 
-    :ivar team_log.DashChangedAudienceOfSharedLinkToStackDetails.stack_name: The
-        name of the stack.
-    :ivar team_log.DashChangedAudienceOfSharedLinkToStackDetails.stack_type: The
-        type of stack backend.
+    :ivar DashChangedAudienceOfSharedLinkToStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashChangedAudienceOfSharedLinkToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6191,11 +6270,14 @@ class DashClonedStackDetails(bb.Struct):
     """
     Cloned stack.
 
-    :ivar team_log.DashClonedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashClonedStackDetails.actor_email: Email of the actor.
-    :ivar team_log.DashClonedStackDetails.new_cloned_stack_name: New cloned
-        stack name.
-    :ivar team_log.DashClonedStackDetails.stack_type: The type of stack backend.
+    :ivar DashClonedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashClonedStackDetails.actor_email:
+        Email of the actor.
+    :ivar DashClonedStackDetails.new_cloned_stack_name:
+        New cloned stack name.
+    :ivar DashClonedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6314,12 +6396,12 @@ class DashConnectorToolsCallDetails(bb.Struct):
     """
     Called a tool on a connector.
 
-    :ivar team_log.DashConnectorToolsCallDetails.connector_name: The name of the
-        connector.
-    :ivar team_log.DashConnectorToolsCallDetails.tool_name: The name of the tool
-        that was called.
-    :ivar team_log.DashConnectorToolsCallDetails.surface: The surface from which
-        the tool was called.
+    :ivar DashConnectorToolsCallDetails.connector_name:
+        The name of the connector.
+    :ivar DashConnectorToolsCallDetails.tool_name:
+        The name of the tool that was called.
+    :ivar DashConnectorToolsCallDetails.surface:
+        The surface from which the tool was called.
     """
 
     __slots__ = [
@@ -6384,9 +6466,10 @@ class DashCreatedStackDetails(bb.Struct):
     """
     Created a stack.
 
-    :ivar team_log.DashCreatedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashCreatedStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashCreatedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashCreatedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6443,12 +6526,12 @@ class DashDeletedCommentFromStackDetails(bb.Struct):
     """
     Deleted a comment from a stack.
 
-    :ivar team_log.DashDeletedCommentFromStackDetails.stack_name: The name of
-        the stack where the comment exists.
-    :ivar team_log.DashDeletedCommentFromStackDetails.stack_item_name: The name
-        of the stack item that the comment is tied to.
-    :ivar team_log.DashDeletedCommentFromStackDetails.stack_type: The type of
-        stack backend.
+    :ivar DashDeletedCommentFromStackDetails.stack_name:
+        The name of the stack where the comment exists.
+    :ivar DashDeletedCommentFromStackDetails.stack_item_name:
+        The name of the stack item that the comment is tied to.
+    :ivar DashDeletedCommentFromStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6513,9 +6596,10 @@ class DashDeletedStackDetails(bb.Struct):
     """
     Deleted a stack.
 
-    :ivar team_log.DashDeletedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashDeletedStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashDeletedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashDeletedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6572,14 +6656,14 @@ class DashEditedCommentInStackDetails(bb.Struct):
     """
     Edited a comment in a stack.
 
-    :ivar team_log.DashEditedCommentInStackDetails.stack_name: The name of the
-        stack where the comment exists.
-    :ivar team_log.DashEditedCommentInStackDetails.stack_item_name: The name of
-        the stack item that the comment is tied to.
-    :ivar team_log.DashEditedCommentInStackDetails.comment_text: The text of the
-        comment.
-    :ivar team_log.DashEditedCommentInStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashEditedCommentInStackDetails.stack_name:
+        The name of the stack where the comment exists.
+    :ivar DashEditedCommentInStackDetails.stack_item_name:
+        The name of the stack item that the comment is tied to.
+    :ivar DashEditedCommentInStackDetails.comment_text:
+        The text of the comment.
+    :ivar DashEditedCommentInStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6708,8 +6792,10 @@ class DashExternalSharingPolicyChangedDetails(bb.Struct):
     """
     Changed Dash external sharing policy for team.
 
-    :ivar team_log.DashExternalSharingPolicyChangedDetails.new_value: To.
-    :ivar team_log.DashExternalSharingPolicyChangedDetails.previous_value: From.
+    :ivar DashExternalSharingPolicyChangedDetails.new_value:
+        To.
+    :ivar DashExternalSharingPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -6766,18 +6852,18 @@ class DashExternalUserOpenedStackDetails(bb.Struct):
     """
     External user opened a stack.
 
-    :ivar team_log.DashExternalUserOpenedStackDetails.stack_name: The name of
-        the stack.
-    :ivar team_log.DashExternalUserOpenedStackDetails.stack_sharing_scope: The
-        sharing scope of the stack.
-    :ivar team_log.DashExternalUserOpenedStackDetails.is_invited: Whether the
-        user was invited to the stack.
-    :ivar team_log.DashExternalUserOpenedStackDetails.is_verified: Whether the
-        user has verified their email address.
-    :ivar team_log.DashExternalUserOpenedStackDetails.stack_owner_team_id: The
-        team ID of the stack owner.
-    :ivar team_log.DashExternalUserOpenedStackDetails.stack_type: The type of
-        stack backend.
+    :ivar DashExternalUserOpenedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashExternalUserOpenedStackDetails.stack_sharing_scope:
+        The sharing scope of the stack.
+    :ivar DashExternalUserOpenedStackDetails.is_invited:
+        Whether the user was invited to the stack.
+    :ivar DashExternalUserOpenedStackDetails.is_verified:
+        Whether the user has verified their email address.
+    :ivar DashExternalUserOpenedStackDetails.stack_owner_team_id:
+        The team ID of the stack owner.
+    :ivar DashExternalUserOpenedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -6866,8 +6952,8 @@ class DashFirstLaunchedDesktopDetails(bb.Struct):
     """
     Opened the desktop app for the first time.
 
-    :ivar team_log.DashFirstLaunchedDesktopDetails.os_name: The name of the
-        operating system.
+    :ivar DashFirstLaunchedDesktopDetails.os_name:
+        The name of the operating system.
     """
 
     __slots__ = [
@@ -6916,8 +7002,8 @@ class DashFirstLaunchedExtensionDetails(bb.Struct):
     """
     Opened the extension for the first time.
 
-    :ivar team_log.DashFirstLaunchedExtensionDetails.browser_name: The name of
-        the web browser.
+    :ivar DashFirstLaunchedExtensionDetails.browser_name:
+        The name of the web browser.
     """
 
     __slots__ = [
@@ -6966,8 +7052,8 @@ class DashFirstLaunchedWebStartPageDetails(bb.Struct):
     """
     Opened the web Start Page for the first time.
 
-    :ivar team_log.DashFirstLaunchedWebStartPageDetails.browser_name: The name
-        of the web browser.
+    :ivar DashFirstLaunchedWebStartPageDetails.browser_name:
+        The name of the web browser.
     """
 
     __slots__ = [
@@ -7016,10 +7102,10 @@ class DashOpenedSharedLinkToStackDetails(bb.Struct):
     """
     Checked access permissions to a stack.
 
-    :ivar team_log.DashOpenedSharedLinkToStackDetails.stack_name: The name of
-        the stack.
-    :ivar team_log.DashOpenedSharedLinkToStackDetails.stack_type: The type of
-        stack backend.
+    :ivar DashOpenedSharedLinkToStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashOpenedSharedLinkToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7076,8 +7162,10 @@ class DashOpenedStackDetails(bb.Struct):
     """
     Opened a stack.
 
-    :ivar team_log.DashOpenedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashOpenedStackDetails.stack_type: The type of stack backend.
+    :ivar DashOpenedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashOpenedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7180,8 +7268,8 @@ class DashPreviewOptOutStatusChangedDetails(bb.Struct):
     """
     Changed the preview opt-out status.
 
-    :ivar team_log.DashPreviewOptOutStatusChangedDetails.opt_out_status: The new
-        preview opt-out status.
+    :ivar DashPreviewOptOutStatusChangedDetails.opt_out_status:
+        The new preview opt-out status.
     """
 
     __slots__ = [
@@ -7230,10 +7318,10 @@ class DashRemovedConnectorDetails(bb.Struct):
     """
     Disconnected a user connector.
 
-    :ivar team_log.DashRemovedConnectorDetails.connector_name: The name of the
-        Connector.
-    :ivar team_log.DashRemovedConnectorDetails.connector_status: The status of
-        the Connector.
+    :ivar DashRemovedConnectorDetails.connector_name:
+        The name of the Connector.
+    :ivar DashRemovedConnectorDetails.connector_status:
+        The status of the Connector.
     """
 
     __slots__ = [
@@ -7290,12 +7378,12 @@ class DashRemovedLinkFromStackDetails(bb.Struct):
     """
     Removed a link from a stack.
 
-    :ivar team_log.DashRemovedLinkFromStackDetails.stack_name: The name of the
-        stack.
-    :ivar team_log.DashRemovedLinkFromStackDetails.stack_item_link: The link to
-        the item in the stack.
-    :ivar team_log.DashRemovedLinkFromStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashRemovedLinkFromStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashRemovedLinkFromStackDetails.stack_item_link:
+        The link to the item in the stack.
+    :ivar DashRemovedLinkFromStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7360,10 +7448,10 @@ class DashRemovedSharedLinkToStackDetails(bb.Struct):
     """
     Removed a shared link to a stack.
 
-    :ivar team_log.DashRemovedSharedLinkToStackDetails.stack_name: The name of
-        the stack.
-    :ivar team_log.DashRemovedSharedLinkToStackDetails.stack_type: The type of
-        stack backend.
+    :ivar DashRemovedSharedLinkToStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashRemovedSharedLinkToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7420,8 +7508,8 @@ class DashRemovedTeamEmailDomainAllowlistDetails(bb.Struct):
     """
     Admin removed an email domain from the team allowlist.
 
-    :ivar team_log.DashRemovedTeamEmailDomainAllowlistDetails.email_domain: The
-        email domain that gets added/removed from the team allowlist.
+    :ivar DashRemovedTeamEmailDomainAllowlistDetails.email_domain:
+        The email domain that gets added/removed from the team allowlist.
     """
 
     __slots__ = [
@@ -7470,10 +7558,12 @@ class DashRenamedStackDetails(bb.Struct):
     """
     Renamed a stack.
 
-    :ivar team_log.DashRenamedStackDetails.old_name: The old name of the stack.
-    :ivar team_log.DashRenamedStackDetails.new_name: The new name of the stack.
-    :ivar team_log.DashRenamedStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashRenamedStackDetails.old_name:
+        The old name of the stack.
+    :ivar DashRenamedStackDetails.new_name:
+        The new name of the stack.
+    :ivar DashRenamedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7538,10 +7628,10 @@ class DashSharedLinkToStackDetails(bb.Struct):
     """
     Shared a link to a stack.
 
-    :ivar team_log.DashSharedLinkToStackDetails.stack_name: The name of the
-        stack.
-    :ivar team_log.DashSharedLinkToStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashSharedLinkToStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashSharedLinkToStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7720,9 +7810,10 @@ class DashUnarchivedStackDetails(bb.Struct):
     """
     Unarchived a stack.
 
-    :ivar team_log.DashUnarchivedStackDetails.stack_name: The name of the stack.
-    :ivar team_log.DashUnarchivedStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashUnarchivedStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashUnarchivedStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7779,10 +7870,10 @@ class DashViewedCompanyStackDetails(bb.Struct):
     """
     Member viewed a company stack.
 
-    :ivar team_log.DashViewedCompanyStackDetails.stack_name: The name of the
-        stack.
-    :ivar team_log.DashViewedCompanyStackDetails.stack_type: The type of stack
-        backend.
+    :ivar DashViewedCompanyStackDetails.stack_name:
+        The name of the stack.
+    :ivar DashViewedCompanyStackDetails.stack_type:
+        The type of stack backend.
     """
 
     __slots__ = [
@@ -7879,10 +7970,10 @@ class DataPlacementRestrictionChangePolicyDetails(bb.Struct):
     """
     Set restrictions on data center locations where team data resides.
 
-    :ivar team_log.DataPlacementRestrictionChangePolicyDetails.previous_value:
+    :ivar DataPlacementRestrictionChangePolicyDetails.previous_value:
         Previous placement restriction.
-    :ivar team_log.DataPlacementRestrictionChangePolicyDetails.new_value: New
-        placement restriction.
+    :ivar DataPlacementRestrictionChangePolicyDetails.new_value:
+        New placement restriction.
     """
 
     __slots__ = [
@@ -7939,8 +8030,7 @@ class DataPlacementRestrictionSatisfyPolicyDetails(bb.Struct):
     """
     Completed restrictions on data center locations where team data resides.
 
-    :ivar
-        team_log.DataPlacementRestrictionSatisfyPolicyDetails.placement_restriction:
+    :ivar DataPlacementRestrictionSatisfyPolicyDetails.placement_restriction:
         Placement restriction.
     """
 
@@ -8177,8 +8267,8 @@ class DeleteTeamInviteLinkDetails(bb.Struct):
     """
     Deleted team invite link.
 
-    :ivar team_log.DeleteTeamInviteLinkDetails.link_url: The invite link url
-        that was deleted.
+    :ivar DeleteTeamInviteLinkDetails.link_url:
+        The invite link url that was deleted.
     """
 
     __slots__ = [
@@ -8227,12 +8317,12 @@ class DeviceSessionLogInfo(bb.Struct):
     """
     Device's session logged information.
 
-    :ivar team_log.DeviceSessionLogInfo.ip_address: The IP address of the last
-        activity from this session.
-    :ivar team_log.DeviceSessionLogInfo.created: The time this session was
-        created.
-    :ivar team_log.DeviceSessionLogInfo.updated: The time of the last activity
-        from this session.
+    :ivar DeviceSessionLogInfo.ip_address:
+        The IP address of the last activity from this session.
+    :ivar DeviceSessionLogInfo.created:
+        The time this session was created.
+    :ivar DeviceSessionLogInfo.updated:
+        The time of the last activity from this session.
     """
 
     __slots__ = [
@@ -8275,17 +8365,17 @@ class DesktopDeviceSessionLogInfo(DeviceSessionLogInfo):
     """
     Information about linked Dropbox desktop client sessions
 
-    :ivar team_log.DesktopDeviceSessionLogInfo.session_info: Desktop session
-        unique id.
-    :ivar team_log.DesktopDeviceSessionLogInfo.host_name: Name of the hosting
-        desktop.
-    :ivar team_log.DesktopDeviceSessionLogInfo.client_type: The Dropbox desktop
-        client type.
-    :ivar team_log.DesktopDeviceSessionLogInfo.client_version: The Dropbox
-        client version.
-    :ivar team_log.DesktopDeviceSessionLogInfo.platform: Information on the
-        hosting platform.
-    :ivar team_log.DesktopDeviceSessionLogInfo.is_delete_on_unlink_supported:
+    :ivar DesktopDeviceSessionLogInfo.session_info:
+        Desktop session unique id.
+    :ivar DesktopDeviceSessionLogInfo.host_name:
+        Name of the hosting desktop.
+    :ivar DesktopDeviceSessionLogInfo.client_type:
+        The Dropbox desktop client type.
+    :ivar DesktopDeviceSessionLogInfo.client_version:
+        The Dropbox client version.
+    :ivar DesktopDeviceSessionLogInfo.platform:
+        Information on the hosting platform.
+    :ivar DesktopDeviceSessionLogInfo.is_delete_on_unlink_supported:
         Whether itu2019s possible to delete all of the account files upon
         unlinking.
     """
@@ -8360,7 +8450,8 @@ class SessionLogInfo(bb.Struct):
     """
     Session's logged information.
 
-    :ivar team_log.SessionLogInfo.session_id: Session ID.
+    :ivar SessionLogInfo.session_id:
+        Session ID.
     """
 
     __slots__ = [
@@ -8447,10 +8538,10 @@ class DeviceApprovalsChangeDesktopPolicyDetails(bb.Struct):
     Set/removed limit on number of computers member can link to team Dropbox
     account.
 
-    :ivar team_log.DeviceApprovalsChangeDesktopPolicyDetails.new_value: New
-        desktop device approvals policy. Might be missing due to historical data
-        gap.
-    :ivar team_log.DeviceApprovalsChangeDesktopPolicyDetails.previous_value:
+    :ivar DeviceApprovalsChangeDesktopPolicyDetails.new_value:
+        New desktop device approvals policy. Might be missing due to historical
+        data gap.
+    :ivar DeviceApprovalsChangeDesktopPolicyDetails.previous_value:
         Previous desktop device approvals policy. Might be missing due to
         historical data gap.
     """
@@ -8510,10 +8601,10 @@ class DeviceApprovalsChangeMobilePolicyDetails(bb.Struct):
     Set/removed limit on number of mobile devices member can link to team
     Dropbox account.
 
-    :ivar team_log.DeviceApprovalsChangeMobilePolicyDetails.new_value: New
-        mobile device approvals policy. Might be missing due to historical data
-        gap.
-    :ivar team_log.DeviceApprovalsChangeMobilePolicyDetails.previous_value:
+    :ivar DeviceApprovalsChangeMobilePolicyDetails.new_value:
+        New mobile device approvals policy. Might be missing due to historical
+        data gap.
+    :ivar DeviceApprovalsChangeMobilePolicyDetails.previous_value:
         Previous mobile device approvals policy. Might be missing due to
         historical data gap.
     """
@@ -8572,9 +8663,9 @@ class DeviceApprovalsChangeOverageActionDetails(bb.Struct):
     """
     Changed device approvals setting when member is over limit.
 
-    :ivar team_log.DeviceApprovalsChangeOverageActionDetails.new_value: New over
-        the limits policy. Might be missing due to historical data gap.
-    :ivar team_log.DeviceApprovalsChangeOverageActionDetails.previous_value:
+    :ivar DeviceApprovalsChangeOverageActionDetails.new_value:
+        New over the limits policy. Might be missing due to historical data gap.
+    :ivar DeviceApprovalsChangeOverageActionDetails.previous_value:
         Previous over the limit policy. Might be missing due to historical data
         gap.
     """
@@ -8633,9 +8724,9 @@ class DeviceApprovalsChangeUnlinkActionDetails(bb.Struct):
     """
     Changed device approvals setting when member unlinks approved device.
 
-    :ivar team_log.DeviceApprovalsChangeUnlinkActionDetails.new_value: New
-        device unlink policy. Might be missing due to historical data gap.
-    :ivar team_log.DeviceApprovalsChangeUnlinkActionDetails.previous_value:
+    :ivar DeviceApprovalsChangeUnlinkActionDetails.new_value:
+        New device unlink policy. Might be missing due to historical data gap.
+    :ivar DeviceApprovalsChangeUnlinkActionDetails.previous_value:
         Previous device unlink policy. Might be missing due to historical data
         gap.
     """
@@ -8778,8 +8869,8 @@ class DeviceChangeIpDesktopDetails(bb.Struct):
     """
     Changed IP address associated with active desktop session.
 
-    :ivar team_log.DeviceChangeIpDesktopDetails.device_session_info: Device's
-        session logged information.
+    :ivar DeviceChangeIpDesktopDetails.device_session_info:
+        Device's session logged information.
     """
 
     __slots__ = [
@@ -8828,8 +8919,8 @@ class DeviceChangeIpMobileDetails(bb.Struct):
     """
     Changed IP address associated with active mobile session.
 
-    :ivar team_log.DeviceChangeIpMobileDetails.device_session_info: Device's
-        session logged information.
+    :ivar DeviceChangeIpMobileDetails.device_session_info:
+        Device's session logged information.
     """
 
     __slots__ = [
@@ -8878,7 +8969,8 @@ class DeviceChangeIpWebDetails(bb.Struct):
     """
     Changed IP address associated with active web session.
 
-    :ivar team_log.DeviceChangeIpWebDetails.user_agent: Web browser name.
+    :ivar DeviceChangeIpWebDetails.user_agent:
+        Web browser name.
     """
 
     __slots__ = [
@@ -8927,12 +9019,12 @@ class DeviceDeleteOnUnlinkFailDetails(bb.Struct):
     """
     Failed to delete all files from unlinked device.
 
-    :ivar team_log.DeviceDeleteOnUnlinkFailDetails.session_info: Session unique
-        id.
-    :ivar team_log.DeviceDeleteOnUnlinkFailDetails.display_name: The device
-        name. Might be missing due to historical data gap.
-    :ivar team_log.DeviceDeleteOnUnlinkFailDetails.num_failures: The number of
-        times that remote file deletion failed.
+    :ivar DeviceDeleteOnUnlinkFailDetails.session_info:
+        Session unique id.
+    :ivar DeviceDeleteOnUnlinkFailDetails.display_name:
+        The device name. Might be missing due to historical data gap.
+    :ivar DeviceDeleteOnUnlinkFailDetails.num_failures:
+        The number of times that remote file deletion failed.
     """
 
     __slots__ = [
@@ -8997,10 +9089,10 @@ class DeviceDeleteOnUnlinkSuccessDetails(bb.Struct):
     """
     Deleted all files from unlinked device.
 
-    :ivar team_log.DeviceDeleteOnUnlinkSuccessDetails.session_info: Session
-        unique id.
-    :ivar team_log.DeviceDeleteOnUnlinkSuccessDetails.display_name: The device
-        name. Might be missing due to historical data gap.
+    :ivar DeviceDeleteOnUnlinkSuccessDetails.session_info:
+        Session unique id.
+    :ivar DeviceDeleteOnUnlinkSuccessDetails.display_name:
+        The device name. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -9057,10 +9149,10 @@ class DeviceLinkFailDetails(bb.Struct):
     """
     Failed to link device.
 
-    :ivar team_log.DeviceLinkFailDetails.ip_address: IP address. Might be
-        missing due to historical data gap.
-    :ivar team_log.DeviceLinkFailDetails.device_type: A description of the
-        device used while user approval blocked.
+    :ivar DeviceLinkFailDetails.ip_address:
+        IP address. Might be missing due to historical data gap.
+    :ivar DeviceLinkFailDetails.device_type:
+        A description of the device used while user approval blocked.
     """
 
     __slots__ = [
@@ -9117,8 +9209,8 @@ class DeviceLinkSuccessDetails(bb.Struct):
     """
     Linked device.
 
-    :ivar team_log.DeviceLinkSuccessDetails.device_session_info: Device's
-        session logged information.
+    :ivar DeviceLinkSuccessDetails.device_session_info:
+        Device's session logged information.
     """
 
     __slots__ = [
@@ -9247,13 +9339,12 @@ class DeviceSyncBackupStatusChangedDetails(bb.Struct):
     """
     Enabled/disabled backup for computer.
 
-    :ivar
-        team_log.DeviceSyncBackupStatusChangedDetails.desktop_device_session_info:
+    :ivar DeviceSyncBackupStatusChangedDetails.desktop_device_session_info:
         Device's session logged information.
-    :ivar team_log.DeviceSyncBackupStatusChangedDetails.previous_value: Previous
-        status of computer backup on the device.
-    :ivar team_log.DeviceSyncBackupStatusChangedDetails.new_value: Next status
-        of computer backup on the device.
+    :ivar DeviceSyncBackupStatusChangedDetails.previous_value:
+        Previous status of computer backup on the device.
+    :ivar DeviceSyncBackupStatusChangedDetails.new_value:
+        Next status of computer backup on the device.
     """
 
     __slots__ = [
@@ -9362,11 +9453,13 @@ class DeviceUnlinkDetails(bb.Struct):
     """
     Disconnected device.
 
-    :ivar team_log.DeviceUnlinkDetails.session_info: Session unique id.
-    :ivar team_log.DeviceUnlinkDetails.display_name: The device name. Might be
-        missing due to historical data gap.
-    :ivar team_log.DeviceUnlinkDetails.delete_data: True if the user requested
-        to delete data after device unlink, false otherwise.
+    :ivar DeviceUnlinkDetails.session_info:
+        Session unique id.
+    :ivar DeviceUnlinkDetails.display_name:
+        The device name. Might be missing due to historical data gap.
+    :ivar DeviceUnlinkDetails.delete_data:
+        True if the user requested to delete data after device unlink, false
+        otherwise.
     """
 
     __slots__ = [
@@ -9719,10 +9812,10 @@ class DomainInvitesEmailExistingUsersDetails(bb.Struct):
     """
     Sent domain invites to existing domain accounts.
 
-    :ivar team_log.DomainInvitesEmailExistingUsersDetails.domain_name: Domain
-        names.
-    :ivar team_log.DomainInvitesEmailExistingUsersDetails.num_recipients: Number
-        of recipients.
+    :ivar DomainInvitesEmailExistingUsersDetails.domain_name:
+        Domain names.
+    :ivar DomainInvitesEmailExistingUsersDetails.num_recipients:
+        Number of recipients.
     """
 
     __slots__ = [
@@ -9899,9 +9992,9 @@ class DomainVerificationAddDomainFailDetails(bb.Struct):
     """
     Failed to verify team domain.
 
-    :ivar team_log.DomainVerificationAddDomainFailDetails.domain_name: Domain
-        name.
-    :ivar team_log.DomainVerificationAddDomainFailDetails.verification_method:
+    :ivar DomainVerificationAddDomainFailDetails.domain_name:
+        Domain name.
+    :ivar DomainVerificationAddDomainFailDetails.verification_method:
         Domain name verification method. Might be missing due to historical data
         gap.
     """
@@ -9960,10 +10053,9 @@ class DomainVerificationAddDomainSuccessDetails(bb.Struct):
     """
     Verified team domain.
 
-    :ivar team_log.DomainVerificationAddDomainSuccessDetails.domain_names:
+    :ivar DomainVerificationAddDomainSuccessDetails.domain_names:
         Domain names.
-    :ivar
-        team_log.DomainVerificationAddDomainSuccessDetails.verification_method:
+    :ivar DomainVerificationAddDomainSuccessDetails.verification_method:
         Domain name verification method. Might be missing due to historical data
         gap.
     """
@@ -10022,8 +10114,8 @@ class DomainVerificationRemoveDomainDetails(bb.Struct):
     """
     Removed domain from list of verified team domains.
 
-    :ivar team_log.DomainVerificationRemoveDomainDetails.domain_names: Domain
-        names.
+    :ivar DomainVerificationRemoveDomainDetails.domain_names:
+        Domain names.
     """
 
     __slots__ = [
@@ -10118,8 +10210,8 @@ class DropboxPasswordsExportedDetails(bb.Struct):
     """
     Exported passwords.
 
-    :ivar team_log.DropboxPasswordsExportedDetails.platform: The platform the
-        device runs export.
+    :ivar DropboxPasswordsExportedDetails.platform:
+        The platform the device runs export.
     """
 
     __slots__ = [
@@ -10168,10 +10260,10 @@ class DropboxPasswordsNewDeviceEnrolledDetails(bb.Struct):
     """
     Enrolled new Dropbox Passwords device.
 
-    :ivar team_log.DropboxPasswordsNewDeviceEnrolledDetails.is_first_device:
+    :ivar DropboxPasswordsNewDeviceEnrolledDetails.is_first_device:
         Whether it's a first device enrolled.
-    :ivar team_log.DropboxPasswordsNewDeviceEnrolledDetails.platform: The
-        platform the device is enrolled.
+    :ivar DropboxPasswordsNewDeviceEnrolledDetails.platform:
+        The platform the device is enrolled.
     """
 
     __slots__ = [
@@ -10284,8 +10376,10 @@ class DropboxPasswordsPolicyChangedDetails(bb.Struct):
     """
     Changed Dropbox Passwords policy for team.
 
-    :ivar team_log.DropboxPasswordsPolicyChangedDetails.new_value: To.
-    :ivar team_log.DropboxPasswordsPolicyChangedDetails.previous_value: From.
+    :ivar DropboxPasswordsPolicyChangedDetails.new_value:
+        To.
+    :ivar DropboxPasswordsPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -10342,8 +10436,10 @@ class DurationLogInfo(bb.Struct):
     """
     Represents a time duration: unit and amount
 
-    :ivar team_log.DurationLogInfo.unit: Time unit.
-    :ivar team_log.DurationLogInfo.amount: Amount of time.
+    :ivar DurationLogInfo.unit:
+        Time unit.
+    :ivar DurationLogInfo.amount:
+        Amount of time.
     """
 
     __slots__ = [
@@ -10424,8 +10520,10 @@ class EmailIngestPolicyChangedDetails(bb.Struct):
     """
     Changed email to Dropbox policy for team.
 
-    :ivar team_log.EmailIngestPolicyChangedDetails.new_value: To.
-    :ivar team_log.EmailIngestPolicyChangedDetails.previous_value: From.
+    :ivar EmailIngestPolicyChangedDetails.new_value:
+        To.
+    :ivar EmailIngestPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -10482,14 +10580,16 @@ class EmailIngestReceiveFileDetails(bb.Struct):
     """
     Received files via Email to Dropbox.
 
-    :ivar team_log.EmailIngestReceiveFileDetails.inbox_name: Inbox name.
-    :ivar team_log.EmailIngestReceiveFileDetails.attachment_names: Submitted
-        file names.
-    :ivar team_log.EmailIngestReceiveFileDetails.subject: Subject of the email.
-    :ivar team_log.EmailIngestReceiveFileDetails.from_name: The name as provided
-        by the submitter.
-    :ivar team_log.EmailIngestReceiveFileDetails.from_email: The email as
-        provided by the submitter.
+    :ivar EmailIngestReceiveFileDetails.inbox_name:
+        Inbox name.
+    :ivar EmailIngestReceiveFileDetails.attachment_names:
+        Submitted file names.
+    :ivar EmailIngestReceiveFileDetails.subject:
+        Subject of the email.
+    :ivar EmailIngestReceiveFileDetails.from_name:
+        The name as provided by the submitter.
+    :ivar EmailIngestReceiveFileDetails.from_email:
+        The email as provided by the submitter.
     """
 
     __slots__ = [
@@ -10610,10 +10710,11 @@ class EmmChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled enterprise mobility management for members.
 
-    :ivar team_log.EmmChangePolicyDetails.new_value: New enterprise mobility
-        management policy.
-    :ivar team_log.EmmChangePolicyDetails.previous_value: Previous enterprise
-        mobility management policy. Might be missing due to historical data gap.
+    :ivar EmmChangePolicyDetails.new_value:
+        New enterprise mobility management policy.
+    :ivar EmmChangePolicyDetails.previous_value:
+        Previous enterprise mobility management policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -10750,7 +10851,8 @@ class EmmErrorDetails(bb.Struct):
     """
     Failed to sign in via EMM.
 
-    :ivar team_log.EmmErrorDetails.error_details: Error details.
+    :ivar EmmErrorDetails.error_details:
+        Error details.
     """
 
     __slots__ = [
@@ -10919,7 +11021,7 @@ class EncryptedFolderCancelTeamKeyRotationDetails(bb.Struct):
     """
     Canceled team key rotation.
 
-    :ivar team_log.EncryptedFolderCancelTeamKeyRotationDetails.team_key_id:
+    :ivar EncryptedFolderCancelTeamKeyRotationDetails.team_key_id:
         Identifier of the team key.
     """
 
@@ -10969,7 +11071,7 @@ class EncryptedFolderEnrollBackupKeyDetails(bb.Struct):
     """
     Added recovery key.
 
-    :ivar team_log.EncryptedFolderEnrollBackupKeyDetails.backup_key_id:
+    :ivar EncryptedFolderEnrollBackupKeyDetails.backup_key_id:
         Identifier of the recovery key.
     """
 
@@ -11019,8 +11121,8 @@ class EncryptedFolderEnrollClientDetails(bb.Struct):
     """
     Enrolled device.
 
-    :ivar team_log.EncryptedFolderEnrollClientDetails.client_key_id: Identifier
-        of the client key.
+    :ivar EncryptedFolderEnrollClientDetails.client_key_id:
+        Identifier of the client key.
     """
 
     __slots__ = [
@@ -11149,7 +11251,7 @@ class EncryptedFolderInitTeamKeyRotationDetails(bb.Struct):
     """
     Initiated team key rotation.
 
-    :ivar team_log.EncryptedFolderInitTeamKeyRotationDetails.team_key_id:
+    :ivar EncryptedFolderInitTeamKeyRotationDetails.team_key_id:
         Identifier of the team key.
     """
 
@@ -11239,7 +11341,7 @@ class EncryptedFolderRemoveBackupKeyDetails(bb.Struct):
     """
     Removed recovery key.
 
-    :ivar team_log.EncryptedFolderRemoveBackupKeyDetails.backup_key_id:
+    :ivar EncryptedFolderRemoveBackupKeyDetails.backup_key_id:
         Identifier of the recovery key.
     """
 
@@ -11289,8 +11391,8 @@ class EncryptedFolderRotateTeamKeyDetails(bb.Struct):
     """
     Rotated team key.
 
-    :ivar team_log.EncryptedFolderRotateTeamKeyDetails.team_key_id: Identifier
-        of the team key.
+    :ivar EncryptedFolderRotateTeamKeyDetails.team_key_id:
+        Identifier of the team key.
     """
 
     __slots__ = [
@@ -11339,7 +11441,7 @@ class EncryptedFolderUnenrollClientDetails(bb.Struct):
     """
     Unenrolled device.
 
-    :ivar team_log.EncryptedFolderUnenrollClientDetails.client_key_id:
+    :ivar EncryptedFolderUnenrollClientDetails.client_key_id:
         Identifier of the client key.
     """
 
@@ -11389,8 +11491,7 @@ class EndedEnterpriseAdminSessionDeprecatedDetails(bb.Struct):
     """
     Ended enterprise admin session.
 
-    :ivar
-        team_log.EndedEnterpriseAdminSessionDeprecatedDetails.federation_extra_details:
+    :ivar EndedEnterpriseAdminSessionDeprecatedDetails.federation_extra_details:
         More information about the organization or team.
     """
 
@@ -11527,15 +11628,13 @@ class EnterpriseSettingsLockingDetails(bb.Struct):
     """
     Changed who can update a setting.
 
-    :ivar team_log.EnterpriseSettingsLockingDetails.team_name: The secondary
-        team name.
-    :ivar team_log.EnterpriseSettingsLockingDetails.settings_page_name: Settings
-        page name.
-    :ivar
-        team_log.EnterpriseSettingsLockingDetails.previous_settings_page_locking_state:
+    :ivar EnterpriseSettingsLockingDetails.team_name:
+        The secondary team name.
+    :ivar EnterpriseSettingsLockingDetails.settings_page_name:
+        Settings page name.
+    :ivar EnterpriseSettingsLockingDetails.previous_settings_page_locking_state:
         Previous locked settings page state.
-    :ivar
-        team_log.EnterpriseSettingsLockingDetails.new_settings_page_locking_state:
+    :ivar EnterpriseSettingsLockingDetails.new_settings_page_locking_state:
         New locked settings page state.
     """
 
@@ -11613,54 +11712,64 @@ class EventCategory(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_log.EventCategory.admin_alerting: Events that involve team
-        related alerts.
-    :ivar team_log.EventCategory.apps: Events that apply to management of linked
-        apps.
-    :ivar team_log.EventCategory.comments: Events that have to do with comments
-        on files and Paper documents.
-    :ivar team_log.EventCategory.dash: Events that apply to Dropbox Dash
-    :ivar team_log.EventCategory.data_governance: Events that involve data
-        governance actions
-    :ivar team_log.EventCategory.devices: Events that apply to linked devices on
-        mobile, desktop and Web platforms.
-    :ivar team_log.EventCategory.domains: Events that involve domain management
-        feature: domain verification, invite enforcement and account capture.
-    :ivar team_log.EventCategory.encryption: Events that involve encryption.
-    :ivar team_log.EventCategory.file_operations: Events that have to do with
-        filesystem operations on files and folders: copy, move, delete, etc.
-    :ivar team_log.EventCategory.file_requests: Events that apply to the file
-        requests feature.
-    :ivar team_log.EventCategory.groups: Events that involve group management.
-    :ivar team_log.EventCategory.logins: Events that involve users signing in to
-        or out of Dropbox.
-    :ivar team_log.EventCategory.members: Events that involve team member
-        management.
-    :ivar team_log.EventCategory.paper: Events that apply to Dropbox Paper.
-    :ivar team_log.EventCategory.passwords: Events that involve using, changing
-        or resetting passwords.
-    :ivar team_log.EventCategory.protect: Events that apply to Dropbox Protect
-    :ivar team_log.EventCategory.reports: Events that concern generation of
-        admin reports, including team activity and device usage.
-    :ivar team_log.EventCategory.sharing: Events that apply to all types of
-        sharing and collaboration.
-    :ivar team_log.EventCategory.showcase: Events that apply to Dropbox
-        Showcase.
-    :ivar team_log.EventCategory.signatures: Events that apply to Dropbox Sign
-    :ivar team_log.EventCategory.sso: Events that involve using or configuring
-        single sign-on as well as administrative policies concerning single
-        sign-on.
-    :ivar team_log.EventCategory.team_folders: Events that involve team folder
-        management.
-    :ivar team_log.EventCategory.team_policies: Events that involve a change in
-        team-wide policies.
-    :ivar team_log.EventCategory.team_profile: Events that involve a change in
-        the team profile.
-    :ivar team_log.EventCategory.tfa: Events that involve using or configuring
-        two factor authentication as well as administrative policies concerning
-        two factor authentication.
-    :ivar team_log.EventCategory.trusted_teams: Events that apply to cross-team
-        trust establishment.
+    :ivar EventCategory.admin_alerting:
+        Events that involve team related alerts.
+    :ivar EventCategory.apps:
+        Events that apply to management of linked apps.
+    :ivar EventCategory.comments:
+        Events that have to do with comments on files and Paper documents.
+    :ivar EventCategory.dash:
+        Events that apply to Dropbox Dash
+    :ivar EventCategory.data_governance:
+        Events that involve data governance actions
+    :ivar EventCategory.devices:
+        Events that apply to linked devices on mobile, desktop and Web
+        platforms.
+    :ivar EventCategory.domains:
+        Events that involve domain management feature: domain verification,
+        invite enforcement and account capture.
+    :ivar EventCategory.encryption:
+        Events that involve encryption.
+    :ivar EventCategory.file_operations:
+        Events that have to do with filesystem operations on files and folders:
+        copy, move, delete, etc.
+    :ivar EventCategory.file_requests:
+        Events that apply to the file requests feature.
+    :ivar EventCategory.groups:
+        Events that involve group management.
+    :ivar EventCategory.logins:
+        Events that involve users signing in to or out of Dropbox.
+    :ivar EventCategory.members:
+        Events that involve team member management.
+    :ivar EventCategory.paper:
+        Events that apply to Dropbox Paper.
+    :ivar EventCategory.passwords:
+        Events that involve using, changing or resetting passwords.
+    :ivar EventCategory.protect:
+        Events that apply to Dropbox Protect
+    :ivar EventCategory.reports:
+        Events that concern generation of admin reports, including team activity
+        and device usage.
+    :ivar EventCategory.sharing:
+        Events that apply to all types of sharing and collaboration.
+    :ivar EventCategory.showcase:
+        Events that apply to Dropbox Showcase.
+    :ivar EventCategory.signatures:
+        Events that apply to Dropbox Sign
+    :ivar EventCategory.sso:
+        Events that involve using or configuring single sign-on as well as
+        administrative policies concerning single sign-on.
+    :ivar EventCategory.team_folders:
+        Events that involve team folder management.
+    :ivar EventCategory.team_policies:
+        Events that involve a change in team-wide policies.
+    :ivar EventCategory.team_profile:
+        Events that involve a change in the team profile.
+    :ivar EventCategory.tfa:
+        Events that involve using or configuring two factor authentication as
+        well as administrative policies concerning two factor authentication.
+    :ivar EventCategory.trusted_teams:
+        Events that apply to cross-team trust establishment.
     """
 
     _catch_all = 'other'
@@ -11948,8 +12057,10 @@ class EventDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar MissingDetails EventDetails.missing_details: Hints that this event was
-        returned with missing details due to an internal error.
+    :ivar EventDetails.missing_details:
+        Hints that this event was returned with missing details due to an
+        internal error.
+    :vartype EventDetails.missing_details: MissingDetails
     """
 
     _catch_all = 'other'
@@ -30023,1524 +30134,1947 @@ class EventType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar AdminAlertingAlertStateChangedType
-        EventType.admin_alerting_alert_state_changed: (admin_alerting) Changed
-        an alert state
-    :ivar AdminAlertingChangedAlertConfigType
-        EventType.admin_alerting_changed_alert_config: (admin_alerting) Changed
-        an alert setting
-    :ivar AdminAlertingTriggeredAlertType
-        EventType.admin_alerting_triggered_alert: (admin_alerting) Triggered
-        security alert
-    :ivar RansomwareRestoreProcessCompletedType
-        EventType.ransomware_restore_process_completed: (admin_alerting)
-        Completed ransomware restore process
-    :ivar RansomwareRestoreProcessStartedType
-        EventType.ransomware_restore_process_started: (admin_alerting) Started
-        ransomware restore process
-    :ivar AppBlockedByPermissionsType EventType.app_blocked_by_permissions:
+    :ivar EventType.admin_alerting_alert_state_changed:
+        (admin_alerting) Changed an alert state
+    :vartype EventType.admin_alerting_alert_state_changed: AdminAlertingAlertStateChangedType
+    :ivar EventType.admin_alerting_changed_alert_config:
+        (admin_alerting) Changed an alert setting
+    :vartype EventType.admin_alerting_changed_alert_config: AdminAlertingChangedAlertConfigType
+    :ivar EventType.admin_alerting_triggered_alert:
+        (admin_alerting) Triggered security alert
+    :vartype EventType.admin_alerting_triggered_alert: AdminAlertingTriggeredAlertType
+    :ivar EventType.ransomware_restore_process_completed:
+        (admin_alerting) Completed ransomware restore process
+    :vartype EventType.ransomware_restore_process_completed: RansomwareRestoreProcessCompletedType
+    :ivar EventType.ransomware_restore_process_started:
+        (admin_alerting) Started ransomware restore process
+    :vartype EventType.ransomware_restore_process_started: RansomwareRestoreProcessStartedType
+    :ivar EventType.app_blocked_by_permissions:
         (apps) Failed to connect app for member
-    :ivar AppLinkTeamType EventType.app_link_team: (apps) Linked app for team
-    :ivar AppLinkUserType EventType.app_link_user: (apps) Linked app for member
-    :ivar AppUnlinkTeamType EventType.app_unlink_team: (apps) Unlinked app for
-        team
-    :ivar AppUnlinkUserType EventType.app_unlink_user: (apps) Unlinked app for
-        member
-    :ivar IntegrationConnectedType EventType.integration_connected: (apps)
-        Connected integration for member
-    :ivar IntegrationDisconnectedType EventType.integration_disconnected: (apps)
-        Disconnected integration for member
-    :ivar FileAddCommentType EventType.file_add_comment: (comments) Added file
-        comment
-    :ivar FileChangeCommentSubscriptionType
-        EventType.file_change_comment_subscription: (comments) Subscribed to or
-        unsubscribed from comment notifications for file
-    :ivar FileDeleteCommentType EventType.file_delete_comment: (comments)
-        Deleted file comment
-    :ivar FileEditCommentType EventType.file_edit_comment: (comments) Edited
-        file comment
-    :ivar FileLikeCommentType EventType.file_like_comment: (comments) Liked file
-        comment (deprecated, no longer logged)
-    :ivar FileResolveCommentType EventType.file_resolve_comment: (comments)
-        Resolved file comment
-    :ivar FileUnlikeCommentType EventType.file_unlike_comment: (comments)
-        Unliked file comment (deprecated, no longer logged)
-    :ivar FileUnresolveCommentType EventType.file_unresolve_comment: (comments)
-        Unresolved file comment
-    :ivar DashAddedCommentToStackType EventType.dash_added_comment_to_stack:
+    :vartype EventType.app_blocked_by_permissions: AppBlockedByPermissionsType
+    :ivar EventType.app_link_team:
+        (apps) Linked app for team
+    :vartype EventType.app_link_team: AppLinkTeamType
+    :ivar EventType.app_link_user:
+        (apps) Linked app for member
+    :vartype EventType.app_link_user: AppLinkUserType
+    :ivar EventType.app_unlink_team:
+        (apps) Unlinked app for team
+    :vartype EventType.app_unlink_team: AppUnlinkTeamType
+    :ivar EventType.app_unlink_user:
+        (apps) Unlinked app for member
+    :vartype EventType.app_unlink_user: AppUnlinkUserType
+    :ivar EventType.integration_connected:
+        (apps) Connected integration for member
+    :vartype EventType.integration_connected: IntegrationConnectedType
+    :ivar EventType.integration_disconnected:
+        (apps) Disconnected integration for member
+    :vartype EventType.integration_disconnected: IntegrationDisconnectedType
+    :ivar EventType.file_add_comment:
+        (comments) Added file comment
+    :vartype EventType.file_add_comment: FileAddCommentType
+    :ivar EventType.file_change_comment_subscription:
+        (comments) Subscribed to or unsubscribed from comment notifications for
+        file
+    :vartype EventType.file_change_comment_subscription: FileChangeCommentSubscriptionType
+    :ivar EventType.file_delete_comment:
+        (comments) Deleted file comment
+    :vartype EventType.file_delete_comment: FileDeleteCommentType
+    :ivar EventType.file_edit_comment:
+        (comments) Edited file comment
+    :vartype EventType.file_edit_comment: FileEditCommentType
+    :ivar EventType.file_like_comment:
+        (comments) Liked file comment (deprecated, no longer logged)
+    :vartype EventType.file_like_comment: FileLikeCommentType
+    :ivar EventType.file_resolve_comment:
+        (comments) Resolved file comment
+    :vartype EventType.file_resolve_comment: FileResolveCommentType
+    :ivar EventType.file_unlike_comment:
+        (comments) Unliked file comment (deprecated, no longer logged)
+    :vartype EventType.file_unlike_comment: FileUnlikeCommentType
+    :ivar EventType.file_unresolve_comment:
+        (comments) Unresolved file comment
+    :vartype EventType.file_unresolve_comment: FileUnresolveCommentType
+    :ivar EventType.dash_added_comment_to_stack:
         (dash) Added a comment to a stack
-    :ivar DashAddedConnectorType EventType.dash_added_connector: (dash)
-        Connected to a user connector
-    :ivar DashAddedLinkToStackType EventType.dash_added_link_to_stack: (dash)
-        Added a link to a stack
-    :ivar DashAddedTeamEmailDomainAllowlistType
-        EventType.dash_added_team_email_domain_allowlist: (dash) Admin added an
-        email domain to the team allowlist
-    :ivar DashAdminAddedOrgWideConnectorType
-        EventType.dash_admin_added_org_wide_connector: (dash) Admin added an
-        admin connector
-    :ivar DashAdminDisabledConnectorType
-        EventType.dash_admin_disabled_connector: (dash) Admin disabled a user
-        connector
-    :ivar DashAdminEnabledConnectorType EventType.dash_admin_enabled_connector:
+    :vartype EventType.dash_added_comment_to_stack: DashAddedCommentToStackType
+    :ivar EventType.dash_added_connector:
+        (dash) Connected to a user connector
+    :vartype EventType.dash_added_connector: DashAddedConnectorType
+    :ivar EventType.dash_added_link_to_stack:
+        (dash) Added a link to a stack
+    :vartype EventType.dash_added_link_to_stack: DashAddedLinkToStackType
+    :ivar EventType.dash_added_team_email_domain_allowlist:
+        (dash) Admin added an email domain to the team allowlist
+    :vartype EventType.dash_added_team_email_domain_allowlist: DashAddedTeamEmailDomainAllowlistType
+    :ivar EventType.dash_admin_added_org_wide_connector:
+        (dash) Admin added an admin connector
+    :vartype EventType.dash_admin_added_org_wide_connector: DashAdminAddedOrgWideConnectorType
+    :ivar EventType.dash_admin_disabled_connector:
+        (dash) Admin disabled a user connector
+    :vartype EventType.dash_admin_disabled_connector: DashAdminDisabledConnectorType
+    :ivar EventType.dash_admin_enabled_connector:
         (dash) Admin enabled a user connector
-    :ivar DashAdminRemovedOrgWideConnectorType
-        EventType.dash_admin_removed_org_wide_connector: (dash) Admin removed an
-        admin connector
-    :ivar DashArchivedStackType EventType.dash_archived_stack: (dash) Archived a
-        stack
-    :ivar DashChangedAudienceOfSharedLinkToStackType
-        EventType.dash_changed_audience_of_shared_link_to_stack: (dash) Changed
-        the audience of a shared link to a stack
-    :ivar DashClonedStackType EventType.dash_cloned_stack: (dash) Cloned stack
-    :ivar DashConnectorToolsCallType EventType.dash_connector_tools_call: (dash)
-        Called a tool on a connector
-    :ivar DashCreatedStackType EventType.dash_created_stack: (dash) Created a
-        stack
-    :ivar DashDeletedCommentFromStackType
-        EventType.dash_deleted_comment_from_stack: (dash) Deleted a comment from
-        a stack
-    :ivar DashDeletedStackType EventType.dash_deleted_stack: (dash) Deleted a
-        stack
-    :ivar DashEditedCommentInStackType EventType.dash_edited_comment_in_stack:
+    :vartype EventType.dash_admin_enabled_connector: DashAdminEnabledConnectorType
+    :ivar EventType.dash_admin_removed_org_wide_connector:
+        (dash) Admin removed an admin connector
+    :vartype EventType.dash_admin_removed_org_wide_connector: DashAdminRemovedOrgWideConnectorType
+    :ivar EventType.dash_archived_stack:
+        (dash) Archived a stack
+    :vartype EventType.dash_archived_stack: DashArchivedStackType
+    :ivar EventType.dash_changed_audience_of_shared_link_to_stack:
+        (dash) Changed the audience of a shared link to a stack
+    :vartype EventType.dash_changed_audience_of_shared_link_to_stack: DashChangedAudienceOfSharedLinkToStackType
+    :ivar EventType.dash_cloned_stack:
+        (dash) Cloned stack
+    :vartype EventType.dash_cloned_stack: DashClonedStackType
+    :ivar EventType.dash_connector_tools_call:
+        (dash) Called a tool on a connector
+    :vartype EventType.dash_connector_tools_call: DashConnectorToolsCallType
+    :ivar EventType.dash_created_stack:
+        (dash) Created a stack
+    :vartype EventType.dash_created_stack: DashCreatedStackType
+    :ivar EventType.dash_deleted_comment_from_stack:
+        (dash) Deleted a comment from a stack
+    :vartype EventType.dash_deleted_comment_from_stack: DashDeletedCommentFromStackType
+    :ivar EventType.dash_deleted_stack:
+        (dash) Deleted a stack
+    :vartype EventType.dash_deleted_stack: DashDeletedStackType
+    :ivar EventType.dash_edited_comment_in_stack:
         (dash) Edited a comment in a stack
-    :ivar DashExternalUserOpenedStackType
-        EventType.dash_external_user_opened_stack: (dash) External user opened a
-        stack
-    :ivar DashFirstLaunchedDesktopType EventType.dash_first_launched_desktop:
+    :vartype EventType.dash_edited_comment_in_stack: DashEditedCommentInStackType
+    :ivar EventType.dash_external_user_opened_stack:
+        (dash) External user opened a stack
+    :vartype EventType.dash_external_user_opened_stack: DashExternalUserOpenedStackType
+    :ivar EventType.dash_first_launched_desktop:
         (dash) Opened the desktop app for the first time
-    :ivar DashFirstLaunchedExtensionType
-        EventType.dash_first_launched_extension: (dash) Opened the extension for
-        the first time
-    :ivar DashFirstLaunchedWebStartPageType
-        EventType.dash_first_launched_web_start_page: (dash) Opened the web
-        Start Page for the first time
-    :ivar DashOpenedSharedLinkToStackType
-        EventType.dash_opened_shared_link_to_stack: (dash) Checked access
-        permissions to a stack
-    :ivar DashOpenedStackType EventType.dash_opened_stack: (dash) Opened a stack
-    :ivar DashPreviewOptOutStatusChangedType
-        EventType.dash_preview_opt_out_status_changed: (dash) Changed the
-        preview opt-out status
-    :ivar DashRemovedConnectorType EventType.dash_removed_connector: (dash)
-        Disconnected a user connector
-    :ivar DashRemovedLinkFromStackType EventType.dash_removed_link_from_stack:
+    :vartype EventType.dash_first_launched_desktop: DashFirstLaunchedDesktopType
+    :ivar EventType.dash_first_launched_extension:
+        (dash) Opened the extension for the first time
+    :vartype EventType.dash_first_launched_extension: DashFirstLaunchedExtensionType
+    :ivar EventType.dash_first_launched_web_start_page:
+        (dash) Opened the web Start Page for the first time
+    :vartype EventType.dash_first_launched_web_start_page: DashFirstLaunchedWebStartPageType
+    :ivar EventType.dash_opened_shared_link_to_stack:
+        (dash) Checked access permissions to a stack
+    :vartype EventType.dash_opened_shared_link_to_stack: DashOpenedSharedLinkToStackType
+    :ivar EventType.dash_opened_stack:
+        (dash) Opened a stack
+    :vartype EventType.dash_opened_stack: DashOpenedStackType
+    :ivar EventType.dash_preview_opt_out_status_changed:
+        (dash) Changed the preview opt-out status
+    :vartype EventType.dash_preview_opt_out_status_changed: DashPreviewOptOutStatusChangedType
+    :ivar EventType.dash_removed_connector:
+        (dash) Disconnected a user connector
+    :vartype EventType.dash_removed_connector: DashRemovedConnectorType
+    :ivar EventType.dash_removed_link_from_stack:
         (dash) Removed a link from a stack
-    :ivar DashRemovedSharedLinkToStackType
-        EventType.dash_removed_shared_link_to_stack: (dash) Removed a shared
-        link to a stack
-    :ivar DashRemovedTeamEmailDomainAllowlistType
-        EventType.dash_removed_team_email_domain_allowlist: (dash) Admin removed
-        an email domain from the team allowlist
-    :ivar DashRenamedStackType EventType.dash_renamed_stack: (dash) Renamed a
-        stack
-    :ivar DashSharedLinkToStackType EventType.dash_shared_link_to_stack: (dash)
-        Shared a link to a stack
-    :ivar DashUnarchivedStackType EventType.dash_unarchived_stack: (dash)
-        Unarchived a stack
-    :ivar DashViewedCompanyStackType EventType.dash_viewed_company_stack: (dash)
-        Member viewed a company stack
-    :ivar DashViewedExternalAiActivityReportType
-        EventType.dash_viewed_external_ai_activity_report: (dash) Admin viewed
-        the external AI activity report
-    :ivar GovernancePolicyAddFoldersType
-        EventType.governance_policy_add_folders: (data_governance) Added folders
-        to policy
-    :ivar GovernancePolicyAddFolderFailedType
-        EventType.governance_policy_add_folder_failed: (data_governance)
-        Couldn't add a folder to a policy
-    :ivar GovernancePolicyContentDisposedType
-        EventType.governance_policy_content_disposed: (data_governance) Content
-        disposed
-    :ivar GovernancePolicyCreateType EventType.governance_policy_create:
+    :vartype EventType.dash_removed_link_from_stack: DashRemovedLinkFromStackType
+    :ivar EventType.dash_removed_shared_link_to_stack:
+        (dash) Removed a shared link to a stack
+    :vartype EventType.dash_removed_shared_link_to_stack: DashRemovedSharedLinkToStackType
+    :ivar EventType.dash_removed_team_email_domain_allowlist:
+        (dash) Admin removed an email domain from the team allowlist
+    :vartype EventType.dash_removed_team_email_domain_allowlist: DashRemovedTeamEmailDomainAllowlistType
+    :ivar EventType.dash_renamed_stack:
+        (dash) Renamed a stack
+    :vartype EventType.dash_renamed_stack: DashRenamedStackType
+    :ivar EventType.dash_shared_link_to_stack:
+        (dash) Shared a link to a stack
+    :vartype EventType.dash_shared_link_to_stack: DashSharedLinkToStackType
+    :ivar EventType.dash_unarchived_stack:
+        (dash) Unarchived a stack
+    :vartype EventType.dash_unarchived_stack: DashUnarchivedStackType
+    :ivar EventType.dash_viewed_company_stack:
+        (dash) Member viewed a company stack
+    :vartype EventType.dash_viewed_company_stack: DashViewedCompanyStackType
+    :ivar EventType.dash_viewed_external_ai_activity_report:
+        (dash) Admin viewed the external AI activity report
+    :vartype EventType.dash_viewed_external_ai_activity_report: DashViewedExternalAiActivityReportType
+    :ivar EventType.governance_policy_add_folders:
+        (data_governance) Added folders to policy
+    :vartype EventType.governance_policy_add_folders: GovernancePolicyAddFoldersType
+    :ivar EventType.governance_policy_add_folder_failed:
+        (data_governance) Couldn't add a folder to a policy
+    :vartype EventType.governance_policy_add_folder_failed: GovernancePolicyAddFolderFailedType
+    :ivar EventType.governance_policy_content_disposed:
+        (data_governance) Content disposed
+    :vartype EventType.governance_policy_content_disposed: GovernancePolicyContentDisposedType
+    :ivar EventType.governance_policy_create:
         (data_governance) Activated a new policy
-    :ivar GovernancePolicyDeleteType EventType.governance_policy_delete:
+    :vartype EventType.governance_policy_create: GovernancePolicyCreateType
+    :ivar EventType.governance_policy_delete:
         (data_governance) Deleted a policy
-    :ivar GovernancePolicyEditDetailsType
-        EventType.governance_policy_edit_details: (data_governance) Edited
-        policy
-    :ivar GovernancePolicyEditDurationType
-        EventType.governance_policy_edit_duration: (data_governance) Changed
-        policy duration
-    :ivar GovernancePolicyExportCreatedType
-        EventType.governance_policy_export_created: (data_governance) Created a
-        policy download
-    :ivar GovernancePolicyExportRemovedType
-        EventType.governance_policy_export_removed: (data_governance) Removed a
-        policy download
-    :ivar GovernancePolicyRemoveFoldersType
-        EventType.governance_policy_remove_folders: (data_governance) Removed
-        folders from policy
-    :ivar GovernancePolicyReportCreatedType
-        EventType.governance_policy_report_created: (data_governance) Created a
-        summary report for a policy
-    :ivar GovernancePolicyZipPartDownloadedType
-        EventType.governance_policy_zip_part_downloaded: (data_governance)
-        Downloaded content from a policy
-    :ivar LegalHoldsActivateAHoldType EventType.legal_holds_activate_a_hold:
+    :vartype EventType.governance_policy_delete: GovernancePolicyDeleteType
+    :ivar EventType.governance_policy_edit_details:
+        (data_governance) Edited policy
+    :vartype EventType.governance_policy_edit_details: GovernancePolicyEditDetailsType
+    :ivar EventType.governance_policy_edit_duration:
+        (data_governance) Changed policy duration
+    :vartype EventType.governance_policy_edit_duration: GovernancePolicyEditDurationType
+    :ivar EventType.governance_policy_export_created:
+        (data_governance) Created a policy download
+    :vartype EventType.governance_policy_export_created: GovernancePolicyExportCreatedType
+    :ivar EventType.governance_policy_export_removed:
+        (data_governance) Removed a policy download
+    :vartype EventType.governance_policy_export_removed: GovernancePolicyExportRemovedType
+    :ivar EventType.governance_policy_remove_folders:
+        (data_governance) Removed folders from policy
+    :vartype EventType.governance_policy_remove_folders: GovernancePolicyRemoveFoldersType
+    :ivar EventType.governance_policy_report_created:
+        (data_governance) Created a summary report for a policy
+    :vartype EventType.governance_policy_report_created: GovernancePolicyReportCreatedType
+    :ivar EventType.governance_policy_zip_part_downloaded:
+        (data_governance) Downloaded content from a policy
+    :vartype EventType.governance_policy_zip_part_downloaded: GovernancePolicyZipPartDownloadedType
+    :ivar EventType.legal_holds_activate_a_hold:
         (data_governance) Activated a hold
-    :ivar LegalHoldsAddMembersType EventType.legal_holds_add_members:
+    :vartype EventType.legal_holds_activate_a_hold: LegalHoldsActivateAHoldType
+    :ivar EventType.legal_holds_add_members:
         (data_governance) Added members to a hold
-    :ivar LegalHoldsChangeHoldDetailsType
-        EventType.legal_holds_change_hold_details: (data_governance) Edited
-        details for a hold
-    :ivar LegalHoldsChangeHoldNameType EventType.legal_holds_change_hold_name:
+    :vartype EventType.legal_holds_add_members: LegalHoldsAddMembersType
+    :ivar EventType.legal_holds_change_hold_details:
+        (data_governance) Edited details for a hold
+    :vartype EventType.legal_holds_change_hold_details: LegalHoldsChangeHoldDetailsType
+    :ivar EventType.legal_holds_change_hold_name:
         (data_governance) Renamed a hold
-    :ivar LegalHoldsExportAHoldType EventType.legal_holds_export_a_hold:
+    :vartype EventType.legal_holds_change_hold_name: LegalHoldsChangeHoldNameType
+    :ivar EventType.legal_holds_export_a_hold:
         (data_governance) Exported hold
-    :ivar LegalHoldsExportCancelledType EventType.legal_holds_export_cancelled:
+    :vartype EventType.legal_holds_export_a_hold: LegalHoldsExportAHoldType
+    :ivar EventType.legal_holds_export_cancelled:
         (data_governance) Canceled export for a hold
-    :ivar LegalHoldsExportDownloadedType
-        EventType.legal_holds_export_downloaded: (data_governance) Downloaded
-        export for a hold
-    :ivar LegalHoldsExportRemovedType EventType.legal_holds_export_removed:
+    :vartype EventType.legal_holds_export_cancelled: LegalHoldsExportCancelledType
+    :ivar EventType.legal_holds_export_downloaded:
+        (data_governance) Downloaded export for a hold
+    :vartype EventType.legal_holds_export_downloaded: LegalHoldsExportDownloadedType
+    :ivar EventType.legal_holds_export_removed:
         (data_governance) Removed export for a hold
-    :ivar LegalHoldsReleaseAHoldType EventType.legal_holds_release_a_hold:
+    :vartype EventType.legal_holds_export_removed: LegalHoldsExportRemovedType
+    :ivar EventType.legal_holds_release_a_hold:
         (data_governance) Released a hold
-    :ivar LegalHoldsRemoveMembersType EventType.legal_holds_remove_members:
+    :vartype EventType.legal_holds_release_a_hold: LegalHoldsReleaseAHoldType
+    :ivar EventType.legal_holds_remove_members:
         (data_governance) Removed members from a hold
-    :ivar LegalHoldsReportAHoldType EventType.legal_holds_report_a_hold:
+    :vartype EventType.legal_holds_remove_members: LegalHoldsRemoveMembersType
+    :ivar EventType.legal_holds_report_a_hold:
         (data_governance) Created a summary report for a hold
-    :ivar DeviceChangeIpDesktopType EventType.device_change_ip_desktop:
+    :vartype EventType.legal_holds_report_a_hold: LegalHoldsReportAHoldType
+    :ivar EventType.device_change_ip_desktop:
         (devices) Changed IP address associated with active desktop session
-    :ivar DeviceChangeIpMobileType EventType.device_change_ip_mobile: (devices)
-        Changed IP address associated with active mobile session
-    :ivar DeviceChangeIpWebType EventType.device_change_ip_web: (devices)
-        Changed IP address associated with active web session
-    :ivar DeviceDeleteOnUnlinkFailType EventType.device_delete_on_unlink_fail:
+    :vartype EventType.device_change_ip_desktop: DeviceChangeIpDesktopType
+    :ivar EventType.device_change_ip_mobile:
+        (devices) Changed IP address associated with active mobile session
+    :vartype EventType.device_change_ip_mobile: DeviceChangeIpMobileType
+    :ivar EventType.device_change_ip_web:
+        (devices) Changed IP address associated with active web session
+    :vartype EventType.device_change_ip_web: DeviceChangeIpWebType
+    :ivar EventType.device_delete_on_unlink_fail:
         (devices) Failed to delete all files from unlinked device
-    :ivar DeviceDeleteOnUnlinkSuccessType
-        EventType.device_delete_on_unlink_success: (devices) Deleted all files
-        from unlinked device
-    :ivar DeviceLinkFailType EventType.device_link_fail: (devices) Failed to
-        link device
-    :ivar DeviceLinkSuccessType EventType.device_link_success: (devices) Linked
-        device
-    :ivar DeviceManagementDisabledType EventType.device_management_disabled:
+    :vartype EventType.device_delete_on_unlink_fail: DeviceDeleteOnUnlinkFailType
+    :ivar EventType.device_delete_on_unlink_success:
+        (devices) Deleted all files from unlinked device
+    :vartype EventType.device_delete_on_unlink_success: DeviceDeleteOnUnlinkSuccessType
+    :ivar EventType.device_link_fail:
+        (devices) Failed to link device
+    :vartype EventType.device_link_fail: DeviceLinkFailType
+    :ivar EventType.device_link_success:
+        (devices) Linked device
+    :vartype EventType.device_link_success: DeviceLinkSuccessType
+    :ivar EventType.device_management_disabled:
         (devices) Disabled device management (deprecated, no longer logged)
-    :ivar DeviceManagementEnabledType EventType.device_management_enabled:
+    :vartype EventType.device_management_disabled: DeviceManagementDisabledType
+    :ivar EventType.device_management_enabled:
         (devices) Enabled device management (deprecated, no longer logged)
-    :ivar DeviceSyncBackupStatusChangedType
-        EventType.device_sync_backup_status_changed: (devices) Enabled/disabled
-        backup for computer
-    :ivar DeviceUnlinkType EventType.device_unlink: (devices) Disconnected
-        device
-    :ivar DropboxPasswordsExportedType EventType.dropbox_passwords_exported:
+    :vartype EventType.device_management_enabled: DeviceManagementEnabledType
+    :ivar EventType.device_sync_backup_status_changed:
+        (devices) Enabled/disabled backup for computer
+    :vartype EventType.device_sync_backup_status_changed: DeviceSyncBackupStatusChangedType
+    :ivar EventType.device_unlink:
+        (devices) Disconnected device
+    :vartype EventType.device_unlink: DeviceUnlinkType
+    :ivar EventType.dropbox_passwords_exported:
         (devices) Exported passwords
-    :ivar DropboxPasswordsNewDeviceEnrolledType
-        EventType.dropbox_passwords_new_device_enrolled: (devices) Enrolled new
-        Dropbox Passwords device
-    :ivar EmmRefreshAuthTokenType EventType.emm_refresh_auth_token: (devices)
-        Refreshed auth token used for setting up EMM
-    :ivar ExternalDriveBackupEligibilityStatusCheckedType
-        EventType.external_drive_backup_eligibility_status_checked: (devices)
-        Checked external drive backup eligibility status
-    :ivar ExternalDriveBackupStatusChangedType
-        EventType.external_drive_backup_status_changed: (devices) Modified
-        external drive backup
-    :ivar AccountCaptureChangeAvailabilityType
-        EventType.account_capture_change_availability: (domains) Granted/revoked
-        option to enable account capture on team domains
-    :ivar AccountCaptureMigrateAccountType
-        EventType.account_capture_migrate_account: (domains) Account-captured
-        user migrated account to team
-    :ivar AccountCaptureNotificationEmailsSentType
-        EventType.account_capture_notification_emails_sent: (domains) Sent
-        account capture email to all unmanaged members
-    :ivar AccountCaptureRelinquishAccountType
-        EventType.account_capture_relinquish_account: (domains) Account-captured
-        user changed account email to personal email
-    :ivar DisabledDomainInvitesType EventType.disabled_domain_invites: (domains)
-        Disabled domain invites (deprecated, no longer logged)
-    :ivar DomainInvitesApproveRequestToJoinTeamType
-        EventType.domain_invites_approve_request_to_join_team: (domains)
-        Approved user's request to join team
-    :ivar DomainInvitesDeclineRequestToJoinTeamType
-        EventType.domain_invites_decline_request_to_join_team: (domains)
-        Declined user's request to join team
-    :ivar DomainInvitesEmailExistingUsersType
-        EventType.domain_invites_email_existing_users: (domains) Sent domain
-        invites to existing domain accounts (deprecated, no longer logged)
-    :ivar DomainInvitesRequestToJoinTeamType
-        EventType.domain_invites_request_to_join_team: (domains) Requested to
-        join team
-    :ivar DomainInvitesSetInviteNewUserPrefToNoType
-        EventType.domain_invites_set_invite_new_user_pref_to_no: (domains)
-        Disabled "Automatically invite new users" (deprecated, no longer logged)
-    :ivar DomainInvitesSetInviteNewUserPrefToYesType
-        EventType.domain_invites_set_invite_new_user_pref_to_yes: (domains)
-        Enabled "Automatically invite new users" (deprecated, no longer logged)
-    :ivar DomainVerificationAddDomainFailType
-        EventType.domain_verification_add_domain_fail: (domains) Failed to
-        verify team domain
-    :ivar DomainVerificationAddDomainSuccessType
-        EventType.domain_verification_add_domain_success: (domains) Verified
-        team domain
-    :ivar DomainVerificationRemoveDomainType
-        EventType.domain_verification_remove_domain: (domains) Removed domain
-        from list of verified team domains
-    :ivar EnabledDomainInvitesType EventType.enabled_domain_invites: (domains)
-        Enabled domain invites (deprecated, no longer logged)
-    :ivar EncryptedFolderCancelTeamKeyRotationType
-        EventType.encrypted_folder_cancel_team_key_rotation: (encryption)
-        Canceled team key rotation
-    :ivar EncryptedFolderEnrollBackupKeyType
-        EventType.encrypted_folder_enroll_backup_key: (encryption) Added
-        recovery key
-    :ivar EncryptedFolderEnrollClientType
-        EventType.encrypted_folder_enroll_client: (encryption) Enrolled device
-    :ivar EncryptedFolderEnrollTeamType EventType.encrypted_folder_enroll_team:
+    :vartype EventType.dropbox_passwords_exported: DropboxPasswordsExportedType
+    :ivar EventType.dropbox_passwords_new_device_enrolled:
+        (devices) Enrolled new Dropbox Passwords device
+    :vartype EventType.dropbox_passwords_new_device_enrolled: DropboxPasswordsNewDeviceEnrolledType
+    :ivar EventType.emm_refresh_auth_token:
+        (devices) Refreshed auth token used for setting up EMM
+    :vartype EventType.emm_refresh_auth_token: EmmRefreshAuthTokenType
+    :ivar EventType.external_drive_backup_eligibility_status_checked:
+        (devices) Checked external drive backup eligibility status
+    :vartype EventType.external_drive_backup_eligibility_status_checked: ExternalDriveBackupEligibilityStatusCheckedType
+    :ivar EventType.external_drive_backup_status_changed:
+        (devices) Modified external drive backup
+    :vartype EventType.external_drive_backup_status_changed: ExternalDriveBackupStatusChangedType
+    :ivar EventType.account_capture_change_availability:
+        (domains) Granted/revoked option to enable account capture on team
+        domains
+    :vartype EventType.account_capture_change_availability: AccountCaptureChangeAvailabilityType
+    :ivar EventType.account_capture_migrate_account:
+        (domains) Account-captured user migrated account to team
+    :vartype EventType.account_capture_migrate_account: AccountCaptureMigrateAccountType
+    :ivar EventType.account_capture_notification_emails_sent:
+        (domains) Sent account capture email to all unmanaged members
+    :vartype EventType.account_capture_notification_emails_sent: AccountCaptureNotificationEmailsSentType
+    :ivar EventType.account_capture_relinquish_account:
+        (domains) Account-captured user changed account email to personal email
+    :vartype EventType.account_capture_relinquish_account: AccountCaptureRelinquishAccountType
+    :ivar EventType.disabled_domain_invites:
+        (domains) Disabled domain invites (deprecated, no longer logged)
+    :vartype EventType.disabled_domain_invites: DisabledDomainInvitesType
+    :ivar EventType.domain_invites_approve_request_to_join_team:
+        (domains) Approved user's request to join team
+    :vartype EventType.domain_invites_approve_request_to_join_team: DomainInvitesApproveRequestToJoinTeamType
+    :ivar EventType.domain_invites_decline_request_to_join_team:
+        (domains) Declined user's request to join team
+    :vartype EventType.domain_invites_decline_request_to_join_team: DomainInvitesDeclineRequestToJoinTeamType
+    :ivar EventType.domain_invites_email_existing_users:
+        (domains) Sent domain invites to existing domain accounts (deprecated,
+        no longer logged)
+    :vartype EventType.domain_invites_email_existing_users: DomainInvitesEmailExistingUsersType
+    :ivar EventType.domain_invites_request_to_join_team:
+        (domains) Requested to join team
+    :vartype EventType.domain_invites_request_to_join_team: DomainInvitesRequestToJoinTeamType
+    :ivar EventType.domain_invites_set_invite_new_user_pref_to_no:
+        (domains) Disabled "Automatically invite new users" (deprecated, no
+        longer logged)
+    :vartype EventType.domain_invites_set_invite_new_user_pref_to_no: DomainInvitesSetInviteNewUserPrefToNoType
+    :ivar EventType.domain_invites_set_invite_new_user_pref_to_yes:
+        (domains) Enabled "Automatically invite new users" (deprecated, no
+        longer logged)
+    :vartype EventType.domain_invites_set_invite_new_user_pref_to_yes: DomainInvitesSetInviteNewUserPrefToYesType
+    :ivar EventType.domain_verification_add_domain_fail:
+        (domains) Failed to verify team domain
+    :vartype EventType.domain_verification_add_domain_fail: DomainVerificationAddDomainFailType
+    :ivar EventType.domain_verification_add_domain_success:
+        (domains) Verified team domain
+    :vartype EventType.domain_verification_add_domain_success: DomainVerificationAddDomainSuccessType
+    :ivar EventType.domain_verification_remove_domain:
+        (domains) Removed domain from list of verified team domains
+    :vartype EventType.domain_verification_remove_domain: DomainVerificationRemoveDomainType
+    :ivar EventType.enabled_domain_invites:
+        (domains) Enabled domain invites (deprecated, no longer logged)
+    :vartype EventType.enabled_domain_invites: EnabledDomainInvitesType
+    :ivar EventType.encrypted_folder_cancel_team_key_rotation:
+        (encryption) Canceled team key rotation
+    :vartype EventType.encrypted_folder_cancel_team_key_rotation: EncryptedFolderCancelTeamKeyRotationType
+    :ivar EventType.encrypted_folder_enroll_backup_key:
+        (encryption) Added recovery key
+    :vartype EventType.encrypted_folder_enroll_backup_key: EncryptedFolderEnrollBackupKeyType
+    :ivar EventType.encrypted_folder_enroll_client:
+        (encryption) Enrolled device
+    :vartype EventType.encrypted_folder_enroll_client: EncryptedFolderEnrollClientType
+    :ivar EventType.encrypted_folder_enroll_team:
         (encryption) Activated team folder encryption
-    :ivar EncryptedFolderFinishTeamUnenrollmentType
-        EventType.encrypted_folder_finish_team_unenrollment: (encryption)
-        Deactivated team folder encryption
-    :ivar EncryptedFolderInitTeamKeyRotationType
-        EventType.encrypted_folder_init_team_key_rotation: (encryption)
-        Initiated team key rotation
-    :ivar EncryptedFolderInitTeamUnenrollmentType
-        EventType.encrypted_folder_init_team_unenrollment: (encryption)
-        Initiated deactivation of team folder encryption
-    :ivar EncryptedFolderRemoveBackupKeyType
-        EventType.encrypted_folder_remove_backup_key: (encryption) Removed
-        recovery key
-    :ivar EncryptedFolderRotateTeamKeyType
-        EventType.encrypted_folder_rotate_team_key: (encryption) Rotated team
-        key
-    :ivar EncryptedFolderUnenrollClientType
-        EventType.encrypted_folder_unenroll_client: (encryption) Unenrolled
-        device
-    :ivar TeamEncryptionKeyActivateKeyType
-        EventType.team_encryption_key_activate_key: (encryption) Activated team
-        encryption key
-    :ivar TeamEncryptionKeyCancelKeyDeletionType
-        EventType.team_encryption_key_cancel_key_deletion: (encryption) Canceled
-        team encryption key deletion
-    :ivar TeamEncryptionKeyCreateKeyType
-        EventType.team_encryption_key_create_key: (encryption) Created team
-        encryption key
-    :ivar TeamEncryptionKeyDeactivateKeyType
-        EventType.team_encryption_key_deactivate_key: (encryption) Deactivated
-        team encryption key
-    :ivar TeamEncryptionKeyDeleteKeyType
-        EventType.team_encryption_key_delete_key: (encryption) Deleted team
-        encryption key
-    :ivar TeamEncryptionKeyDisableKeyType
-        EventType.team_encryption_key_disable_key: (encryption) Disabled team
-        encryption key
-    :ivar TeamEncryptionKeyEnableKeyType
-        EventType.team_encryption_key_enable_key: (encryption) Enabled team
-        encryption key
-    :ivar TeamEncryptionKeyRotateKeyType
-        EventType.team_encryption_key_rotate_key: (encryption) Rotated team
-        encryption key (deprecated, no longer logged)
-    :ivar TeamEncryptionKeyScheduleKeyDeletionType
-        EventType.team_encryption_key_schedule_key_deletion: (encryption)
-        Scheduled encryption key deletion
-    :ivar ApplyNamingConventionType EventType.apply_naming_convention:
+    :vartype EventType.encrypted_folder_enroll_team: EncryptedFolderEnrollTeamType
+    :ivar EventType.encrypted_folder_finish_team_unenrollment:
+        (encryption) Deactivated team folder encryption
+    :vartype EventType.encrypted_folder_finish_team_unenrollment: EncryptedFolderFinishTeamUnenrollmentType
+    :ivar EventType.encrypted_folder_init_team_key_rotation:
+        (encryption) Initiated team key rotation
+    :vartype EventType.encrypted_folder_init_team_key_rotation: EncryptedFolderInitTeamKeyRotationType
+    :ivar EventType.encrypted_folder_init_team_unenrollment:
+        (encryption) Initiated deactivation of team folder encryption
+    :vartype EventType.encrypted_folder_init_team_unenrollment: EncryptedFolderInitTeamUnenrollmentType
+    :ivar EventType.encrypted_folder_remove_backup_key:
+        (encryption) Removed recovery key
+    :vartype EventType.encrypted_folder_remove_backup_key: EncryptedFolderRemoveBackupKeyType
+    :ivar EventType.encrypted_folder_rotate_team_key:
+        (encryption) Rotated team key
+    :vartype EventType.encrypted_folder_rotate_team_key: EncryptedFolderRotateTeamKeyType
+    :ivar EventType.encrypted_folder_unenroll_client:
+        (encryption) Unenrolled device
+    :vartype EventType.encrypted_folder_unenroll_client: EncryptedFolderUnenrollClientType
+    :ivar EventType.team_encryption_key_activate_key:
+        (encryption) Activated team encryption key
+    :vartype EventType.team_encryption_key_activate_key: TeamEncryptionKeyActivateKeyType
+    :ivar EventType.team_encryption_key_cancel_key_deletion:
+        (encryption) Canceled team encryption key deletion
+    :vartype EventType.team_encryption_key_cancel_key_deletion: TeamEncryptionKeyCancelKeyDeletionType
+    :ivar EventType.team_encryption_key_create_key:
+        (encryption) Created team encryption key
+    :vartype EventType.team_encryption_key_create_key: TeamEncryptionKeyCreateKeyType
+    :ivar EventType.team_encryption_key_deactivate_key:
+        (encryption) Deactivated team encryption key
+    :vartype EventType.team_encryption_key_deactivate_key: TeamEncryptionKeyDeactivateKeyType
+    :ivar EventType.team_encryption_key_delete_key:
+        (encryption) Deleted team encryption key
+    :vartype EventType.team_encryption_key_delete_key: TeamEncryptionKeyDeleteKeyType
+    :ivar EventType.team_encryption_key_disable_key:
+        (encryption) Disabled team encryption key
+    :vartype EventType.team_encryption_key_disable_key: TeamEncryptionKeyDisableKeyType
+    :ivar EventType.team_encryption_key_enable_key:
+        (encryption) Enabled team encryption key
+    :vartype EventType.team_encryption_key_enable_key: TeamEncryptionKeyEnableKeyType
+    :ivar EventType.team_encryption_key_rotate_key:
+        (encryption) Rotated team encryption key (deprecated, no longer logged)
+    :vartype EventType.team_encryption_key_rotate_key: TeamEncryptionKeyRotateKeyType
+    :ivar EventType.team_encryption_key_schedule_key_deletion:
+        (encryption) Scheduled encryption key deletion
+    :vartype EventType.team_encryption_key_schedule_key_deletion: TeamEncryptionKeyScheduleKeyDeletionType
+    :ivar EventType.apply_naming_convention:
         (file_operations) Applied naming convention
-    :ivar CreateFolderType EventType.create_folder: (file_operations) Created
-        folders (deprecated, no longer logged)
-    :ivar FileAddType EventType.file_add: (file_operations) Added files and/or
-        folders
-    :ivar FileAddFromAutomationType EventType.file_add_from_automation:
+    :vartype EventType.apply_naming_convention: ApplyNamingConventionType
+    :ivar EventType.create_folder:
+        (file_operations) Created folders (deprecated, no longer logged)
+    :vartype EventType.create_folder: CreateFolderType
+    :ivar EventType.file_add:
+        (file_operations) Added files and/or folders
+    :vartype EventType.file_add: FileAddType
+    :ivar EventType.file_add_from_automation:
         (file_operations) Added files and/or folders from automation
-    :ivar FileCopyType EventType.file_copy: (file_operations) Copied files
-        and/or folders
-    :ivar FileDeleteType EventType.file_delete: (file_operations) Deleted files
-        and/or folders
-    :ivar FileDownloadType EventType.file_download: (file_operations) Downloaded
-        files and/or folders
-    :ivar FileEditType EventType.file_edit: (file_operations) Edited files
-    :ivar FileGetCopyReferenceType EventType.file_get_copy_reference:
+    :vartype EventType.file_add_from_automation: FileAddFromAutomationType
+    :ivar EventType.file_copy:
+        (file_operations) Copied files and/or folders
+    :vartype EventType.file_copy: FileCopyType
+    :ivar EventType.file_delete:
+        (file_operations) Deleted files and/or folders
+    :vartype EventType.file_delete: FileDeleteType
+    :ivar EventType.file_download:
+        (file_operations) Downloaded files and/or folders
+    :vartype EventType.file_download: FileDownloadType
+    :ivar EventType.file_edit:
+        (file_operations) Edited files
+    :vartype EventType.file_edit: FileEditType
+    :ivar EventType.file_get_copy_reference:
         (file_operations) Created copy reference to file/folder
-    :ivar FileLockingLockStatusChangedType
-        EventType.file_locking_lock_status_changed: (file_operations)
-        Locked/unlocked editing for a file
-    :ivar FileMoveType EventType.file_move: (file_operations) Moved files and/or
-        folders
-    :ivar FilePermanentlyDeleteType EventType.file_permanently_delete:
+    :vartype EventType.file_get_copy_reference: FileGetCopyReferenceType
+    :ivar EventType.file_locking_lock_status_changed:
+        (file_operations) Locked/unlocked editing for a file
+    :vartype EventType.file_locking_lock_status_changed: FileLockingLockStatusChangedType
+    :ivar EventType.file_move:
+        (file_operations) Moved files and/or folders
+    :vartype EventType.file_move: FileMoveType
+    :ivar EventType.file_permanently_delete:
         (file_operations) Permanently deleted files and/or folders
-    :ivar FilePreviewType EventType.file_preview: (file_operations) Previewed
-        files and/or folders
-    :ivar FileRenameType EventType.file_rename: (file_operations) Renamed files
-        and/or folders
-    :ivar FileRestoreType EventType.file_restore: (file_operations) Restored
-        deleted files and/or folders
-    :ivar FileRevertType EventType.file_revert: (file_operations) Reverted files
-        to previous version
-    :ivar FileRollbackChangesType EventType.file_rollback_changes:
+    :vartype EventType.file_permanently_delete: FilePermanentlyDeleteType
+    :ivar EventType.file_preview:
+        (file_operations) Previewed files and/or folders
+    :vartype EventType.file_preview: FilePreviewType
+    :ivar EventType.file_rename:
+        (file_operations) Renamed files and/or folders
+    :vartype EventType.file_rename: FileRenameType
+    :ivar EventType.file_restore:
+        (file_operations) Restored deleted files and/or folders
+    :vartype EventType.file_restore: FileRestoreType
+    :ivar EventType.file_revert:
+        (file_operations) Reverted files to previous version
+    :vartype EventType.file_revert: FileRevertType
+    :ivar EventType.file_rollback_changes:
         (file_operations) Rolled back file actions
-    :ivar FileSaveCopyReferenceType EventType.file_save_copy_reference:
+    :vartype EventType.file_rollback_changes: FileRollbackChangesType
+    :ivar EventType.file_save_copy_reference:
         (file_operations) Saved file/folder using copy reference
-    :ivar FolderOverviewDescriptionChangedType
-        EventType.folder_overview_description_changed: (file_operations) Updated
-        folder overview
-    :ivar FolderOverviewItemPinnedType EventType.folder_overview_item_pinned:
+    :vartype EventType.file_save_copy_reference: FileSaveCopyReferenceType
+    :ivar EventType.folder_overview_description_changed:
+        (file_operations) Updated folder overview
+    :vartype EventType.folder_overview_description_changed: FolderOverviewDescriptionChangedType
+    :ivar EventType.folder_overview_item_pinned:
         (file_operations) Pinned item to folder overview
-    :ivar FolderOverviewItemUnpinnedType
-        EventType.folder_overview_item_unpinned: (file_operations) Unpinned item
-        from folder overview
-    :ivar MediaHubFileDownloadedType EventType.media_hub_file_downloaded:
+    :vartype EventType.folder_overview_item_pinned: FolderOverviewItemPinnedType
+    :ivar EventType.folder_overview_item_unpinned:
+        (file_operations) Unpinned item from folder overview
+    :vartype EventType.folder_overview_item_unpinned: FolderOverviewItemUnpinnedType
+    :ivar EventType.media_hub_file_downloaded:
         (file_operations) Downloaded files in Media Hub
-    :ivar ObjectLabelAddedType EventType.object_label_added: (file_operations)
-        Added a label
-    :ivar ObjectLabelRemovedType EventType.object_label_removed:
+    :vartype EventType.media_hub_file_downloaded: MediaHubFileDownloadedType
+    :ivar EventType.object_label_added:
+        (file_operations) Added a label
+    :vartype EventType.object_label_added: ObjectLabelAddedType
+    :ivar EventType.object_label_removed:
         (file_operations) Removed a label
-    :ivar ObjectLabelUpdatedValueType EventType.object_label_updated_value:
+    :vartype EventType.object_label_removed: ObjectLabelRemovedType
+    :ivar EventType.object_label_updated_value:
         (file_operations) Updated a label's value
-    :ivar OrganizeFolderWithTidyType EventType.organize_folder_with_tidy:
+    :vartype EventType.object_label_updated_value: ObjectLabelUpdatedValueType
+    :ivar EventType.organize_folder_with_tidy:
         (file_operations) Organized a folder with multi-file organize
-    :ivar ReplayFileDeleteType EventType.replay_file_delete: (file_operations)
-        Deleted files in Replay
-    :ivar ReplayFileDownloadedType EventType.replay_file_downloaded:
+    :vartype EventType.organize_folder_with_tidy: OrganizeFolderWithTidyType
+    :ivar EventType.replay_file_delete:
+        (file_operations) Deleted files in Replay
+    :vartype EventType.replay_file_delete: ReplayFileDeleteType
+    :ivar EventType.replay_file_downloaded:
         (file_operations) Downloaded files in Replay
-    :ivar ReplayTeamProjectCreatedType EventType.replay_team_project_created:
+    :vartype EventType.replay_file_downloaded: ReplayFileDownloadedType
+    :ivar EventType.replay_team_project_created:
         (file_operations) Created a team project in Replay
-    :ivar RewindFolderType EventType.rewind_folder: (file_operations) Rewound a
-        folder
-    :ivar UndoNamingConventionType EventType.undo_naming_convention:
+    :vartype EventType.replay_team_project_created: ReplayTeamProjectCreatedType
+    :ivar EventType.rewind_folder:
+        (file_operations) Rewound a folder
+    :vartype EventType.rewind_folder: RewindFolderType
+    :ivar EventType.undo_naming_convention:
         (file_operations) Reverted naming convention
-    :ivar UndoOrganizeFolderWithTidyType
-        EventType.undo_organize_folder_with_tidy: (file_operations) Removed
-        multi-file organize
-    :ivar UserTagsAddedType EventType.user_tags_added: (file_operations) Tagged
-        a file
-    :ivar UserTagsRemovedType EventType.user_tags_removed: (file_operations)
-        Removed tags
-    :ivar EmailIngestReceiveFileType EventType.email_ingest_receive_file:
+    :vartype EventType.undo_naming_convention: UndoNamingConventionType
+    :ivar EventType.undo_organize_folder_with_tidy:
+        (file_operations) Removed multi-file organize
+    :vartype EventType.undo_organize_folder_with_tidy: UndoOrganizeFolderWithTidyType
+    :ivar EventType.user_tags_added:
+        (file_operations) Tagged a file
+    :vartype EventType.user_tags_added: UserTagsAddedType
+    :ivar EventType.user_tags_removed:
+        (file_operations) Removed tags
+    :vartype EventType.user_tags_removed: UserTagsRemovedType
+    :ivar EventType.email_ingest_receive_file:
         (file_requests) Received files via Email to Dropbox
-    :ivar FileRequestAutoCloseType EventType.file_request_auto_close:
+    :vartype EventType.email_ingest_receive_file: EmailIngestReceiveFileType
+    :ivar EventType.file_request_auto_close:
         (file_requests) Auto closed file request
-    :ivar FileRequestChangeType EventType.file_request_change: (file_requests)
-        Changed file request
-    :ivar FileRequestCloseType EventType.file_request_close: (file_requests)
-        Closed file request
-    :ivar FileRequestCreateType EventType.file_request_create: (file_requests)
-        Created file request
-    :ivar FileRequestDeleteType EventType.file_request_delete: (file_requests)
-        Delete file request
-    :ivar FileRequestReceiveFileType EventType.file_request_receive_file:
+    :vartype EventType.file_request_auto_close: FileRequestAutoCloseType
+    :ivar EventType.file_request_change:
+        (file_requests) Changed file request
+    :vartype EventType.file_request_change: FileRequestChangeType
+    :ivar EventType.file_request_close:
+        (file_requests) Closed file request
+    :vartype EventType.file_request_close: FileRequestCloseType
+    :ivar EventType.file_request_create:
+        (file_requests) Created file request
+    :vartype EventType.file_request_create: FileRequestCreateType
+    :ivar EventType.file_request_delete:
+        (file_requests) Delete file request
+    :vartype EventType.file_request_delete: FileRequestDeleteType
+    :ivar EventType.file_request_receive_file:
         (file_requests) Received files for file request
-    :ivar GroupAddExternalIdType EventType.group_add_external_id: (groups) Added
-        external ID for group
-    :ivar GroupAddMemberType EventType.group_add_member: (groups) Added team
-        members to group
-    :ivar GroupChangeExternalIdType EventType.group_change_external_id: (groups)
-        Changed external ID for group
-    :ivar GroupChangeManagementTypeType EventType.group_change_management_type:
+    :vartype EventType.file_request_receive_file: FileRequestReceiveFileType
+    :ivar EventType.group_add_external_id:
+        (groups) Added external ID for group
+    :vartype EventType.group_add_external_id: GroupAddExternalIdType
+    :ivar EventType.group_add_member:
+        (groups) Added team members to group
+    :vartype EventType.group_add_member: GroupAddMemberType
+    :ivar EventType.group_change_external_id:
+        (groups) Changed external ID for group
+    :vartype EventType.group_change_external_id: GroupChangeExternalIdType
+    :ivar EventType.group_change_management_type:
         (groups) Changed group management type
-    :ivar GroupChangeMemberRoleType EventType.group_change_member_role: (groups)
-        Changed manager permissions of group member
-    :ivar GroupCreateType EventType.group_create: (groups) Created group
-    :ivar GroupDeleteType EventType.group_delete: (groups) Deleted group
-    :ivar GroupDescriptionUpdatedType EventType.group_description_updated:
+    :vartype EventType.group_change_management_type: GroupChangeManagementTypeType
+    :ivar EventType.group_change_member_role:
+        (groups) Changed manager permissions of group member
+    :vartype EventType.group_change_member_role: GroupChangeMemberRoleType
+    :ivar EventType.group_create:
+        (groups) Created group
+    :vartype EventType.group_create: GroupCreateType
+    :ivar EventType.group_delete:
+        (groups) Deleted group
+    :vartype EventType.group_delete: GroupDeleteType
+    :ivar EventType.group_description_updated:
         (groups) Updated group (deprecated, no longer logged)
-    :ivar GroupExternalSharingSettingOverrideChangedType
-        EventType.group_external_sharing_setting_override_changed: (groups)
-        Changed group's external sharing setting
-    :ivar GroupJoinPolicyUpdatedType EventType.group_join_policy_updated:
+    :vartype EventType.group_description_updated: GroupDescriptionUpdatedType
+    :ivar EventType.group_external_sharing_setting_override_changed:
+        (groups) Changed group's external sharing setting
+    :vartype EventType.group_external_sharing_setting_override_changed: GroupExternalSharingSettingOverrideChangedType
+    :ivar EventType.group_join_policy_updated:
         (groups) Updated group join policy (deprecated, no longer logged)
-    :ivar GroupMovedType EventType.group_moved: (groups) Moved group
-        (deprecated, no longer logged)
-    :ivar GroupRemoveExternalIdType EventType.group_remove_external_id: (groups)
-        Removed external ID for group
-    :ivar GroupRemoveMemberType EventType.group_remove_member: (groups) Removed
-        team members from group
-    :ivar GroupRenameType EventType.group_rename: (groups) Renamed group
-    :ivar AccountLockOrUnlockedType EventType.account_lock_or_unlocked: (logins)
-        Unlocked/locked account after failed sign in attempts
-    :ivar EmmErrorType EventType.emm_error: (logins) Failed to sign in via EMM
-        (deprecated, replaced by 'Failed to sign in')
-    :ivar GuestAdminSignedInViaTrustedTeamsType
-        EventType.guest_admin_signed_in_via_trusted_teams: (logins) Started
-        trusted team admin session
-    :ivar GuestAdminSignedOutViaTrustedTeamsType
-        EventType.guest_admin_signed_out_via_trusted_teams: (logins) Ended
-        trusted team admin session
-    :ivar LoginFailType EventType.login_fail: (logins) Failed to sign in
-    :ivar LoginSuccessType EventType.login_success: (logins) Signed in
-    :ivar LogoutType EventType.logout: (logins) Signed out
-    :ivar ResellerSupportSessionEndType EventType.reseller_support_session_end:
+    :vartype EventType.group_join_policy_updated: GroupJoinPolicyUpdatedType
+    :ivar EventType.group_moved:
+        (groups) Moved group (deprecated, no longer logged)
+    :vartype EventType.group_moved: GroupMovedType
+    :ivar EventType.group_remove_external_id:
+        (groups) Removed external ID for group
+    :vartype EventType.group_remove_external_id: GroupRemoveExternalIdType
+    :ivar EventType.group_remove_member:
+        (groups) Removed team members from group
+    :vartype EventType.group_remove_member: GroupRemoveMemberType
+    :ivar EventType.group_rename:
+        (groups) Renamed group
+    :vartype EventType.group_rename: GroupRenameType
+    :ivar EventType.account_lock_or_unlocked:
+        (logins) Unlocked/locked account after failed sign in attempts
+    :vartype EventType.account_lock_or_unlocked: AccountLockOrUnlockedType
+    :ivar EventType.emm_error:
+        (logins) Failed to sign in via EMM (deprecated, replaced by 'Failed to
+        sign in')
+    :vartype EventType.emm_error: EmmErrorType
+    :ivar EventType.guest_admin_signed_in_via_trusted_teams:
+        (logins) Started trusted team admin session
+    :vartype EventType.guest_admin_signed_in_via_trusted_teams: GuestAdminSignedInViaTrustedTeamsType
+    :ivar EventType.guest_admin_signed_out_via_trusted_teams:
+        (logins) Ended trusted team admin session
+    :vartype EventType.guest_admin_signed_out_via_trusted_teams: GuestAdminSignedOutViaTrustedTeamsType
+    :ivar EventType.login_fail:
+        (logins) Failed to sign in
+    :vartype EventType.login_fail: LoginFailType
+    :ivar EventType.login_success:
+        (logins) Signed in
+    :vartype EventType.login_success: LoginSuccessType
+    :ivar EventType.logout:
+        (logins) Signed out
+    :vartype EventType.logout: LogoutType
+    :ivar EventType.reseller_support_session_end:
         (logins) Ended reseller support session
-    :ivar ResellerSupportSessionStartType
-        EventType.reseller_support_session_start: (logins) Started reseller
-        support session
-    :ivar SignInAsSessionEndType EventType.sign_in_as_session_end: (logins)
-        Ended admin sign-in-as session
-    :ivar SignInAsSessionStartType EventType.sign_in_as_session_start: (logins)
-        Started admin sign-in-as session
-    :ivar SsoErrorType EventType.sso_error: (logins) Failed to sign in via SSO
-        (deprecated, replaced by 'Failed to sign in')
-    :ivar AddonAssignedType EventType.addon_assigned: (members) Add-on Assigned
-    :ivar AddonRemovedType EventType.addon_removed: (members) Add-on Removed
-    :ivar BackupAdminInvitationSentType EventType.backup_admin_invitation_sent:
+    :vartype EventType.reseller_support_session_end: ResellerSupportSessionEndType
+    :ivar EventType.reseller_support_session_start:
+        (logins) Started reseller support session
+    :vartype EventType.reseller_support_session_start: ResellerSupportSessionStartType
+    :ivar EventType.sign_in_as_session_end:
+        (logins) Ended admin sign-in-as session
+    :vartype EventType.sign_in_as_session_end: SignInAsSessionEndType
+    :ivar EventType.sign_in_as_session_start:
+        (logins) Started admin sign-in-as session
+    :vartype EventType.sign_in_as_session_start: SignInAsSessionStartType
+    :ivar EventType.sso_error:
+        (logins) Failed to sign in via SSO (deprecated, replaced by 'Failed to
+        sign in')
+    :vartype EventType.sso_error: SsoErrorType
+    :ivar EventType.addon_assigned:
+        (members) Add-on Assigned
+    :vartype EventType.addon_assigned: AddonAssignedType
+    :ivar EventType.addon_removed:
+        (members) Add-on Removed
+    :vartype EventType.addon_removed: AddonRemovedType
+    :ivar EventType.backup_admin_invitation_sent:
         (members) Invited members to activate Backup
-    :ivar BackupInvitationOpenedType EventType.backup_invitation_opened:
+    :vartype EventType.backup_admin_invitation_sent: BackupAdminInvitationSentType
+    :ivar EventType.backup_invitation_opened:
         (members) Opened Backup invite
-    :ivar CreateTeamInviteLinkType EventType.create_team_invite_link: (members)
-        Created team invite link
-    :ivar DeleteTeamInviteLinkType EventType.delete_team_invite_link: (members)
-        Deleted team invite link
-    :ivar MemberAddExternalIdType EventType.member_add_external_id: (members)
-        Added an external ID for team member
-    :ivar MemberAddNameType EventType.member_add_name: (members) Added team
-        member name
-    :ivar MemberChangeAdminRoleType EventType.member_change_admin_role:
+    :vartype EventType.backup_invitation_opened: BackupInvitationOpenedType
+    :ivar EventType.create_team_invite_link:
+        (members) Created team invite link
+    :vartype EventType.create_team_invite_link: CreateTeamInviteLinkType
+    :ivar EventType.delete_team_invite_link:
+        (members) Deleted team invite link
+    :vartype EventType.delete_team_invite_link: DeleteTeamInviteLinkType
+    :ivar EventType.member_add_external_id:
+        (members) Added an external ID for team member
+    :vartype EventType.member_add_external_id: MemberAddExternalIdType
+    :ivar EventType.member_add_name:
+        (members) Added team member name
+    :vartype EventType.member_add_name: MemberAddNameType
+    :ivar EventType.member_change_admin_role:
         (members) Changed team member admin role
-    :ivar MemberChangeEmailType EventType.member_change_email: (members) Changed
-        team member email
-    :ivar MemberChangeExternalIdType EventType.member_change_external_id:
+    :vartype EventType.member_change_admin_role: MemberChangeAdminRoleType
+    :ivar EventType.member_change_email:
+        (members) Changed team member email
+    :vartype EventType.member_change_email: MemberChangeEmailType
+    :ivar EventType.member_change_external_id:
         (members) Changed the external ID for team member
-    :ivar MemberChangeMembershipTypeType
-        EventType.member_change_membership_type: (members) Changed membership
-        type (limited/full) of member (deprecated, no longer logged)
-    :ivar MemberChangeNameType EventType.member_change_name: (members) Changed
-        team member name
-    :ivar MemberChangeResellerRoleType EventType.member_change_reseller_role:
+    :vartype EventType.member_change_external_id: MemberChangeExternalIdType
+    :ivar EventType.member_change_membership_type:
+        (members) Changed membership type (limited/full) of member (deprecated,
+        no longer logged)
+    :vartype EventType.member_change_membership_type: MemberChangeMembershipTypeType
+    :ivar EventType.member_change_name:
+        (members) Changed team member name
+    :vartype EventType.member_change_name: MemberChangeNameType
+    :ivar EventType.member_change_reseller_role:
         (members) Changed team member reseller role
-    :ivar MemberChangeStatusType EventType.member_change_status: (members)
-        Changed member status (invited, joined, suspended, etc.)
-    :ivar MemberDeleteManualContactsType
-        EventType.member_delete_manual_contacts: (members) Cleared manually
-        added contacts
-    :ivar MemberDeleteProfilePhotoType EventType.member_delete_profile_photo:
+    :vartype EventType.member_change_reseller_role: MemberChangeResellerRoleType
+    :ivar EventType.member_change_status:
+        (members) Changed member status (invited, joined, suspended, etc.)
+    :vartype EventType.member_change_status: MemberChangeStatusType
+    :ivar EventType.member_delete_manual_contacts:
+        (members) Cleared manually added contacts
+    :vartype EventType.member_delete_manual_contacts: MemberDeleteManualContactsType
+    :ivar EventType.member_delete_profile_photo:
         (members) Deleted team member profile photo
-    :ivar MemberPermanentlyDeleteAccountContentsType
-        EventType.member_permanently_delete_account_contents: (members)
-        Permanently deleted contents of deleted team member account
-    :ivar MemberRemoveExternalIdType EventType.member_remove_external_id:
+    :vartype EventType.member_delete_profile_photo: MemberDeleteProfilePhotoType
+    :ivar EventType.member_permanently_delete_account_contents:
+        (members) Permanently deleted contents of deleted team member account
+    :vartype EventType.member_permanently_delete_account_contents: MemberPermanentlyDeleteAccountContentsType
+    :ivar EventType.member_remove_external_id:
         (members) Removed the external ID for team member
-    :ivar MemberSetProfilePhotoType EventType.member_set_profile_photo:
+    :vartype EventType.member_remove_external_id: MemberRemoveExternalIdType
+    :ivar EventType.member_set_profile_photo:
         (members) Set team member profile photo
-    :ivar MemberSpaceLimitsAddCustomQuotaType
-        EventType.member_space_limits_add_custom_quota: (members) Set custom
-        member space limit
-    :ivar MemberSpaceLimitsChangeCustomQuotaType
-        EventType.member_space_limits_change_custom_quota: (members) Changed
-        custom member space limit
-    :ivar MemberSpaceLimitsChangeStatusType
-        EventType.member_space_limits_change_status: (members) Changed space
-        limit status
-    :ivar MemberSpaceLimitsRemoveCustomQuotaType
-        EventType.member_space_limits_remove_custom_quota: (members) Removed
-        custom member space limit
-    :ivar MemberSuggestType EventType.member_suggest: (members) Suggested person
-        to add to team
-    :ivar MemberTransferAccountContentsType
-        EventType.member_transfer_account_contents: (members) Transferred
-        contents of deleted member account to another member
-    :ivar PendingSecondaryEmailAddedType
-        EventType.pending_secondary_email_added: (members) Added pending
-        secondary email
-    :ivar ProductAssignedToMemberType EventType.product_assigned_to_member:
+    :vartype EventType.member_set_profile_photo: MemberSetProfilePhotoType
+    :ivar EventType.member_space_limits_add_custom_quota:
+        (members) Set custom member space limit
+    :vartype EventType.member_space_limits_add_custom_quota: MemberSpaceLimitsAddCustomQuotaType
+    :ivar EventType.member_space_limits_change_custom_quota:
+        (members) Changed custom member space limit
+    :vartype EventType.member_space_limits_change_custom_quota: MemberSpaceLimitsChangeCustomQuotaType
+    :ivar EventType.member_space_limits_change_status:
+        (members) Changed space limit status
+    :vartype EventType.member_space_limits_change_status: MemberSpaceLimitsChangeStatusType
+    :ivar EventType.member_space_limits_remove_custom_quota:
+        (members) Removed custom member space limit
+    :vartype EventType.member_space_limits_remove_custom_quota: MemberSpaceLimitsRemoveCustomQuotaType
+    :ivar EventType.member_suggest:
+        (members) Suggested person to add to team
+    :vartype EventType.member_suggest: MemberSuggestType
+    :ivar EventType.member_transfer_account_contents:
+        (members) Transferred contents of deleted member account to another
+        member
+    :vartype EventType.member_transfer_account_contents: MemberTransferAccountContentsType
+    :ivar EventType.pending_secondary_email_added:
+        (members) Added pending secondary email
+    :vartype EventType.pending_secondary_email_added: PendingSecondaryEmailAddedType
+    :ivar EventType.product_assigned_to_member:
         (members) Product assigned to team member
-    :ivar ProductRemovedFromMemberType EventType.product_removed_from_member:
+    :vartype EventType.product_assigned_to_member: ProductAssignedToMemberType
+    :ivar EventType.product_removed_from_member:
         (members) Product removed from team member
-    :ivar SecondaryEmailDeletedType EventType.secondary_email_deleted: (members)
-        Deleted secondary email
-    :ivar SecondaryEmailVerifiedType EventType.secondary_email_verified:
+    :vartype EventType.product_removed_from_member: ProductRemovedFromMemberType
+    :ivar EventType.secondary_email_deleted:
+        (members) Deleted secondary email
+    :vartype EventType.secondary_email_deleted: SecondaryEmailDeletedType
+    :ivar EventType.secondary_email_verified:
         (members) Verified secondary email
-    :ivar SecondaryMailsPolicyChangedType
-        EventType.secondary_mails_policy_changed: (members) Secondary mails
-        policy changed
-    :ivar BinderAddPageType EventType.binder_add_page: (paper) Added Binder page
-        (deprecated, replaced by 'Edited files')
-    :ivar BinderAddSectionType EventType.binder_add_section: (paper) Added
-        Binder section (deprecated, replaced by 'Edited files')
-    :ivar BinderRemovePageType EventType.binder_remove_page: (paper) Removed
-        Binder page (deprecated, replaced by 'Edited files')
-    :ivar BinderRemoveSectionType EventType.binder_remove_section: (paper)
-        Removed Binder section (deprecated, replaced by 'Edited files')
-    :ivar BinderRenamePageType EventType.binder_rename_page: (paper) Renamed
-        Binder page (deprecated, replaced by 'Edited files')
-    :ivar BinderRenameSectionType EventType.binder_rename_section: (paper)
-        Renamed Binder section (deprecated, replaced by 'Edited files')
-    :ivar BinderReorderPageType EventType.binder_reorder_page: (paper) Reordered
-        Binder page (deprecated, replaced by 'Edited files')
-    :ivar BinderReorderSectionType EventType.binder_reorder_section: (paper)
-        Reordered Binder section (deprecated, replaced by 'Edited files')
-    :ivar PaperContentAddMemberType EventType.paper_content_add_member: (paper)
-        Added users and/or groups to Paper doc/folder
-    :ivar PaperContentAddToFolderType EventType.paper_content_add_to_folder:
+    :vartype EventType.secondary_email_verified: SecondaryEmailVerifiedType
+    :ivar EventType.secondary_mails_policy_changed:
+        (members) Secondary mails policy changed
+    :vartype EventType.secondary_mails_policy_changed: SecondaryMailsPolicyChangedType
+    :ivar EventType.binder_add_page:
+        (paper) Added Binder page (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_add_page: BinderAddPageType
+    :ivar EventType.binder_add_section:
+        (paper) Added Binder section (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_add_section: BinderAddSectionType
+    :ivar EventType.binder_remove_page:
+        (paper) Removed Binder page (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_remove_page: BinderRemovePageType
+    :ivar EventType.binder_remove_section:
+        (paper) Removed Binder section (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_remove_section: BinderRemoveSectionType
+    :ivar EventType.binder_rename_page:
+        (paper) Renamed Binder page (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_rename_page: BinderRenamePageType
+    :ivar EventType.binder_rename_section:
+        (paper) Renamed Binder section (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_rename_section: BinderRenameSectionType
+    :ivar EventType.binder_reorder_page:
+        (paper) Reordered Binder page (deprecated, replaced by 'Edited files')
+    :vartype EventType.binder_reorder_page: BinderReorderPageType
+    :ivar EventType.binder_reorder_section:
+        (paper) Reordered Binder section (deprecated, replaced by 'Edited
+        files')
+    :vartype EventType.binder_reorder_section: BinderReorderSectionType
+    :ivar EventType.paper_content_add_member:
+        (paper) Added users and/or groups to Paper doc/folder
+    :vartype EventType.paper_content_add_member: PaperContentAddMemberType
+    :ivar EventType.paper_content_add_to_folder:
         (paper) Added Paper doc/folder to folder
-    :ivar PaperContentArchiveType EventType.paper_content_archive: (paper)
-        Archived Paper doc/folder
-    :ivar PaperContentCreateType EventType.paper_content_create: (paper) Created
-        Paper doc/folder
-    :ivar PaperContentPermanentlyDeleteType
-        EventType.paper_content_permanently_delete: (paper) Permanently deleted
-        Paper doc/folder
-    :ivar PaperContentRemoveFromFolderType
-        EventType.paper_content_remove_from_folder: (paper) Removed Paper
-        doc/folder from folder
-    :ivar PaperContentRemoveMemberType EventType.paper_content_remove_member:
+    :vartype EventType.paper_content_add_to_folder: PaperContentAddToFolderType
+    :ivar EventType.paper_content_archive:
+        (paper) Archived Paper doc/folder
+    :vartype EventType.paper_content_archive: PaperContentArchiveType
+    :ivar EventType.paper_content_create:
+        (paper) Created Paper doc/folder
+    :vartype EventType.paper_content_create: PaperContentCreateType
+    :ivar EventType.paper_content_permanently_delete:
+        (paper) Permanently deleted Paper doc/folder
+    :vartype EventType.paper_content_permanently_delete: PaperContentPermanentlyDeleteType
+    :ivar EventType.paper_content_remove_from_folder:
+        (paper) Removed Paper doc/folder from folder
+    :vartype EventType.paper_content_remove_from_folder: PaperContentRemoveFromFolderType
+    :ivar EventType.paper_content_remove_member:
         (paper) Removed users and/or groups from Paper doc/folder
-    :ivar PaperContentRenameType EventType.paper_content_rename: (paper) Renamed
-        Paper doc/folder
-    :ivar PaperContentRestoreType EventType.paper_content_restore: (paper)
-        Restored archived Paper doc/folder
-    :ivar PaperDocAddCommentType EventType.paper_doc_add_comment: (paper) Added
-        Paper doc comment
-    :ivar PaperDocChangeMemberRoleType EventType.paper_doc_change_member_role:
+    :vartype EventType.paper_content_remove_member: PaperContentRemoveMemberType
+    :ivar EventType.paper_content_rename:
+        (paper) Renamed Paper doc/folder
+    :vartype EventType.paper_content_rename: PaperContentRenameType
+    :ivar EventType.paper_content_restore:
+        (paper) Restored archived Paper doc/folder
+    :vartype EventType.paper_content_restore: PaperContentRestoreType
+    :ivar EventType.paper_doc_add_comment:
+        (paper) Added Paper doc comment
+    :vartype EventType.paper_doc_add_comment: PaperDocAddCommentType
+    :ivar EventType.paper_doc_change_member_role:
         (paper) Changed member permissions for Paper doc
-    :ivar PaperDocChangeSharingPolicyType
-        EventType.paper_doc_change_sharing_policy: (paper) Changed sharing
-        setting for Paper doc
-    :ivar PaperDocChangeSubscriptionType
-        EventType.paper_doc_change_subscription: (paper) Followed/unfollowed
-        Paper doc
-    :ivar PaperDocDeletedType EventType.paper_doc_deleted: (paper) Archived
-        Paper doc (deprecated, no longer logged)
-    :ivar PaperDocDeleteCommentType EventType.paper_doc_delete_comment: (paper)
-        Deleted Paper doc comment
-    :ivar PaperDocDownloadType EventType.paper_doc_download: (paper) Downloaded
-        Paper doc in specific format
-    :ivar PaperDocEditType EventType.paper_doc_edit: (paper) Edited Paper doc
-    :ivar PaperDocEditCommentType EventType.paper_doc_edit_comment: (paper)
-        Edited Paper doc comment
-    :ivar PaperDocFollowedType EventType.paper_doc_followed: (paper) Followed
-        Paper doc (deprecated, replaced by 'Followed/unfollowed Paper doc')
-    :ivar PaperDocMentionType EventType.paper_doc_mention: (paper) Mentioned
-        user in Paper doc
-    :ivar PaperDocOwnershipChangedType EventType.paper_doc_ownership_changed:
+    :vartype EventType.paper_doc_change_member_role: PaperDocChangeMemberRoleType
+    :ivar EventType.paper_doc_change_sharing_policy:
+        (paper) Changed sharing setting for Paper doc
+    :vartype EventType.paper_doc_change_sharing_policy: PaperDocChangeSharingPolicyType
+    :ivar EventType.paper_doc_change_subscription:
+        (paper) Followed/unfollowed Paper doc
+    :vartype EventType.paper_doc_change_subscription: PaperDocChangeSubscriptionType
+    :ivar EventType.paper_doc_deleted:
+        (paper) Archived Paper doc (deprecated, no longer logged)
+    :vartype EventType.paper_doc_deleted: PaperDocDeletedType
+    :ivar EventType.paper_doc_delete_comment:
+        (paper) Deleted Paper doc comment
+    :vartype EventType.paper_doc_delete_comment: PaperDocDeleteCommentType
+    :ivar EventType.paper_doc_download:
+        (paper) Downloaded Paper doc in specific format
+    :vartype EventType.paper_doc_download: PaperDocDownloadType
+    :ivar EventType.paper_doc_edit:
+        (paper) Edited Paper doc
+    :vartype EventType.paper_doc_edit: PaperDocEditType
+    :ivar EventType.paper_doc_edit_comment:
+        (paper) Edited Paper doc comment
+    :vartype EventType.paper_doc_edit_comment: PaperDocEditCommentType
+    :ivar EventType.paper_doc_followed:
+        (paper) Followed Paper doc (deprecated, replaced by 'Followed/unfollowed
+        Paper doc')
+    :vartype EventType.paper_doc_followed: PaperDocFollowedType
+    :ivar EventType.paper_doc_mention:
+        (paper) Mentioned user in Paper doc
+    :vartype EventType.paper_doc_mention: PaperDocMentionType
+    :ivar EventType.paper_doc_ownership_changed:
         (paper) Transferred ownership of Paper doc
-    :ivar PaperDocRequestAccessType EventType.paper_doc_request_access: (paper)
-        Requested access to Paper doc
-    :ivar PaperDocResolveCommentType EventType.paper_doc_resolve_comment:
+    :vartype EventType.paper_doc_ownership_changed: PaperDocOwnershipChangedType
+    :ivar EventType.paper_doc_request_access:
+        (paper) Requested access to Paper doc
+    :vartype EventType.paper_doc_request_access: PaperDocRequestAccessType
+    :ivar EventType.paper_doc_resolve_comment:
         (paper) Resolved Paper doc comment
-    :ivar PaperDocRevertType EventType.paper_doc_revert: (paper) Restored Paper
-        doc to previous version
-    :ivar PaperDocSlackShareType EventType.paper_doc_slack_share: (paper) Shared
-        Paper doc via Slack
-    :ivar PaperDocTeamInviteType EventType.paper_doc_team_invite: (paper) Shared
-        Paper doc with users and/or groups (deprecated, no longer logged)
-    :ivar PaperDocTrashedType EventType.paper_doc_trashed: (paper) Deleted Paper
-        doc
-    :ivar PaperDocUnresolveCommentType EventType.paper_doc_unresolve_comment:
+    :vartype EventType.paper_doc_resolve_comment: PaperDocResolveCommentType
+    :ivar EventType.paper_doc_revert:
+        (paper) Restored Paper doc to previous version
+    :vartype EventType.paper_doc_revert: PaperDocRevertType
+    :ivar EventType.paper_doc_slack_share:
+        (paper) Shared Paper doc via Slack
+    :vartype EventType.paper_doc_slack_share: PaperDocSlackShareType
+    :ivar EventType.paper_doc_team_invite:
+        (paper) Shared Paper doc with users and/or groups (deprecated, no longer
+        logged)
+    :vartype EventType.paper_doc_team_invite: PaperDocTeamInviteType
+    :ivar EventType.paper_doc_trashed:
+        (paper) Deleted Paper doc
+    :vartype EventType.paper_doc_trashed: PaperDocTrashedType
+    :ivar EventType.paper_doc_unresolve_comment:
         (paper) Unresolved Paper doc comment
-    :ivar PaperDocUntrashedType EventType.paper_doc_untrashed: (paper) Restored
-        Paper doc
-    :ivar PaperDocViewType EventType.paper_doc_view: (paper) Viewed Paper doc
-    :ivar PaperExternalViewAllowType EventType.paper_external_view_allow:
+    :vartype EventType.paper_doc_unresolve_comment: PaperDocUnresolveCommentType
+    :ivar EventType.paper_doc_untrashed:
+        (paper) Restored Paper doc
+    :vartype EventType.paper_doc_untrashed: PaperDocUntrashedType
+    :ivar EventType.paper_doc_view:
+        (paper) Viewed Paper doc
+    :vartype EventType.paper_doc_view: PaperDocViewType
+    :ivar EventType.paper_external_view_allow:
         (paper) Changed Paper external sharing setting to anyone (deprecated, no
         longer logged)
-    :ivar PaperExternalViewDefaultTeamType
-        EventType.paper_external_view_default_team: (paper) Changed Paper
-        external sharing setting to default team (deprecated, no longer logged)
-    :ivar PaperExternalViewForbidType EventType.paper_external_view_forbid:
+    :vartype EventType.paper_external_view_allow: PaperExternalViewAllowType
+    :ivar EventType.paper_external_view_default_team:
+        (paper) Changed Paper external sharing setting to default team
+        (deprecated, no longer logged)
+    :vartype EventType.paper_external_view_default_team: PaperExternalViewDefaultTeamType
+    :ivar EventType.paper_external_view_forbid:
         (paper) Changed Paper external sharing setting to team-only (deprecated,
         no longer logged)
-    :ivar PaperFolderChangeSubscriptionType
-        EventType.paper_folder_change_subscription: (paper) Followed/unfollowed
-        Paper folder
-    :ivar PaperFolderDeletedType EventType.paper_folder_deleted: (paper)
-        Archived Paper folder (deprecated, no longer logged)
-    :ivar PaperFolderFollowedType EventType.paper_folder_followed: (paper)
-        Followed Paper folder (deprecated, replaced by 'Followed/unfollowed
-        Paper folder')
-    :ivar PaperFolderTeamInviteType EventType.paper_folder_team_invite: (paper)
-        Shared Paper folder with users and/or groups (deprecated, no longer
-        logged)
-    :ivar PaperPublishedLinkChangePermissionType
-        EventType.paper_published_link_change_permission: (paper) Changed
-        permissions for published doc
-    :ivar PaperPublishedLinkCreateType EventType.paper_published_link_create:
+    :vartype EventType.paper_external_view_forbid: PaperExternalViewForbidType
+    :ivar EventType.paper_folder_change_subscription:
+        (paper) Followed/unfollowed Paper folder
+    :vartype EventType.paper_folder_change_subscription: PaperFolderChangeSubscriptionType
+    :ivar EventType.paper_folder_deleted:
+        (paper) Archived Paper folder (deprecated, no longer logged)
+    :vartype EventType.paper_folder_deleted: PaperFolderDeletedType
+    :ivar EventType.paper_folder_followed:
+        (paper) Followed Paper folder (deprecated, replaced by
+        'Followed/unfollowed Paper folder')
+    :vartype EventType.paper_folder_followed: PaperFolderFollowedType
+    :ivar EventType.paper_folder_team_invite:
+        (paper) Shared Paper folder with users and/or groups (deprecated, no
+        longer logged)
+    :vartype EventType.paper_folder_team_invite: PaperFolderTeamInviteType
+    :ivar EventType.paper_published_link_change_permission:
+        (paper) Changed permissions for published doc
+    :vartype EventType.paper_published_link_change_permission: PaperPublishedLinkChangePermissionType
+    :ivar EventType.paper_published_link_create:
         (paper) Published doc
-    :ivar PaperPublishedLinkDisabledType
-        EventType.paper_published_link_disabled: (paper) Unpublished doc
-    :ivar PaperPublishedLinkViewType EventType.paper_published_link_view:
+    :vartype EventType.paper_published_link_create: PaperPublishedLinkCreateType
+    :ivar EventType.paper_published_link_disabled:
+        (paper) Unpublished doc
+    :vartype EventType.paper_published_link_disabled: PaperPublishedLinkDisabledType
+    :ivar EventType.paper_published_link_view:
         (paper) Viewed published doc
-    :ivar PasswordChangeType EventType.password_change: (passwords) Changed
-        password
-    :ivar PasswordResetType EventType.password_reset: (passwords) Reset password
-    :ivar PasswordResetAllType EventType.password_reset_all: (passwords) Reset
-        all team member passwords
-    :ivar ProtectInternalDomainsChangedType
-        EventType.protect_internal_domains_changed: (protect) Modified Protect
-        internal domains list
-    :ivar ClassificationCreateReportType EventType.classification_create_report:
+    :vartype EventType.paper_published_link_view: PaperPublishedLinkViewType
+    :ivar EventType.password_change:
+        (passwords) Changed password
+    :vartype EventType.password_change: PasswordChangeType
+    :ivar EventType.password_reset:
+        (passwords) Reset password
+    :vartype EventType.password_reset: PasswordResetType
+    :ivar EventType.password_reset_all:
+        (passwords) Reset all team member passwords
+    :vartype EventType.password_reset_all: PasswordResetAllType
+    :ivar EventType.protect_internal_domains_changed:
+        (protect) Modified Protect internal domains list
+    :vartype EventType.protect_internal_domains_changed: ProtectInternalDomainsChangedType
+    :ivar EventType.classification_create_report:
         (reports) Created Classification report
-    :ivar ClassificationCreateReportFailType
-        EventType.classification_create_report_fail: (reports) Couldn't create
-        Classification report
-    :ivar EmmCreateExceptionsReportType EventType.emm_create_exceptions_report:
+    :vartype EventType.classification_create_report: ClassificationCreateReportType
+    :ivar EventType.classification_create_report_fail:
+        (reports) Couldn't create Classification report
+    :vartype EventType.classification_create_report_fail: ClassificationCreateReportFailType
+    :ivar EventType.emm_create_exceptions_report:
         (reports) Created EMM-excluded users report
-    :ivar EmmCreateUsageReportType EventType.emm_create_usage_report: (reports)
-        Created EMM mobile app usage report
-    :ivar ExportMembersReportType EventType.export_members_report: (reports)
-        Created member data report
-    :ivar ExportMembersReportFailType EventType.export_members_report_fail:
+    :vartype EventType.emm_create_exceptions_report: EmmCreateExceptionsReportType
+    :ivar EventType.emm_create_usage_report:
+        (reports) Created EMM mobile app usage report
+    :vartype EventType.emm_create_usage_report: EmmCreateUsageReportType
+    :ivar EventType.export_members_report:
+        (reports) Created member data report
+    :vartype EventType.export_members_report: ExportMembersReportType
+    :ivar EventType.export_members_report_fail:
         (reports) Failed to create members data report
-    :ivar ExternalSharingCreateReportType
-        EventType.external_sharing_create_report: (reports) Created External
-        sharing report
-    :ivar ExternalSharingReportFailedType
-        EventType.external_sharing_report_failed: (reports) Couldn't create
-        External sharing report
-    :ivar MemberAccessDetailsCreateReportType
-        EventType.member_access_details_create_report: (reports) Created member
-        access report
-    :ivar MemberAccessDetailsCreateReportFailedType
-        EventType.member_access_details_create_report_failed: (reports) Couldn't
-        generate member access report
-    :ivar NoExpirationLinkGenCreateReportType
-        EventType.no_expiration_link_gen_create_report: (reports) Report
-        created: Links created with no expiration
-    :ivar NoExpirationLinkGenReportFailedType
-        EventType.no_expiration_link_gen_report_failed: (reports) Couldn't
-        create report: Links created with no expiration
-    :ivar NoPasswordLinkGenCreateReportType
-        EventType.no_password_link_gen_create_report: (reports) Report created:
-        Links created without passwords
-    :ivar NoPasswordLinkGenReportFailedType
-        EventType.no_password_link_gen_report_failed: (reports) Couldn't create
-        report: Links created without passwords
-    :ivar NoPasswordLinkViewCreateReportType
-        EventType.no_password_link_view_create_report: (reports) Report created:
-        Views of links without passwords
-    :ivar NoPasswordLinkViewReportFailedType
-        EventType.no_password_link_view_report_failed: (reports) Couldn't create
-        report: Views of links without passwords
-    :ivar OutdatedLinkViewCreateReportType
-        EventType.outdated_link_view_create_report: (reports) Report created:
-        Views of old links
-    :ivar OutdatedLinkViewReportFailedType
-        EventType.outdated_link_view_report_failed: (reports) Couldn't create
-        report: Views of old links
-    :ivar PaperAdminExportStartType EventType.paper_admin_export_start:
+    :vartype EventType.export_members_report_fail: ExportMembersReportFailType
+    :ivar EventType.external_sharing_create_report:
+        (reports) Created External sharing report
+    :vartype EventType.external_sharing_create_report: ExternalSharingCreateReportType
+    :ivar EventType.external_sharing_report_failed:
+        (reports) Couldn't create External sharing report
+    :vartype EventType.external_sharing_report_failed: ExternalSharingReportFailedType
+    :ivar EventType.member_access_details_create_report:
+        (reports) Created member access report
+    :vartype EventType.member_access_details_create_report: MemberAccessDetailsCreateReportType
+    :ivar EventType.member_access_details_create_report_failed:
+        (reports) Couldn't generate member access report
+    :vartype EventType.member_access_details_create_report_failed: MemberAccessDetailsCreateReportFailedType
+    :ivar EventType.no_expiration_link_gen_create_report:
+        (reports) Report created: Links created with no expiration
+    :vartype EventType.no_expiration_link_gen_create_report: NoExpirationLinkGenCreateReportType
+    :ivar EventType.no_expiration_link_gen_report_failed:
+        (reports) Couldn't create report: Links created with no expiration
+    :vartype EventType.no_expiration_link_gen_report_failed: NoExpirationLinkGenReportFailedType
+    :ivar EventType.no_password_link_gen_create_report:
+        (reports) Report created: Links created without passwords
+    :vartype EventType.no_password_link_gen_create_report: NoPasswordLinkGenCreateReportType
+    :ivar EventType.no_password_link_gen_report_failed:
+        (reports) Couldn't create report: Links created without passwords
+    :vartype EventType.no_password_link_gen_report_failed: NoPasswordLinkGenReportFailedType
+    :ivar EventType.no_password_link_view_create_report:
+        (reports) Report created: Views of links without passwords
+    :vartype EventType.no_password_link_view_create_report: NoPasswordLinkViewCreateReportType
+    :ivar EventType.no_password_link_view_report_failed:
+        (reports) Couldn't create report: Views of links without passwords
+    :vartype EventType.no_password_link_view_report_failed: NoPasswordLinkViewReportFailedType
+    :ivar EventType.outdated_link_view_create_report:
+        (reports) Report created: Views of old links
+    :vartype EventType.outdated_link_view_create_report: OutdatedLinkViewCreateReportType
+    :ivar EventType.outdated_link_view_report_failed:
+        (reports) Couldn't create report: Views of old links
+    :vartype EventType.outdated_link_view_report_failed: OutdatedLinkViewReportFailedType
+    :ivar EventType.paper_admin_export_start:
         (reports) Exported all team Paper docs
-    :ivar RansomwareAlertCreateReportType
-        EventType.ransomware_alert_create_report: (reports) Created ransomware
-        report
-    :ivar RansomwareAlertCreateReportFailedType
-        EventType.ransomware_alert_create_report_failed: (reports) Couldn't
-        generate ransomware report
-    :ivar SharedFoldersCreateReportType EventType.shared_folders_create_report:
+    :vartype EventType.paper_admin_export_start: PaperAdminExportStartType
+    :ivar EventType.ransomware_alert_create_report:
+        (reports) Created ransomware report
+    :vartype EventType.ransomware_alert_create_report: RansomwareAlertCreateReportType
+    :ivar EventType.ransomware_alert_create_report_failed:
+        (reports) Couldn't generate ransomware report
+    :vartype EventType.ransomware_alert_create_report_failed: RansomwareAlertCreateReportFailedType
+    :ivar EventType.shared_folders_create_report:
         (reports) Created shared folders report
-    :ivar SharedFoldersCreateReportFailedType
-        EventType.shared_folders_create_report_failed: (reports) Couldn't
-        generate shared folders report
-    :ivar SmartSyncCreateAdminPrivilegeReportType
-        EventType.smart_sync_create_admin_privilege_report: (reports) Created
-        Smart Sync non-admin devices report
-    :ivar TeamActivityCreateReportType EventType.team_activity_create_report:
+    :vartype EventType.shared_folders_create_report: SharedFoldersCreateReportType
+    :ivar EventType.shared_folders_create_report_failed:
+        (reports) Couldn't generate shared folders report
+    :vartype EventType.shared_folders_create_report_failed: SharedFoldersCreateReportFailedType
+    :ivar EventType.smart_sync_create_admin_privilege_report:
+        (reports) Created Smart Sync non-admin devices report
+    :vartype EventType.smart_sync_create_admin_privilege_report: SmartSyncCreateAdminPrivilegeReportType
+    :ivar EventType.team_activity_create_report:
         (reports) Created team activity report
-    :ivar TeamActivityCreateReportFailType
-        EventType.team_activity_create_report_fail: (reports) Couldn't generate
-        team activity report
-    :ivar TeamFoldersCreateReportType EventType.team_folders_create_report:
+    :vartype EventType.team_activity_create_report: TeamActivityCreateReportType
+    :ivar EventType.team_activity_create_report_fail:
+        (reports) Couldn't generate team activity report
+    :vartype EventType.team_activity_create_report_fail: TeamActivityCreateReportFailType
+    :ivar EventType.team_folders_create_report:
         (reports) Created team folders report
-    :ivar TeamFoldersCreateReportFailedType
-        EventType.team_folders_create_report_failed: (reports) Couldn't generate
-        team folders report
-    :ivar TeamStorageCreateReportType EventType.team_storage_create_report:
+    :vartype EventType.team_folders_create_report: TeamFoldersCreateReportType
+    :ivar EventType.team_folders_create_report_failed:
+        (reports) Couldn't generate team folders report
+    :vartype EventType.team_folders_create_report_failed: TeamFoldersCreateReportFailedType
+    :ivar EventType.team_storage_create_report:
         (reports) Created team storage report
-    :ivar TeamStorageCreateReportFailedType
-        EventType.team_storage_create_report_failed: (reports) Couldn't generate
-        team storage report
-    :ivar CollectionShareType EventType.collection_share: (sharing) Shared album
-    :ivar FileTransfersFileAddType EventType.file_transfers_file_add: (sharing)
-        Transfer files added
-    :ivar FileTransfersTransferDeleteType
-        EventType.file_transfers_transfer_delete: (sharing) Deleted transfer
-    :ivar FileTransfersTransferDownloadType
-        EventType.file_transfers_transfer_download: (sharing) Transfer
-        downloaded
-    :ivar FileTransfersTransferSendType EventType.file_transfers_transfer_send:
+    :vartype EventType.team_storage_create_report: TeamStorageCreateReportType
+    :ivar EventType.team_storage_create_report_failed:
+        (reports) Couldn't generate team storage report
+    :vartype EventType.team_storage_create_report_failed: TeamStorageCreateReportFailedType
+    :ivar EventType.collection_share:
+        (sharing) Shared album
+    :vartype EventType.collection_share: CollectionShareType
+    :ivar EventType.file_transfers_file_add:
+        (sharing) Transfer files added
+    :vartype EventType.file_transfers_file_add: FileTransfersFileAddType
+    :ivar EventType.file_transfers_transfer_delete:
+        (sharing) Deleted transfer
+    :vartype EventType.file_transfers_transfer_delete: FileTransfersTransferDeleteType
+    :ivar EventType.file_transfers_transfer_download:
+        (sharing) Transfer downloaded
+    :vartype EventType.file_transfers_transfer_download: FileTransfersTransferDownloadType
+    :ivar EventType.file_transfers_transfer_send:
         (sharing) Sent transfer
-    :ivar FileTransfersTransferViewType EventType.file_transfers_transfer_view:
+    :vartype EventType.file_transfers_transfer_send: FileTransfersTransferSendType
+    :ivar EventType.file_transfers_transfer_view:
         (sharing) Viewed transfer
-    :ivar MediaHubProjectTeamAddType EventType.media_hub_project_team_add:
+    :vartype EventType.file_transfers_transfer_view: FileTransfersTransferViewType
+    :ivar EventType.media_hub_project_team_add:
         (sharing) Added member to Media Hub project
-    :ivar MediaHubProjectTeamDeleteType EventType.media_hub_project_team_delete:
+    :vartype EventType.media_hub_project_team_add: MediaHubProjectTeamAddType
+    :ivar EventType.media_hub_project_team_delete:
         (sharing) Removed member from Media Hub project
-    :ivar MediaHubProjectTeamRoleChangedType
-        EventType.media_hub_project_team_role_changed: (sharing) Changed member
-        role in Media Hub project
-    :ivar MediaHubSharedLinkAudienceChangedType
-        EventType.media_hub_shared_link_audience_changed: (sharing) Changed
-        Media Hub shared link audience
-    :ivar MediaHubSharedLinkCreatedType EventType.media_hub_shared_link_created:
+    :vartype EventType.media_hub_project_team_delete: MediaHubProjectTeamDeleteType
+    :ivar EventType.media_hub_project_team_role_changed:
+        (sharing) Changed member role in Media Hub project
+    :vartype EventType.media_hub_project_team_role_changed: MediaHubProjectTeamRoleChangedType
+    :ivar EventType.media_hub_shared_link_audience_changed:
+        (sharing) Changed Media Hub shared link audience
+    :vartype EventType.media_hub_shared_link_audience_changed: MediaHubSharedLinkAudienceChangedType
+    :ivar EventType.media_hub_shared_link_created:
         (sharing) Created Media Hub shared link
-    :ivar MediaHubSharedLinkDownloadSettingChangedType
-        EventType.media_hub_shared_link_download_setting_changed: (sharing)
-        Changed Media Hub shared link download setting
-    :ivar MediaHubSharedLinkRevokedType EventType.media_hub_shared_link_revoked:
+    :vartype EventType.media_hub_shared_link_created: MediaHubSharedLinkCreatedType
+    :ivar EventType.media_hub_shared_link_download_setting_changed:
+        (sharing) Changed Media Hub shared link download setting
+    :vartype EventType.media_hub_shared_link_download_setting_changed: MediaHubSharedLinkDownloadSettingChangedType
+    :ivar EventType.media_hub_shared_link_revoked:
         (sharing) Revoked Media Hub shared link
-    :ivar NoteAclInviteOnlyType EventType.note_acl_invite_only: (sharing)
-        Changed Paper doc to invite-only (deprecated, no longer logged)
-    :ivar NoteAclLinkType EventType.note_acl_link: (sharing) Changed Paper doc
-        to link-accessible (deprecated, no longer logged)
-    :ivar NoteAclTeamLinkType EventType.note_acl_team_link: (sharing) Changed
-        Paper doc to link-accessible for team (deprecated, no longer logged)
-    :ivar NoteSharedType EventType.note_shared: (sharing) Shared Paper doc
-        (deprecated, no longer logged)
-    :ivar NoteShareReceiveType EventType.note_share_receive: (sharing) Shared
-        received Paper doc (deprecated, no longer logged)
-    :ivar OpenNoteSharedType EventType.open_note_shared: (sharing) Opened shared
-        Paper doc (deprecated, no longer logged)
-    :ivar ReplayFileSharedLinkCreatedType
-        EventType.replay_file_shared_link_created: (sharing) Created shared link
-        in Replay
-    :ivar ReplayFileSharedLinkModifiedType
-        EventType.replay_file_shared_link_modified: (sharing) Changed shared
-        link in Replay
-    :ivar ReplayProjectTeamAddType EventType.replay_project_team_add: (sharing)
-        Added member to Replay Project
-    :ivar ReplayProjectTeamDeleteType EventType.replay_project_team_delete:
-        (sharing) Removed member from Replay Project
-    :ivar SendAndTrackFileAddedType EventType.send_and_track_file_added:
-        (sharing) File added to Send and Track
-    :ivar SendAndTrackFileRenamedType EventType.send_and_track_file_renamed:
-        (sharing) File renamed in Send and Track
-    :ivar SendAndTrackFileUpdatedType EventType.send_and_track_file_updated:
-        (sharing) File updated in Send and Track
-    :ivar SendAndTrackLinkCreatedType EventType.send_and_track_link_created:
-        (sharing) Link created in Send and Track
-    :ivar SendAndTrackLinkDeletedType EventType.send_and_track_link_deleted:
-        (sharing) Link deleted in Send and Track
-    :ivar SendAndTrackLinkUpdatedType EventType.send_and_track_link_updated:
-        (sharing) Send and Track Link Updated
-    :ivar SendAndTrackLinkViewedType EventType.send_and_track_link_viewed:
-        (sharing) Send and Track Link Visited
-    :ivar SendAndTrackRemovedFileAndAssociatedLinksType
-        EventType.send_and_track_removed_file_and_associated_links: (sharing)
-        Send and Track file and associated links deleted
-    :ivar SfAddGroupType EventType.sf_add_group: (sharing) Added team to shared
-        folder (deprecated, no longer logged)
-    :ivar SfAllowNonMembersToViewSharedLinksType
-        EventType.sf_allow_non_members_to_view_shared_links: (sharing) Allowed
-        non-collaborators to view links to files in shared folder (deprecated,
-        no longer logged)
-    :ivar SfExternalInviteWarnType EventType.sf_external_invite_warn: (sharing)
-        Set team members to see warning before sharing folders outside team
-        (deprecated, no longer logged)
-    :ivar SfFbInviteType EventType.sf_fb_invite: (sharing) Invited Facebook
-        users to shared folder (deprecated, no longer logged)
-    :ivar SfFbInviteChangeRoleType EventType.sf_fb_invite_change_role: (sharing)
-        Changed Facebook user's role in shared folder (deprecated, no longer
+    :vartype EventType.media_hub_shared_link_revoked: MediaHubSharedLinkRevokedType
+    :ivar EventType.note_acl_invite_only:
+        (sharing) Changed Paper doc to invite-only (deprecated, no longer
         logged)
-    :ivar SfFbUninviteType EventType.sf_fb_uninvite: (sharing) Uninvited
-        Facebook user from shared folder (deprecated, no longer logged)
-    :ivar SfInviteGroupType EventType.sf_invite_group: (sharing) Invited group
-        to shared folder (deprecated, no longer logged)
-    :ivar SfTeamGrantAccessType EventType.sf_team_grant_access: (sharing)
-        Granted access to shared folder (deprecated, no longer logged)
-    :ivar SfTeamInviteType EventType.sf_team_invite: (sharing) Invited team
-        members to shared folder (deprecated, replaced by 'Invited user to
-        Dropbox and added them to shared file/folder')
-    :ivar SfTeamInviteChangeRoleType EventType.sf_team_invite_change_role:
+    :vartype EventType.note_acl_invite_only: NoteAclInviteOnlyType
+    :ivar EventType.note_acl_link:
+        (sharing) Changed Paper doc to link-accessible (deprecated, no longer
+        logged)
+    :vartype EventType.note_acl_link: NoteAclLinkType
+    :ivar EventType.note_acl_team_link:
+        (sharing) Changed Paper doc to link-accessible for team (deprecated, no
+        longer logged)
+    :vartype EventType.note_acl_team_link: NoteAclTeamLinkType
+    :ivar EventType.note_shared:
+        (sharing) Shared Paper doc (deprecated, no longer logged)
+    :vartype EventType.note_shared: NoteSharedType
+    :ivar EventType.note_share_receive:
+        (sharing) Shared received Paper doc (deprecated, no longer logged)
+    :vartype EventType.note_share_receive: NoteShareReceiveType
+    :ivar EventType.open_note_shared:
+        (sharing) Opened shared Paper doc (deprecated, no longer logged)
+    :vartype EventType.open_note_shared: OpenNoteSharedType
+    :ivar EventType.replay_file_shared_link_created:
+        (sharing) Created shared link in Replay
+    :vartype EventType.replay_file_shared_link_created: ReplayFileSharedLinkCreatedType
+    :ivar EventType.replay_file_shared_link_modified:
+        (sharing) Changed shared link in Replay
+    :vartype EventType.replay_file_shared_link_modified: ReplayFileSharedLinkModifiedType
+    :ivar EventType.replay_project_team_add:
+        (sharing) Added member to Replay Project
+    :vartype EventType.replay_project_team_add: ReplayProjectTeamAddType
+    :ivar EventType.replay_project_team_delete:
+        (sharing) Removed member from Replay Project
+    :vartype EventType.replay_project_team_delete: ReplayProjectTeamDeleteType
+    :ivar EventType.send_and_track_file_added:
+        (sharing) File added to Send and Track
+    :vartype EventType.send_and_track_file_added: SendAndTrackFileAddedType
+    :ivar EventType.send_and_track_file_renamed:
+        (sharing) File renamed in Send and Track
+    :vartype EventType.send_and_track_file_renamed: SendAndTrackFileRenamedType
+    :ivar EventType.send_and_track_file_updated:
+        (sharing) File updated in Send and Track
+    :vartype EventType.send_and_track_file_updated: SendAndTrackFileUpdatedType
+    :ivar EventType.send_and_track_link_created:
+        (sharing) Link created in Send and Track
+    :vartype EventType.send_and_track_link_created: SendAndTrackLinkCreatedType
+    :ivar EventType.send_and_track_link_deleted:
+        (sharing) Link deleted in Send and Track
+    :vartype EventType.send_and_track_link_deleted: SendAndTrackLinkDeletedType
+    :ivar EventType.send_and_track_link_updated:
+        (sharing) Send and Track Link Updated
+    :vartype EventType.send_and_track_link_updated: SendAndTrackLinkUpdatedType
+    :ivar EventType.send_and_track_link_viewed:
+        (sharing) Send and Track Link Visited
+    :vartype EventType.send_and_track_link_viewed: SendAndTrackLinkViewedType
+    :ivar EventType.send_and_track_removed_file_and_associated_links:
+        (sharing) Send and Track file and associated links deleted
+    :vartype EventType.send_and_track_removed_file_and_associated_links: SendAndTrackRemovedFileAndAssociatedLinksType
+    :ivar EventType.sf_add_group:
+        (sharing) Added team to shared folder (deprecated, no longer logged)
+    :vartype EventType.sf_add_group: SfAddGroupType
+    :ivar EventType.sf_allow_non_members_to_view_shared_links:
+        (sharing) Allowed non-collaborators to view links to files in shared
+        folder (deprecated, no longer logged)
+    :vartype EventType.sf_allow_non_members_to_view_shared_links: SfAllowNonMembersToViewSharedLinksType
+    :ivar EventType.sf_external_invite_warn:
+        (sharing) Set team members to see warning before sharing folders outside
+        team (deprecated, no longer logged)
+    :vartype EventType.sf_external_invite_warn: SfExternalInviteWarnType
+    :ivar EventType.sf_fb_invite:
+        (sharing) Invited Facebook users to shared folder (deprecated, no longer
+        logged)
+    :vartype EventType.sf_fb_invite: SfFbInviteType
+    :ivar EventType.sf_fb_invite_change_role:
+        (sharing) Changed Facebook user's role in shared folder (deprecated, no
+        longer logged)
+    :vartype EventType.sf_fb_invite_change_role: SfFbInviteChangeRoleType
+    :ivar EventType.sf_fb_uninvite:
+        (sharing) Uninvited Facebook user from shared folder (deprecated, no
+        longer logged)
+    :vartype EventType.sf_fb_uninvite: SfFbUninviteType
+    :ivar EventType.sf_invite_group:
+        (sharing) Invited group to shared folder (deprecated, no longer logged)
+    :vartype EventType.sf_invite_group: SfInviteGroupType
+    :ivar EventType.sf_team_grant_access:
+        (sharing) Granted access to shared folder (deprecated, no longer logged)
+    :vartype EventType.sf_team_grant_access: SfTeamGrantAccessType
+    :ivar EventType.sf_team_invite:
+        (sharing) Invited team members to shared folder (deprecated, replaced by
+        'Invited user to Dropbox and added them to shared file/folder')
+    :vartype EventType.sf_team_invite: SfTeamInviteType
+    :ivar EventType.sf_team_invite_change_role:
         (sharing) Changed team member's role in shared folder (deprecated, no
         longer logged)
-    :ivar SfTeamJoinType EventType.sf_team_join: (sharing) Joined team member's
-        shared folder (deprecated, no longer logged)
-    :ivar SfTeamJoinFromOobLinkType EventType.sf_team_join_from_oob_link:
+    :vartype EventType.sf_team_invite_change_role: SfTeamInviteChangeRoleType
+    :ivar EventType.sf_team_join:
+        (sharing) Joined team member's shared folder (deprecated, no longer
+        logged)
+    :vartype EventType.sf_team_join: SfTeamJoinType
+    :ivar EventType.sf_team_join_from_oob_link:
         (sharing) Joined team member's shared folder from link (deprecated, no
         longer logged)
-    :ivar SfTeamUninviteType EventType.sf_team_uninvite: (sharing) Unshared
-        folder with team member (deprecated, replaced by 'Removed invitee from
-        shared file/folder before invite was accepted')
-    :ivar SharedContentAddInviteesType EventType.shared_content_add_invitees:
+    :vartype EventType.sf_team_join_from_oob_link: SfTeamJoinFromOobLinkType
+    :ivar EventType.sf_team_uninvite:
+        (sharing) Unshared folder with team member (deprecated, replaced by
+        'Removed invitee from shared file/folder before invite was accepted')
+    :vartype EventType.sf_team_uninvite: SfTeamUninviteType
+    :ivar EventType.shared_content_add_invitees:
         (sharing) Invited user to Dropbox and added them to shared file/folder
-    :ivar SharedContentAddLinkExpiryType
-        EventType.shared_content_add_link_expiry: (sharing) Added expiration
-        date to link for shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentAddLinkPasswordType
-        EventType.shared_content_add_link_password: (sharing) Added password to
-        link for shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentAddMemberType EventType.shared_content_add_member:
+    :vartype EventType.shared_content_add_invitees: SharedContentAddInviteesType
+    :ivar EventType.shared_content_add_link_expiry:
+        (sharing) Added expiration date to link for shared file/folder
+        (deprecated, no longer logged)
+    :vartype EventType.shared_content_add_link_expiry: SharedContentAddLinkExpiryType
+    :ivar EventType.shared_content_add_link_password:
+        (sharing) Added password to link for shared file/folder (deprecated, no
+        longer logged)
+    :vartype EventType.shared_content_add_link_password: SharedContentAddLinkPasswordType
+    :ivar EventType.shared_content_add_member:
         (sharing) Added users and/or groups to shared file/folder
-    :ivar SharedContentChangeDownloadsPolicyType
-        EventType.shared_content_change_downloads_policy: (sharing) Changed
-        whether members can download shared file/folder (deprecated, no longer
-        logged)
-    :ivar SharedContentChangeInviteeRoleType
-        EventType.shared_content_change_invitee_role: (sharing) Changed access
-        type of invitee to shared file/folder before invite was accepted
-    :ivar SharedContentChangeLinkAudienceType
-        EventType.shared_content_change_link_audience: (sharing) Changed link
-        audience of shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentChangeLinkExpiryType
-        EventType.shared_content_change_link_expiry: (sharing) Changed link
-        expiration of shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentChangeLinkPasswordType
-        EventType.shared_content_change_link_password: (sharing) Changed link
-        password of shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentChangeMemberRoleType
-        EventType.shared_content_change_member_role: (sharing) Changed access
-        type of shared file/folder member
-    :ivar SharedContentChangeViewerInfoPolicyType
-        EventType.shared_content_change_viewer_info_policy: (sharing) Changed
-        whether members can see who viewed shared file/folder
-    :ivar SharedContentClaimInvitationType
-        EventType.shared_content_claim_invitation: (sharing) Acquired membership
-        of shared file/folder by accepting invite
-    :ivar SharedContentCopyType EventType.shared_content_copy: (sharing) Copied
-        shared file/folder to own Dropbox
-    :ivar SharedContentDownloadType EventType.shared_content_download: (sharing)
-        Downloaded shared file/folder
-    :ivar SharedContentRelinquishMembershipType
-        EventType.shared_content_relinquish_membership: (sharing) Left shared
-        file/folder
-    :ivar SharedContentRemoveInviteesType
-        EventType.shared_content_remove_invitees: (sharing) Removed invitee from
-        shared file/folder before invite was accepted
-    :ivar SharedContentRemoveLinkExpiryType
-        EventType.shared_content_remove_link_expiry: (sharing) Removed link
-        expiration date of shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentRemoveLinkPasswordType
-        EventType.shared_content_remove_link_password: (sharing) Removed link
-        password of shared file/folder (deprecated, no longer logged)
-    :ivar SharedContentRemoveMemberType EventType.shared_content_remove_member:
+    :vartype EventType.shared_content_add_member: SharedContentAddMemberType
+    :ivar EventType.shared_content_change_downloads_policy:
+        (sharing) Changed whether members can download shared file/folder
+        (deprecated, no longer logged)
+    :vartype EventType.shared_content_change_downloads_policy: SharedContentChangeDownloadsPolicyType
+    :ivar EventType.shared_content_change_invitee_role:
+        (sharing) Changed access type of invitee to shared file/folder before
+        invite was accepted
+    :vartype EventType.shared_content_change_invitee_role: SharedContentChangeInviteeRoleType
+    :ivar EventType.shared_content_change_link_audience:
+        (sharing) Changed link audience of shared file/folder (deprecated, no
+        longer logged)
+    :vartype EventType.shared_content_change_link_audience: SharedContentChangeLinkAudienceType
+    :ivar EventType.shared_content_change_link_expiry:
+        (sharing) Changed link expiration of shared file/folder (deprecated, no
+        longer logged)
+    :vartype EventType.shared_content_change_link_expiry: SharedContentChangeLinkExpiryType
+    :ivar EventType.shared_content_change_link_password:
+        (sharing) Changed link password of shared file/folder (deprecated, no
+        longer logged)
+    :vartype EventType.shared_content_change_link_password: SharedContentChangeLinkPasswordType
+    :ivar EventType.shared_content_change_member_role:
+        (sharing) Changed access type of shared file/folder member
+    :vartype EventType.shared_content_change_member_role: SharedContentChangeMemberRoleType
+    :ivar EventType.shared_content_change_viewer_info_policy:
+        (sharing) Changed whether members can see who viewed shared file/folder
+    :vartype EventType.shared_content_change_viewer_info_policy: SharedContentChangeViewerInfoPolicyType
+    :ivar EventType.shared_content_claim_invitation:
+        (sharing) Acquired membership of shared file/folder by accepting invite
+    :vartype EventType.shared_content_claim_invitation: SharedContentClaimInvitationType
+    :ivar EventType.shared_content_copy:
+        (sharing) Copied shared file/folder to own Dropbox
+    :vartype EventType.shared_content_copy: SharedContentCopyType
+    :ivar EventType.shared_content_download:
+        (sharing) Downloaded shared file/folder
+    :vartype EventType.shared_content_download: SharedContentDownloadType
+    :ivar EventType.shared_content_relinquish_membership:
+        (sharing) Left shared file/folder
+    :vartype EventType.shared_content_relinquish_membership: SharedContentRelinquishMembershipType
+    :ivar EventType.shared_content_remove_invitees:
+        (sharing) Removed invitee from shared file/folder before invite was
+        accepted
+    :vartype EventType.shared_content_remove_invitees: SharedContentRemoveInviteesType
+    :ivar EventType.shared_content_remove_link_expiry:
+        (sharing) Removed link expiration date of shared file/folder
+        (deprecated, no longer logged)
+    :vartype EventType.shared_content_remove_link_expiry: SharedContentRemoveLinkExpiryType
+    :ivar EventType.shared_content_remove_link_password:
+        (sharing) Removed link password of shared file/folder (deprecated, no
+        longer logged)
+    :vartype EventType.shared_content_remove_link_password: SharedContentRemoveLinkPasswordType
+    :ivar EventType.shared_content_remove_member:
         (sharing) Removed user/group from shared file/folder
-    :ivar SharedContentRequestAccessType
-        EventType.shared_content_request_access: (sharing) Requested access to
-        shared file/folder
-    :ivar SharedContentRestoreInviteesType
-        EventType.shared_content_restore_invitees: (sharing) Restored shared
-        file/folder invitees
-    :ivar SharedContentRestoreMemberType
-        EventType.shared_content_restore_member: (sharing) Restored users and/or
-        groups to membership of shared file/folder
-    :ivar SharedContentUnshareType EventType.shared_content_unshare: (sharing)
-        Unshared file/folder by clearing membership
-    :ivar SharedContentViewType EventType.shared_content_view: (sharing)
-        Previewed shared file/folder
-    :ivar SharedFolderChangeLinkPolicyType
-        EventType.shared_folder_change_link_policy: (sharing) Changed who can
-        access shared folder via link
-    :ivar SharedFolderChangeMembersInheritancePolicyType
-        EventType.shared_folder_change_members_inheritance_policy: (sharing)
-        Changed whether shared folder inherits members from parent folder
-    :ivar SharedFolderChangeMembersManagementPolicyType
-        EventType.shared_folder_change_members_management_policy: (sharing)
-        Changed who can add/remove members of shared folder
-    :ivar SharedFolderChangeMembersPolicyType
-        EventType.shared_folder_change_members_policy: (sharing) Changed who can
-        become member of shared folder
-    :ivar SharedFolderCreateType EventType.shared_folder_create: (sharing)
-        Created shared folder
-    :ivar SharedFolderDeclineInvitationType
-        EventType.shared_folder_decline_invitation: (sharing) Declined team
-        member's invite to shared folder
-    :ivar SharedFolderMountType EventType.shared_folder_mount: (sharing) Added
-        shared folder to own Dropbox
-    :ivar SharedFolderNestType EventType.shared_folder_nest: (sharing) Changed
-        parent of shared folder
-    :ivar SharedFolderTransferOwnershipType
-        EventType.shared_folder_transfer_ownership: (sharing) Transferred
-        ownership of shared folder to another member
-    :ivar SharedFolderUnmountType EventType.shared_folder_unmount: (sharing)
-        Deleted shared folder from Dropbox
-    :ivar SharedLinkAddExpiryType EventType.shared_link_add_expiry: (sharing)
-        Added shared link expiration date
-    :ivar SharedLinkChangeExpiryType EventType.shared_link_change_expiry:
+    :vartype EventType.shared_content_remove_member: SharedContentRemoveMemberType
+    :ivar EventType.shared_content_request_access:
+        (sharing) Requested access to shared file/folder
+    :vartype EventType.shared_content_request_access: SharedContentRequestAccessType
+    :ivar EventType.shared_content_restore_invitees:
+        (sharing) Restored shared file/folder invitees
+    :vartype EventType.shared_content_restore_invitees: SharedContentRestoreInviteesType
+    :ivar EventType.shared_content_restore_member:
+        (sharing) Restored users and/or groups to membership of shared
+        file/folder
+    :vartype EventType.shared_content_restore_member: SharedContentRestoreMemberType
+    :ivar EventType.shared_content_unshare:
+        (sharing) Unshared file/folder by clearing membership
+    :vartype EventType.shared_content_unshare: SharedContentUnshareType
+    :ivar EventType.shared_content_view:
+        (sharing) Previewed shared file/folder
+    :vartype EventType.shared_content_view: SharedContentViewType
+    :ivar EventType.shared_folder_change_link_policy:
+        (sharing) Changed who can access shared folder via link
+    :vartype EventType.shared_folder_change_link_policy: SharedFolderChangeLinkPolicyType
+    :ivar EventType.shared_folder_change_members_inheritance_policy:
+        (sharing) Changed whether shared folder inherits members from parent
+        folder
+    :vartype EventType.shared_folder_change_members_inheritance_policy: SharedFolderChangeMembersInheritancePolicyType
+    :ivar EventType.shared_folder_change_members_management_policy:
+        (sharing) Changed who can add/remove members of shared folder
+    :vartype EventType.shared_folder_change_members_management_policy: SharedFolderChangeMembersManagementPolicyType
+    :ivar EventType.shared_folder_change_members_policy:
+        (sharing) Changed who can become member of shared folder
+    :vartype EventType.shared_folder_change_members_policy: SharedFolderChangeMembersPolicyType
+    :ivar EventType.shared_folder_create:
+        (sharing) Created shared folder
+    :vartype EventType.shared_folder_create: SharedFolderCreateType
+    :ivar EventType.shared_folder_decline_invitation:
+        (sharing) Declined team member's invite to shared folder
+    :vartype EventType.shared_folder_decline_invitation: SharedFolderDeclineInvitationType
+    :ivar EventType.shared_folder_mount:
+        (sharing) Added shared folder to own Dropbox
+    :vartype EventType.shared_folder_mount: SharedFolderMountType
+    :ivar EventType.shared_folder_nest:
+        (sharing) Changed parent of shared folder
+    :vartype EventType.shared_folder_nest: SharedFolderNestType
+    :ivar EventType.shared_folder_transfer_ownership:
+        (sharing) Transferred ownership of shared folder to another member
+    :vartype EventType.shared_folder_transfer_ownership: SharedFolderTransferOwnershipType
+    :ivar EventType.shared_folder_unmount:
+        (sharing) Deleted shared folder from Dropbox
+    :vartype EventType.shared_folder_unmount: SharedFolderUnmountType
+    :ivar EventType.shared_link_add_expiry:
+        (sharing) Added shared link expiration date
+    :vartype EventType.shared_link_add_expiry: SharedLinkAddExpiryType
+    :ivar EventType.shared_link_change_expiry:
         (sharing) Changed shared link expiration date
-    :ivar SharedLinkChangeVisibilityType
-        EventType.shared_link_change_visibility: (sharing) Changed visibility of
-        shared link
-    :ivar SharedLinkCopyType EventType.shared_link_copy: (sharing) Added
-        file/folder to Dropbox from shared link
-    :ivar SharedLinkCreateType EventType.shared_link_create: (sharing) Created
-        shared link
-    :ivar SharedLinkDisableType EventType.shared_link_disable: (sharing) Removed
-        shared link
-    :ivar SharedLinkDownloadType EventType.shared_link_download: (sharing)
-        Downloaded file/folder from shared link
-    :ivar SharedLinkRemoveExpiryType EventType.shared_link_remove_expiry:
+    :vartype EventType.shared_link_change_expiry: SharedLinkChangeExpiryType
+    :ivar EventType.shared_link_change_visibility:
+        (sharing) Changed visibility of shared link
+    :vartype EventType.shared_link_change_visibility: SharedLinkChangeVisibilityType
+    :ivar EventType.shared_link_copy:
+        (sharing) Added file/folder to Dropbox from shared link
+    :vartype EventType.shared_link_copy: SharedLinkCopyType
+    :ivar EventType.shared_link_create:
+        (sharing) Created shared link
+    :vartype EventType.shared_link_create: SharedLinkCreateType
+    :ivar EventType.shared_link_disable:
+        (sharing) Removed shared link
+    :vartype EventType.shared_link_disable: SharedLinkDisableType
+    :ivar EventType.shared_link_download:
+        (sharing) Downloaded file/folder from shared link
+    :vartype EventType.shared_link_download: SharedLinkDownloadType
+    :ivar EventType.shared_link_remove_expiry:
         (sharing) Removed shared link expiration date
-    :ivar SharedLinkRemoveVisitorType EventType.shared_link_remove_visitor:
+    :vartype EventType.shared_link_remove_expiry: SharedLinkRemoveExpiryType
+    :ivar EventType.shared_link_remove_visitor:
         (sharing) Removed link visitor
-    :ivar SharedLinkSettingsAddExpirationType
-        EventType.shared_link_settings_add_expiration: (sharing) Added an
-        expiration date to the shared link
-    :ivar SharedLinkSettingsAddPasswordType
-        EventType.shared_link_settings_add_password: (sharing) Added a password
-        to the shared link
-    :ivar SharedLinkSettingsAllowDownloadDisabledType
-        EventType.shared_link_settings_allow_download_disabled: (sharing)
-        Disabled downloads
-    :ivar SharedLinkSettingsAllowDownloadEnabledType
-        EventType.shared_link_settings_allow_download_enabled: (sharing) Enabled
-        downloads
-    :ivar SharedLinkSettingsChangeAudienceType
-        EventType.shared_link_settings_change_audience: (sharing) Changed the
-        audience of the shared link
-    :ivar SharedLinkSettingsChangeExpirationType
-        EventType.shared_link_settings_change_expiration: (sharing) Changed the
-        expiration date of the shared link
-    :ivar SharedLinkSettingsChangePasswordType
-        EventType.shared_link_settings_change_password: (sharing) Changed the
-        password of the shared link
-    :ivar SharedLinkSettingsRemoveExpirationType
-        EventType.shared_link_settings_remove_expiration: (sharing) Removed the
-        expiration date from the shared link
-    :ivar SharedLinkSettingsRemovePasswordType
-        EventType.shared_link_settings_remove_password: (sharing) Removed the
-        password from the shared link
-    :ivar SharedLinkShareType EventType.shared_link_share: (sharing) Added
-        members as audience of shared link
-    :ivar SharedLinkViewType EventType.shared_link_view: (sharing) Opened shared
-        link
-    :ivar SharedNoteOpenedType EventType.shared_note_opened: (sharing) Opened
-        shared Paper doc (deprecated, no longer logged)
-    :ivar ShmodelDisableDownloadsType EventType.shmodel_disable_downloads:
+    :vartype EventType.shared_link_remove_visitor: SharedLinkRemoveVisitorType
+    :ivar EventType.shared_link_settings_add_expiration:
+        (sharing) Added an expiration date to the shared link
+    :vartype EventType.shared_link_settings_add_expiration: SharedLinkSettingsAddExpirationType
+    :ivar EventType.shared_link_settings_add_password:
+        (sharing) Added a password to the shared link
+    :vartype EventType.shared_link_settings_add_password: SharedLinkSettingsAddPasswordType
+    :ivar EventType.shared_link_settings_allow_download_disabled:
+        (sharing) Disabled downloads
+    :vartype EventType.shared_link_settings_allow_download_disabled: SharedLinkSettingsAllowDownloadDisabledType
+    :ivar EventType.shared_link_settings_allow_download_enabled:
+        (sharing) Enabled downloads
+    :vartype EventType.shared_link_settings_allow_download_enabled: SharedLinkSettingsAllowDownloadEnabledType
+    :ivar EventType.shared_link_settings_change_audience:
+        (sharing) Changed the audience of the shared link
+    :vartype EventType.shared_link_settings_change_audience: SharedLinkSettingsChangeAudienceType
+    :ivar EventType.shared_link_settings_change_expiration:
+        (sharing) Changed the expiration date of the shared link
+    :vartype EventType.shared_link_settings_change_expiration: SharedLinkSettingsChangeExpirationType
+    :ivar EventType.shared_link_settings_change_password:
+        (sharing) Changed the password of the shared link
+    :vartype EventType.shared_link_settings_change_password: SharedLinkSettingsChangePasswordType
+    :ivar EventType.shared_link_settings_remove_expiration:
+        (sharing) Removed the expiration date from the shared link
+    :vartype EventType.shared_link_settings_remove_expiration: SharedLinkSettingsRemoveExpirationType
+    :ivar EventType.shared_link_settings_remove_password:
+        (sharing) Removed the password from the shared link
+    :vartype EventType.shared_link_settings_remove_password: SharedLinkSettingsRemovePasswordType
+    :ivar EventType.shared_link_share:
+        (sharing) Added members as audience of shared link
+    :vartype EventType.shared_link_share: SharedLinkShareType
+    :ivar EventType.shared_link_view:
+        (sharing) Opened shared link
+    :vartype EventType.shared_link_view: SharedLinkViewType
+    :ivar EventType.shared_note_opened:
+        (sharing) Opened shared Paper doc (deprecated, no longer logged)
+    :vartype EventType.shared_note_opened: SharedNoteOpenedType
+    :ivar EventType.shmodel_disable_downloads:
         (sharing) Disabled downloads for link (deprecated, no longer logged)
-    :ivar ShmodelEnableDownloadsType EventType.shmodel_enable_downloads:
+    :vartype EventType.shmodel_disable_downloads: ShmodelDisableDownloadsType
+    :ivar EventType.shmodel_enable_downloads:
         (sharing) Enabled downloads for link (deprecated, no longer logged)
-    :ivar ShmodelGroupShareType EventType.shmodel_group_share: (sharing) Shared
-        link with group (deprecated, no longer logged)
-    :ivar ShowcaseAccessGrantedType EventType.showcase_access_granted:
+    :vartype EventType.shmodel_enable_downloads: ShmodelEnableDownloadsType
+    :ivar EventType.shmodel_group_share:
+        (sharing) Shared link with group (deprecated, no longer logged)
+    :vartype EventType.shmodel_group_share: ShmodelGroupShareType
+    :ivar EventType.showcase_access_granted:
         (showcase) Granted access to showcase
-    :ivar ShowcaseAddMemberType EventType.showcase_add_member: (showcase) Added
-        member to showcase
-    :ivar ShowcaseArchivedType EventType.showcase_archived: (showcase) Archived
-        showcase
-    :ivar ShowcaseCreatedType EventType.showcase_created: (showcase) Created
-        showcase
-    :ivar ShowcaseDeleteCommentType EventType.showcase_delete_comment:
+    :vartype EventType.showcase_access_granted: ShowcaseAccessGrantedType
+    :ivar EventType.showcase_add_member:
+        (showcase) Added member to showcase
+    :vartype EventType.showcase_add_member: ShowcaseAddMemberType
+    :ivar EventType.showcase_archived:
+        (showcase) Archived showcase
+    :vartype EventType.showcase_archived: ShowcaseArchivedType
+    :ivar EventType.showcase_created:
+        (showcase) Created showcase
+    :vartype EventType.showcase_created: ShowcaseCreatedType
+    :ivar EventType.showcase_delete_comment:
         (showcase) Deleted showcase comment
-    :ivar ShowcaseEditedType EventType.showcase_edited: (showcase) Edited
-        showcase
-    :ivar ShowcaseEditCommentType EventType.showcase_edit_comment: (showcase)
-        Edited showcase comment
-    :ivar ShowcaseFileAddedType EventType.showcase_file_added: (showcase) Added
-        file to showcase
-    :ivar ShowcaseFileDownloadType EventType.showcase_file_download: (showcase)
-        Downloaded file from showcase
-    :ivar ShowcaseFileRemovedType EventType.showcase_file_removed: (showcase)
-        Removed file from showcase
-    :ivar ShowcaseFileViewType EventType.showcase_file_view: (showcase) Viewed
-        file in showcase
-    :ivar ShowcasePermanentlyDeletedType EventType.showcase_permanently_deleted:
+    :vartype EventType.showcase_delete_comment: ShowcaseDeleteCommentType
+    :ivar EventType.showcase_edited:
+        (showcase) Edited showcase
+    :vartype EventType.showcase_edited: ShowcaseEditedType
+    :ivar EventType.showcase_edit_comment:
+        (showcase) Edited showcase comment
+    :vartype EventType.showcase_edit_comment: ShowcaseEditCommentType
+    :ivar EventType.showcase_file_added:
+        (showcase) Added file to showcase
+    :vartype EventType.showcase_file_added: ShowcaseFileAddedType
+    :ivar EventType.showcase_file_download:
+        (showcase) Downloaded file from showcase
+    :vartype EventType.showcase_file_download: ShowcaseFileDownloadType
+    :ivar EventType.showcase_file_removed:
+        (showcase) Removed file from showcase
+    :vartype EventType.showcase_file_removed: ShowcaseFileRemovedType
+    :ivar EventType.showcase_file_view:
+        (showcase) Viewed file in showcase
+    :vartype EventType.showcase_file_view: ShowcaseFileViewType
+    :ivar EventType.showcase_permanently_deleted:
         (showcase) Permanently deleted showcase
-    :ivar ShowcasePostCommentType EventType.showcase_post_comment: (showcase)
-        Added showcase comment
-    :ivar ShowcaseRemoveMemberType EventType.showcase_remove_member: (showcase)
-        Removed member from showcase
-    :ivar ShowcaseRenamedType EventType.showcase_renamed: (showcase) Renamed
-        showcase
-    :ivar ShowcaseRequestAccessType EventType.showcase_request_access:
+    :vartype EventType.showcase_permanently_deleted: ShowcasePermanentlyDeletedType
+    :ivar EventType.showcase_post_comment:
+        (showcase) Added showcase comment
+    :vartype EventType.showcase_post_comment: ShowcasePostCommentType
+    :ivar EventType.showcase_remove_member:
+        (showcase) Removed member from showcase
+    :vartype EventType.showcase_remove_member: ShowcaseRemoveMemberType
+    :ivar EventType.showcase_renamed:
+        (showcase) Renamed showcase
+    :vartype EventType.showcase_renamed: ShowcaseRenamedType
+    :ivar EventType.showcase_request_access:
         (showcase) Requested access to showcase
-    :ivar ShowcaseResolveCommentType EventType.showcase_resolve_comment:
+    :vartype EventType.showcase_request_access: ShowcaseRequestAccessType
+    :ivar EventType.showcase_resolve_comment:
         (showcase) Resolved showcase comment
-    :ivar ShowcaseRestoredType EventType.showcase_restored: (showcase)
-        Unarchived showcase
-    :ivar ShowcaseTrashedType EventType.showcase_trashed: (showcase) Deleted
-        showcase
-    :ivar ShowcaseTrashedDeprecatedType EventType.showcase_trashed_deprecated:
+    :vartype EventType.showcase_resolve_comment: ShowcaseResolveCommentType
+    :ivar EventType.showcase_restored:
+        (showcase) Unarchived showcase
+    :vartype EventType.showcase_restored: ShowcaseRestoredType
+    :ivar EventType.showcase_trashed:
+        (showcase) Deleted showcase
+    :vartype EventType.showcase_trashed: ShowcaseTrashedType
+    :ivar EventType.showcase_trashed_deprecated:
         (showcase) Deleted showcase (old version) (deprecated, replaced by
         'Deleted showcase')
-    :ivar ShowcaseUnresolveCommentType EventType.showcase_unresolve_comment:
+    :vartype EventType.showcase_trashed_deprecated: ShowcaseTrashedDeprecatedType
+    :ivar EventType.showcase_unresolve_comment:
         (showcase) Unresolved showcase comment
-    :ivar ShowcaseUntrashedType EventType.showcase_untrashed: (showcase)
-        Restored showcase
-    :ivar ShowcaseUntrashedDeprecatedType
-        EventType.showcase_untrashed_deprecated: (showcase) Restored showcase
-        (old version) (deprecated, replaced by 'Restored showcase')
-    :ivar ShowcaseViewType EventType.showcase_view: (showcase) Viewed showcase
-    :ivar SignSignatureRequestCanceledType
-        EventType.sign_signature_request_canceled: (signatures) Canceled
-        signature request
-    :ivar SignSignatureRequestCompletedType
-        EventType.sign_signature_request_completed: (signatures) Completed
-        signature request
-    :ivar SignSignatureRequestDeclinedType
-        EventType.sign_signature_request_declined: (signatures) Declined
-        signature request
-    :ivar SignSignatureRequestOpenedType
-        EventType.sign_signature_request_opened: (signatures) Opened signature
-        request
-    :ivar SignSignatureRequestReminderSentType
-        EventType.sign_signature_request_reminder_sent: (signatures) Sent
-        signature request reminder
-    :ivar SignSignatureRequestSentType EventType.sign_signature_request_sent:
+    :vartype EventType.showcase_unresolve_comment: ShowcaseUnresolveCommentType
+    :ivar EventType.showcase_untrashed:
+        (showcase) Restored showcase
+    :vartype EventType.showcase_untrashed: ShowcaseUntrashedType
+    :ivar EventType.showcase_untrashed_deprecated:
+        (showcase) Restored showcase (old version) (deprecated, replaced by
+        'Restored showcase')
+    :vartype EventType.showcase_untrashed_deprecated: ShowcaseUntrashedDeprecatedType
+    :ivar EventType.showcase_view:
+        (showcase) Viewed showcase
+    :vartype EventType.showcase_view: ShowcaseViewType
+    :ivar EventType.sign_signature_request_canceled:
+        (signatures) Canceled signature request
+    :vartype EventType.sign_signature_request_canceled: SignSignatureRequestCanceledType
+    :ivar EventType.sign_signature_request_completed:
+        (signatures) Completed signature request
+    :vartype EventType.sign_signature_request_completed: SignSignatureRequestCompletedType
+    :ivar EventType.sign_signature_request_declined:
+        (signatures) Declined signature request
+    :vartype EventType.sign_signature_request_declined: SignSignatureRequestDeclinedType
+    :ivar EventType.sign_signature_request_opened:
+        (signatures) Opened signature request
+    :vartype EventType.sign_signature_request_opened: SignSignatureRequestOpenedType
+    :ivar EventType.sign_signature_request_reminder_sent:
+        (signatures) Sent signature request reminder
+    :vartype EventType.sign_signature_request_reminder_sent: SignSignatureRequestReminderSentType
+    :ivar EventType.sign_signature_request_sent:
         (signatures) Sent signature request
-    :ivar SignTemplateCreatedType EventType.sign_template_created: (signatures)
-        Created template
-    :ivar SignTemplateSharedType EventType.sign_template_shared: (signatures)
-        Shared template
-    :ivar RiscSecurityEventType EventType.risc_security_event: (sso) RISC
-        security event received from external provider
-    :ivar SsoAddCertType EventType.sso_add_cert: (sso) Added X.509 certificate
-        for SSO
-    :ivar SsoAddLoginUrlType EventType.sso_add_login_url: (sso) Added sign-in
-        URL for SSO
-    :ivar SsoAddLogoutUrlType EventType.sso_add_logout_url: (sso) Added sign-out
-        URL for SSO
-    :ivar SsoChangeCertType EventType.sso_change_cert: (sso) Changed X.509
-        certificate for SSO
-    :ivar SsoChangeLoginUrlType EventType.sso_change_login_url: (sso) Changed
-        sign-in URL for SSO
-    :ivar SsoChangeLogoutUrlType EventType.sso_change_logout_url: (sso) Changed
-        sign-out URL for SSO
-    :ivar SsoChangeSamlIdentityModeType EventType.sso_change_saml_identity_mode:
+    :vartype EventType.sign_signature_request_sent: SignSignatureRequestSentType
+    :ivar EventType.sign_template_created:
+        (signatures) Created template
+    :vartype EventType.sign_template_created: SignTemplateCreatedType
+    :ivar EventType.sign_template_shared:
+        (signatures) Shared template
+    :vartype EventType.sign_template_shared: SignTemplateSharedType
+    :ivar EventType.risc_security_event:
+        (sso) RISC security event received from external provider
+    :vartype EventType.risc_security_event: RiscSecurityEventType
+    :ivar EventType.sso_add_cert:
+        (sso) Added X.509 certificate for SSO
+    :vartype EventType.sso_add_cert: SsoAddCertType
+    :ivar EventType.sso_add_login_url:
+        (sso) Added sign-in URL for SSO
+    :vartype EventType.sso_add_login_url: SsoAddLoginUrlType
+    :ivar EventType.sso_add_logout_url:
+        (sso) Added sign-out URL for SSO
+    :vartype EventType.sso_add_logout_url: SsoAddLogoutUrlType
+    :ivar EventType.sso_change_cert:
+        (sso) Changed X.509 certificate for SSO
+    :vartype EventType.sso_change_cert: SsoChangeCertType
+    :ivar EventType.sso_change_login_url:
+        (sso) Changed sign-in URL for SSO
+    :vartype EventType.sso_change_login_url: SsoChangeLoginUrlType
+    :ivar EventType.sso_change_logout_url:
+        (sso) Changed sign-out URL for SSO
+    :vartype EventType.sso_change_logout_url: SsoChangeLogoutUrlType
+    :ivar EventType.sso_change_saml_identity_mode:
         (sso) Changed SAML identity mode for SSO
-    :ivar SsoRemoveCertType EventType.sso_remove_cert: (sso) Removed X.509
-        certificate for SSO
-    :ivar SsoRemoveLoginUrlType EventType.sso_remove_login_url: (sso) Removed
-        sign-in URL for SSO
-    :ivar SsoRemoveLogoutUrlType EventType.sso_remove_logout_url: (sso) Removed
-        sign-out URL for SSO
-    :ivar TeamFolderChangeStatusType EventType.team_folder_change_status:
+    :vartype EventType.sso_change_saml_identity_mode: SsoChangeSamlIdentityModeType
+    :ivar EventType.sso_remove_cert:
+        (sso) Removed X.509 certificate for SSO
+    :vartype EventType.sso_remove_cert: SsoRemoveCertType
+    :ivar EventType.sso_remove_login_url:
+        (sso) Removed sign-in URL for SSO
+    :vartype EventType.sso_remove_login_url: SsoRemoveLoginUrlType
+    :ivar EventType.sso_remove_logout_url:
+        (sso) Removed sign-out URL for SSO
+    :vartype EventType.sso_remove_logout_url: SsoRemoveLogoutUrlType
+    :ivar EventType.team_folder_change_status:
         (team_folders) Changed archival status of team folder
-    :ivar TeamFolderCreateType EventType.team_folder_create: (team_folders)
-        Created team folder in active status
-    :ivar TeamFolderDowngradeType EventType.team_folder_downgrade:
+    :vartype EventType.team_folder_change_status: TeamFolderChangeStatusType
+    :ivar EventType.team_folder_create:
+        (team_folders) Created team folder in active status
+    :vartype EventType.team_folder_create: TeamFolderCreateType
+    :ivar EventType.team_folder_downgrade:
         (team_folders) Downgraded team folder to regular shared folder
-    :ivar TeamFolderPermanentlyDeleteType
-        EventType.team_folder_permanently_delete: (team_folders) Permanently
-        deleted archived team folder
-    :ivar TeamFolderRenameType EventType.team_folder_rename: (team_folders)
-        Renamed active/archived team folder
-    :ivar TeamFolderSpaceLimitsChangeCapsTypeType
-        EventType.team_folder_space_limits_change_caps_type: (team_folders)
-        Changed team folder space limit enforcement type
-    :ivar TeamFolderSpaceLimitsChangeLimitType
-        EventType.team_folder_space_limits_change_limit: (team_folders) Changed
-        team folder space limit
-    :ivar TeamFolderSpaceLimitsChangeNotificationTargetType
-        EventType.team_folder_space_limits_change_notification_target:
+    :vartype EventType.team_folder_downgrade: TeamFolderDowngradeType
+    :ivar EventType.team_folder_permanently_delete:
+        (team_folders) Permanently deleted archived team folder
+    :vartype EventType.team_folder_permanently_delete: TeamFolderPermanentlyDeleteType
+    :ivar EventType.team_folder_rename:
+        (team_folders) Renamed active/archived team folder
+    :vartype EventType.team_folder_rename: TeamFolderRenameType
+    :ivar EventType.team_folder_space_limits_change_caps_type:
+        (team_folders) Changed team folder space limit enforcement type
+    :vartype EventType.team_folder_space_limits_change_caps_type: TeamFolderSpaceLimitsChangeCapsTypeType
+    :ivar EventType.team_folder_space_limits_change_limit:
+        (team_folders) Changed team folder space limit
+    :vartype EventType.team_folder_space_limits_change_limit: TeamFolderSpaceLimitsChangeLimitType
+    :ivar EventType.team_folder_space_limits_change_notification_target:
         (team_folders) Changed team folder space limit notification target
-    :ivar TeamSelectiveSyncSettingsChangedType
-        EventType.team_selective_sync_settings_changed: (team_folders) Changed
-        sync default
-    :ivar AccountCaptureChangePolicyType
-        EventType.account_capture_change_policy: (team_policies) Changed account
-        capture setting on team domain
-    :ivar AdminEmailRemindersChangedType
-        EventType.admin_email_reminders_changed: (team_policies) Changed admin
-        reminder settings for requests to join the team
-    :ivar AiThirdPartySharingDropboxBasePolicyChangedType
-        EventType.ai_third_party_sharing_dropbox_base_policy_changed:
+    :vartype EventType.team_folder_space_limits_change_notification_target: TeamFolderSpaceLimitsChangeNotificationTargetType
+    :ivar EventType.team_selective_sync_settings_changed:
+        (team_folders) Changed sync default
+    :vartype EventType.team_selective_sync_settings_changed: TeamSelectiveSyncSettingsChangedType
+    :ivar EventType.account_capture_change_policy:
+        (team_policies) Changed account capture setting on team domain
+    :vartype EventType.account_capture_change_policy: AccountCaptureChangePolicyType
+    :ivar EventType.admin_email_reminders_changed:
+        (team_policies) Changed admin reminder settings for requests to join the
+        team
+    :vartype EventType.admin_email_reminders_changed: AdminEmailRemindersChangedType
+    :ivar EventType.ai_third_party_sharing_dropbox_base_policy_changed:
         (team_policies) Changed AI third party sharing policy for team
-    :ivar AllowDownloadDisabledType EventType.allow_download_disabled:
+    :vartype EventType.ai_third_party_sharing_dropbox_base_policy_changed: AiThirdPartySharingDropboxBasePolicyChangedType
+    :ivar EventType.allow_download_disabled:
         (team_policies) Disabled downloads (deprecated, no longer logged)
-    :ivar AllowDownloadEnabledType EventType.allow_download_enabled:
+    :vartype EventType.allow_download_disabled: AllowDownloadDisabledType
+    :ivar EventType.allow_download_enabled:
         (team_policies) Enabled downloads (deprecated, no longer logged)
-    :ivar AppleLoginChangePolicyType EventType.apple_login_change_policy:
+    :vartype EventType.allow_download_enabled: AllowDownloadEnabledType
+    :ivar EventType.apple_login_change_policy:
         (team_policies) Enabled/disabled Apple login for team
-    :ivar AppPermissionsChangedType EventType.app_permissions_changed:
+    :vartype EventType.apple_login_change_policy: AppleLoginChangePolicyType
+    :ivar EventType.app_permissions_changed:
         (team_policies) Changed app permissions
-    :ivar CameraUploadsPolicyChangedType
-        EventType.camera_uploads_policy_changed: (team_policies) Changed camera
-        uploads setting for team
-    :ivar CaptureTeamSpacePolicyChangedType
-        EventType.capture_team_space_policy_changed: (team_policies) Changed
-        Capture team space policy for team
-    :ivar CaptureTranscriptPolicyChangedType
-        EventType.capture_transcript_policy_changed: (team_policies) Changed
-        Capture transcription policy for team
-    :ivar ClassificationChangePolicyType EventType.classification_change_policy:
+    :vartype EventType.app_permissions_changed: AppPermissionsChangedType
+    :ivar EventType.camera_uploads_policy_changed:
+        (team_policies) Changed camera uploads setting for team
+    :vartype EventType.camera_uploads_policy_changed: CameraUploadsPolicyChangedType
+    :ivar EventType.capture_team_space_policy_changed:
+        (team_policies) Changed Capture team space policy for team
+    :vartype EventType.capture_team_space_policy_changed: CaptureTeamSpacePolicyChangedType
+    :ivar EventType.capture_transcript_policy_changed:
+        (team_policies) Changed Capture transcription policy for team
+    :vartype EventType.capture_transcript_policy_changed: CaptureTranscriptPolicyChangedType
+    :ivar EventType.classification_change_policy:
         (team_policies) Changed classification policy for team
-    :ivar ComputerBackupPolicyChangedType
-        EventType.computer_backup_policy_changed: (team_policies) Changed
-        computer backup policy for team
-    :ivar ContentAdministrationPolicyChangedType
-        EventType.content_administration_policy_changed: (team_policies) Changed
-        content management setting
-    :ivar ContentDeletionProtectionChangePolicyType
-        EventType.content_deletion_protection_change_policy: (team_policies)
-        Changed content deletion protection policy for team
-    :ivar DashExternalSharingPolicyChangedType
-        EventType.dash_external_sharing_policy_changed: (team_policies) Changed
-        Dash external sharing policy for team
-    :ivar DataPlacementRestrictionChangePolicyType
-        EventType.data_placement_restriction_change_policy: (team_policies) Set
-        restrictions on data center locations where team data resides
-    :ivar DataPlacementRestrictionSatisfyPolicyType
-        EventType.data_placement_restriction_satisfy_policy: (team_policies)
-        Completed restrictions on data center locations where team data resides
-    :ivar DeviceApprovalsAddExceptionType
-        EventType.device_approvals_add_exception: (team_policies) Added members
-        to device approvals exception list
-    :ivar DeviceApprovalsChangeDesktopPolicyType
-        EventType.device_approvals_change_desktop_policy: (team_policies)
-        Set/removed limit on number of computers member can link to team Dropbox
-        account
-    :ivar DeviceApprovalsChangeMobilePolicyType
-        EventType.device_approvals_change_mobile_policy: (team_policies)
-        Set/removed limit on number of mobile devices member can link to team
-        Dropbox account
-    :ivar DeviceApprovalsChangeOverageActionType
-        EventType.device_approvals_change_overage_action: (team_policies)
-        Changed device approvals setting when member is over limit
-    :ivar DeviceApprovalsChangeUnlinkActionType
-        EventType.device_approvals_change_unlink_action: (team_policies) Changed
-        device approvals setting when member unlinks approved device
-    :ivar DeviceApprovalsRemoveExceptionType
-        EventType.device_approvals_remove_exception: (team_policies) Removed
-        members from device approvals exception list
-    :ivar DirectoryRestrictionsAddMembersType
-        EventType.directory_restrictions_add_members: (team_policies) Added
-        members to directory restrictions list
-    :ivar DirectoryRestrictionsRemoveMembersType
-        EventType.directory_restrictions_remove_members: (team_policies) Removed
-        members from directory restrictions list
-    :ivar DropboxPasswordsPolicyChangedType
-        EventType.dropbox_passwords_policy_changed: (team_policies) Changed
-        Dropbox Passwords policy for team
-    :ivar EmailIngestPolicyChangedType EventType.email_ingest_policy_changed:
+    :vartype EventType.classification_change_policy: ClassificationChangePolicyType
+    :ivar EventType.computer_backup_policy_changed:
+        (team_policies) Changed computer backup policy for team
+    :vartype EventType.computer_backup_policy_changed: ComputerBackupPolicyChangedType
+    :ivar EventType.content_administration_policy_changed:
+        (team_policies) Changed content management setting
+    :vartype EventType.content_administration_policy_changed: ContentAdministrationPolicyChangedType
+    :ivar EventType.content_deletion_protection_change_policy:
+        (team_policies) Changed content deletion protection policy for team
+    :vartype EventType.content_deletion_protection_change_policy: ContentDeletionProtectionChangePolicyType
+    :ivar EventType.dash_external_sharing_policy_changed:
+        (team_policies) Changed Dash external sharing policy for team
+    :vartype EventType.dash_external_sharing_policy_changed: DashExternalSharingPolicyChangedType
+    :ivar EventType.data_placement_restriction_change_policy:
+        (team_policies) Set restrictions on data center locations where team
+        data resides
+    :vartype EventType.data_placement_restriction_change_policy: DataPlacementRestrictionChangePolicyType
+    :ivar EventType.data_placement_restriction_satisfy_policy:
+        (team_policies) Completed restrictions on data center locations where
+        team data resides
+    :vartype EventType.data_placement_restriction_satisfy_policy: DataPlacementRestrictionSatisfyPolicyType
+    :ivar EventType.device_approvals_add_exception:
+        (team_policies) Added members to device approvals exception list
+    :vartype EventType.device_approvals_add_exception: DeviceApprovalsAddExceptionType
+    :ivar EventType.device_approvals_change_desktop_policy:
+        (team_policies) Set/removed limit on number of computers member can link
+        to team Dropbox account
+    :vartype EventType.device_approvals_change_desktop_policy: DeviceApprovalsChangeDesktopPolicyType
+    :ivar EventType.device_approvals_change_mobile_policy:
+        (team_policies) Set/removed limit on number of mobile devices member can
+        link to team Dropbox account
+    :vartype EventType.device_approvals_change_mobile_policy: DeviceApprovalsChangeMobilePolicyType
+    :ivar EventType.device_approvals_change_overage_action:
+        (team_policies) Changed device approvals setting when member is over
+        limit
+    :vartype EventType.device_approvals_change_overage_action: DeviceApprovalsChangeOverageActionType
+    :ivar EventType.device_approvals_change_unlink_action:
+        (team_policies) Changed device approvals setting when member unlinks
+        approved device
+    :vartype EventType.device_approvals_change_unlink_action: DeviceApprovalsChangeUnlinkActionType
+    :ivar EventType.device_approvals_remove_exception:
+        (team_policies) Removed members from device approvals exception list
+    :vartype EventType.device_approvals_remove_exception: DeviceApprovalsRemoveExceptionType
+    :ivar EventType.directory_restrictions_add_members:
+        (team_policies) Added members to directory restrictions list
+    :vartype EventType.directory_restrictions_add_members: DirectoryRestrictionsAddMembersType
+    :ivar EventType.directory_restrictions_remove_members:
+        (team_policies) Removed members from directory restrictions list
+    :vartype EventType.directory_restrictions_remove_members: DirectoryRestrictionsRemoveMembersType
+    :ivar EventType.dropbox_passwords_policy_changed:
+        (team_policies) Changed Dropbox Passwords policy for team
+    :vartype EventType.dropbox_passwords_policy_changed: DropboxPasswordsPolicyChangedType
+    :ivar EventType.email_ingest_policy_changed:
         (team_policies) Changed email to Dropbox policy for team
-    :ivar EmmAddExceptionType EventType.emm_add_exception: (team_policies) Added
-        members to EMM exception list
-    :ivar EmmChangePolicyType EventType.emm_change_policy: (team_policies)
-        Enabled/disabled enterprise mobility management for members
-    :ivar EmmRemoveExceptionType EventType.emm_remove_exception: (team_policies)
-        Removed members from EMM exception list
-    :ivar ExtendedVersionHistoryChangePolicyType
-        EventType.extended_version_history_change_policy: (team_policies)
-        Accepted/opted out of extended version history
-    :ivar ExternalDriveBackupPolicyChangedType
-        EventType.external_drive_backup_policy_changed: (team_policies) Changed
-        external drive backup policy for team
-    :ivar FileCommentsChangePolicyType EventType.file_comments_change_policy:
+    :vartype EventType.email_ingest_policy_changed: EmailIngestPolicyChangedType
+    :ivar EventType.emm_add_exception:
+        (team_policies) Added members to EMM exception list
+    :vartype EventType.emm_add_exception: EmmAddExceptionType
+    :ivar EventType.emm_change_policy:
+        (team_policies) Enabled/disabled enterprise mobility management for
+        members
+    :vartype EventType.emm_change_policy: EmmChangePolicyType
+    :ivar EventType.emm_remove_exception:
+        (team_policies) Removed members from EMM exception list
+    :vartype EventType.emm_remove_exception: EmmRemoveExceptionType
+    :ivar EventType.extended_version_history_change_policy:
+        (team_policies) Accepted/opted out of extended version history
+    :vartype EventType.extended_version_history_change_policy: ExtendedVersionHistoryChangePolicyType
+    :ivar EventType.external_drive_backup_policy_changed:
+        (team_policies) Changed external drive backup policy for team
+    :vartype EventType.external_drive_backup_policy_changed: ExternalDriveBackupPolicyChangedType
+    :ivar EventType.file_comments_change_policy:
         (team_policies) Enabled/disabled commenting on team files
-    :ivar FileLockingPolicyChangedType EventType.file_locking_policy_changed:
+    :vartype EventType.file_comments_change_policy: FileCommentsChangePolicyType
+    :ivar EventType.file_locking_policy_changed:
         (team_policies) Changed file locking policy for team
-    :ivar FileProviderMigrationPolicyChangedType
-        EventType.file_provider_migration_policy_changed: (team_policies)
-        Changed File Provider Migration policy for team
-    :ivar FileRequestsChangePolicyType EventType.file_requests_change_policy:
+    :vartype EventType.file_locking_policy_changed: FileLockingPolicyChangedType
+    :ivar EventType.file_provider_migration_policy_changed:
+        (team_policies) Changed File Provider Migration policy for team
+    :vartype EventType.file_provider_migration_policy_changed: FileProviderMigrationPolicyChangedType
+    :ivar EventType.file_requests_change_policy:
         (team_policies) Enabled/disabled file requests
-    :ivar FileRequestsEmailsEnabledType EventType.file_requests_emails_enabled:
+    :vartype EventType.file_requests_change_policy: FileRequestsChangePolicyType
+    :ivar EventType.file_requests_emails_enabled:
         (team_policies) Enabled file request emails for everyone (deprecated, no
         longer logged)
-    :ivar FileRequestsEmailsRestrictedToTeamOnlyType
-        EventType.file_requests_emails_restricted_to_team_only: (team_policies)
-        Enabled file request emails for team (deprecated, no longer logged)
-    :ivar FileTransfersPolicyChangedType
-        EventType.file_transfers_policy_changed: (team_policies) Changed file
-        transfers policy for team
-    :ivar FlexibleFileNamesPolicyChangedType
-        EventType.flexible_file_names_policy_changed: (team_policies) Changed
-        flexible file names policy for team
-    :ivar FolderLinkRestrictionPolicyChangedType
-        EventType.folder_link_restriction_policy_changed: (team_policies)
-        Changed folder link restrictions policy for team
-    :ivar GoogleSsoChangePolicyType EventType.google_sso_change_policy:
+    :vartype EventType.file_requests_emails_enabled: FileRequestsEmailsEnabledType
+    :ivar EventType.file_requests_emails_restricted_to_team_only:
+        (team_policies) Enabled file request emails for team (deprecated, no
+        longer logged)
+    :vartype EventType.file_requests_emails_restricted_to_team_only: FileRequestsEmailsRestrictedToTeamOnlyType
+    :ivar EventType.file_transfers_policy_changed:
+        (team_policies) Changed file transfers policy for team
+    :vartype EventType.file_transfers_policy_changed: FileTransfersPolicyChangedType
+    :ivar EventType.flexible_file_names_policy_changed:
+        (team_policies) Changed flexible file names policy for team
+    :vartype EventType.flexible_file_names_policy_changed: FlexibleFileNamesPolicyChangedType
+    :ivar EventType.folder_link_restriction_policy_changed:
+        (team_policies) Changed folder link restrictions policy for team
+    :vartype EventType.folder_link_restriction_policy_changed: FolderLinkRestrictionPolicyChangedType
+    :ivar EventType.google_sso_change_policy:
         (team_policies) Enabled/disabled Google single sign-on for team
-    :ivar GroupUserManagementChangePolicyType
-        EventType.group_user_management_change_policy: (team_policies) Changed
-        who can create groups
-    :ivar IntegrationPolicyChangedType EventType.integration_policy_changed:
+    :vartype EventType.google_sso_change_policy: GoogleSsoChangePolicyType
+    :ivar EventType.group_user_management_change_policy:
+        (team_policies) Changed who can create groups
+    :vartype EventType.group_user_management_change_policy: GroupUserManagementChangePolicyType
+    :ivar EventType.integration_policy_changed:
         (team_policies) Changed integration policy for team
-    :ivar InviteAcceptanceEmailPolicyChangedType
-        EventType.invite_acceptance_email_policy_changed: (team_policies)
-        Changed invite accept email policy for team
-    :ivar MediaHubAddingPeoplePolicyChangedType
-        EventType.media_hub_adding_people_policy_changed: (team_policies)
-        Changed the policy for adding people to Media Hub content
-    :ivar MediaHubDownloadPolicyChangedType
-        EventType.media_hub_download_policy_changed: (team_policies) Changed the
-        policy for downloading Media Hub content
-    :ivar MediaHubLinkSharingPolicyChangedType
-        EventType.media_hub_link_sharing_policy_changed: (team_policies) Changed
-        the policy for sharing Media Hub content
-    :ivar MemberRequestsChangePolicyType
-        EventType.member_requests_change_policy: (team_policies) Changed whether
-        users can find team when not invited
-    :ivar MemberSendInvitePolicyChangedType
-        EventType.member_send_invite_policy_changed: (team_policies) Changed
-        member send invite policy for team
-    :ivar MemberSpaceLimitsAddExceptionType
-        EventType.member_space_limits_add_exception: (team_policies) Added
-        members to member space limit exception list
-    :ivar MemberSpaceLimitsChangeCapsTypePolicyType
-        EventType.member_space_limits_change_caps_type_policy: (team_policies)
-        Changed member space limit type for team
-    :ivar MemberSpaceLimitsChangePolicyType
-        EventType.member_space_limits_change_policy: (team_policies) Changed
-        team default member space limit
-    :ivar MemberSpaceLimitsRemoveExceptionType
-        EventType.member_space_limits_remove_exception: (team_policies) Removed
-        members from member space limit exception list
-    :ivar MemberSuggestionsChangePolicyType
-        EventType.member_suggestions_change_policy: (team_policies)
-        Enabled/disabled option for team members to suggest people to add to
-        team
-    :ivar MicrosoftLoginChangePolicyType
-        EventType.microsoft_login_change_policy: (team_policies)
-        Enabled/disabled Microsoft login for team
-    :ivar MicrosoftOfficeAddinChangePolicyType
-        EventType.microsoft_office_addin_change_policy: (team_policies)
-        Enabled/disabled Microsoft Office add-in
-    :ivar MultiTeamIdentityPolicyChangedType
-        EventType.multi_team_identity_policy_changed: (team_policies) Changed
-        multi-team identity policy for team
-    :ivar NetworkControlChangePolicyType
-        EventType.network_control_change_policy: (team_policies)
-        Enabled/disabled network control
-    :ivar PaperChangeDeploymentPolicyType
-        EventType.paper_change_deployment_policy: (team_policies) Changed
-        whether Dropbox Paper, when enabled, is deployed to all members or to
-        specific members
-    :ivar PaperChangeMemberLinkPolicyType
-        EventType.paper_change_member_link_policy: (team_policies) Changed
-        whether non-members can view Paper docs with link (deprecated, no longer
-        logged)
-    :ivar PaperChangeMemberPolicyType EventType.paper_change_member_policy:
+    :vartype EventType.integration_policy_changed: IntegrationPolicyChangedType
+    :ivar EventType.invite_acceptance_email_policy_changed:
+        (team_policies) Changed invite accept email policy for team
+    :vartype EventType.invite_acceptance_email_policy_changed: InviteAcceptanceEmailPolicyChangedType
+    :ivar EventType.media_hub_adding_people_policy_changed:
+        (team_policies) Changed the policy for adding people to Media Hub
+        content
+    :vartype EventType.media_hub_adding_people_policy_changed: MediaHubAddingPeoplePolicyChangedType
+    :ivar EventType.media_hub_download_policy_changed:
+        (team_policies) Changed the policy for downloading Media Hub content
+    :vartype EventType.media_hub_download_policy_changed: MediaHubDownloadPolicyChangedType
+    :ivar EventType.media_hub_link_sharing_policy_changed:
+        (team_policies) Changed the policy for sharing Media Hub content
+    :vartype EventType.media_hub_link_sharing_policy_changed: MediaHubLinkSharingPolicyChangedType
+    :ivar EventType.member_requests_change_policy:
+        (team_policies) Changed whether users can find team when not invited
+    :vartype EventType.member_requests_change_policy: MemberRequestsChangePolicyType
+    :ivar EventType.member_send_invite_policy_changed:
+        (team_policies) Changed member send invite policy for team
+    :vartype EventType.member_send_invite_policy_changed: MemberSendInvitePolicyChangedType
+    :ivar EventType.member_space_limits_add_exception:
+        (team_policies) Added members to member space limit exception list
+    :vartype EventType.member_space_limits_add_exception: MemberSpaceLimitsAddExceptionType
+    :ivar EventType.member_space_limits_change_caps_type_policy:
+        (team_policies) Changed member space limit type for team
+    :vartype EventType.member_space_limits_change_caps_type_policy: MemberSpaceLimitsChangeCapsTypePolicyType
+    :ivar EventType.member_space_limits_change_policy:
+        (team_policies) Changed team default member space limit
+    :vartype EventType.member_space_limits_change_policy: MemberSpaceLimitsChangePolicyType
+    :ivar EventType.member_space_limits_remove_exception:
+        (team_policies) Removed members from member space limit exception list
+    :vartype EventType.member_space_limits_remove_exception: MemberSpaceLimitsRemoveExceptionType
+    :ivar EventType.member_suggestions_change_policy:
+        (team_policies) Enabled/disabled option for team members to suggest
+        people to add to team
+    :vartype EventType.member_suggestions_change_policy: MemberSuggestionsChangePolicyType
+    :ivar EventType.microsoft_login_change_policy:
+        (team_policies) Enabled/disabled Microsoft login for team
+    :vartype EventType.microsoft_login_change_policy: MicrosoftLoginChangePolicyType
+    :ivar EventType.microsoft_office_addin_change_policy:
+        (team_policies) Enabled/disabled Microsoft Office add-in
+    :vartype EventType.microsoft_office_addin_change_policy: MicrosoftOfficeAddinChangePolicyType
+    :ivar EventType.multi_team_identity_policy_changed:
+        (team_policies) Changed multi-team identity policy for team
+    :vartype EventType.multi_team_identity_policy_changed: MultiTeamIdentityPolicyChangedType
+    :ivar EventType.network_control_change_policy:
+        (team_policies) Enabled/disabled network control
+    :vartype EventType.network_control_change_policy: NetworkControlChangePolicyType
+    :ivar EventType.paper_change_deployment_policy:
+        (team_policies) Changed whether Dropbox Paper, when enabled, is deployed
+        to all members or to specific members
+    :vartype EventType.paper_change_deployment_policy: PaperChangeDeploymentPolicyType
+    :ivar EventType.paper_change_member_link_policy:
+        (team_policies) Changed whether non-members can view Paper docs with
+        link (deprecated, no longer logged)
+    :vartype EventType.paper_change_member_link_policy: PaperChangeMemberLinkPolicyType
+    :ivar EventType.paper_change_member_policy:
         (team_policies) Changed whether members can share Paper docs outside
         team, and if docs are accessible only by team members or anyone by
         default
-    :ivar PaperChangePolicyType EventType.paper_change_policy: (team_policies)
-        Enabled/disabled Dropbox Paper for team
-    :ivar PaperDefaultFolderPolicyChangedType
-        EventType.paper_default_folder_policy_changed: (team_policies) Changed
-        Paper Default Folder Policy setting for team
-    :ivar PaperDesktopPolicyChangedType EventType.paper_desktop_policy_changed:
+    :vartype EventType.paper_change_member_policy: PaperChangeMemberPolicyType
+    :ivar EventType.paper_change_policy:
+        (team_policies) Enabled/disabled Dropbox Paper for team
+    :vartype EventType.paper_change_policy: PaperChangePolicyType
+    :ivar EventType.paper_default_folder_policy_changed:
+        (team_policies) Changed Paper Default Folder Policy setting for team
+    :vartype EventType.paper_default_folder_policy_changed: PaperDefaultFolderPolicyChangedType
+    :ivar EventType.paper_desktop_policy_changed:
         (team_policies) Enabled/disabled Paper Desktop for team
-    :ivar PaperEnabledUsersGroupAdditionType
-        EventType.paper_enabled_users_group_addition: (team_policies) Added
-        users to Paper-enabled users list
-    :ivar PaperEnabledUsersGroupRemovalType
-        EventType.paper_enabled_users_group_removal: (team_policies) Removed
-        users from Paper-enabled users list
-    :ivar PasskeyLoginPolicyChangedType EventType.passkey_login_policy_changed:
+    :vartype EventType.paper_desktop_policy_changed: PaperDesktopPolicyChangedType
+    :ivar EventType.paper_enabled_users_group_addition:
+        (team_policies) Added users to Paper-enabled users list
+    :vartype EventType.paper_enabled_users_group_addition: PaperEnabledUsersGroupAdditionType
+    :ivar EventType.paper_enabled_users_group_removal:
+        (team_policies) Removed users from Paper-enabled users list
+    :vartype EventType.paper_enabled_users_group_removal: PaperEnabledUsersGroupRemovalType
+    :ivar EventType.passkey_login_policy_changed:
         (team_policies) Changed passkey login policy for team
-    :ivar PasswordStrengthRequirementsChangePolicyType
-        EventType.password_strength_requirements_change_policy: (team_policies)
-        Changed team password strength requirements
-    :ivar PermanentDeleteChangePolicyType
-        EventType.permanent_delete_change_policy: (team_policies)
-        Enabled/disabled ability of team members to permanently delete content
-    :ivar PreviewsAiPolicyChangedType EventType.previews_ai_policy_changed:
+    :vartype EventType.passkey_login_policy_changed: PasskeyLoginPolicyChangedType
+    :ivar EventType.password_strength_requirements_change_policy:
+        (team_policies) Changed team password strength requirements
+    :vartype EventType.password_strength_requirements_change_policy: PasswordStrengthRequirementsChangePolicyType
+    :ivar EventType.permanent_delete_change_policy:
+        (team_policies) Enabled/disabled ability of team members to permanently
+        delete content
+    :vartype EventType.permanent_delete_change_policy: PermanentDeleteChangePolicyType
+    :ivar EventType.previews_ai_policy_changed:
         (team_policies) Changed Dropbox AI policy for team
-    :ivar ReplayAddingPeoplePolicyChangedType
-        EventType.replay_adding_people_policy_changed: (team_policies) Changed
-        the policy for adding people to Replay content
-    :ivar ReplaySharingPolicyChangedType
-        EventType.replay_sharing_policy_changed: (team_policies) Changed the
-        policy for sharing Replay content
-    :ivar ResellerSupportChangePolicyType
-        EventType.reseller_support_change_policy: (team_policies)
-        Enabled/disabled reseller support
-    :ivar RewindPolicyChangedType EventType.rewind_policy_changed:
+    :vartype EventType.previews_ai_policy_changed: PreviewsAiPolicyChangedType
+    :ivar EventType.replay_adding_people_policy_changed:
+        (team_policies) Changed the policy for adding people to Replay content
+    :vartype EventType.replay_adding_people_policy_changed: ReplayAddingPeoplePolicyChangedType
+    :ivar EventType.replay_sharing_policy_changed:
+        (team_policies) Changed the policy for sharing Replay content
+    :vartype EventType.replay_sharing_policy_changed: ReplaySharingPolicyChangedType
+    :ivar EventType.reseller_support_change_policy:
+        (team_policies) Enabled/disabled reseller support
+    :vartype EventType.reseller_support_change_policy: ResellerSupportChangePolicyType
+    :ivar EventType.rewind_policy_changed:
         (team_policies) Changed Rewind policy for team
-    :ivar SendAndTrackPolicyChangedType EventType.send_and_track_policy_changed:
+    :vartype EventType.rewind_policy_changed: RewindPolicyChangedType
+    :ivar EventType.send_and_track_policy_changed:
         (team_policies) Changed “Send and track” policy for team
-    :ivar SendExternalSharingPolicyChangedType
-        EventType.send_external_sharing_policy_changed: (team_policies) Changed
-        “Send and track” external sharing policy for team
-    :ivar SendForSignaturePolicyChangedType
-        EventType.send_for_signature_policy_changed: (team_policies) Changed
-        send for signature policy for team
-    :ivar SharedLinkDefaultPermissionsPolicyChangedType
-        EventType.shared_link_default_permissions_policy_changed:
+    :vartype EventType.send_and_track_policy_changed: SendAndTrackPolicyChangedType
+    :ivar EventType.send_external_sharing_policy_changed:
+        (team_policies) Changed “Send and track” external sharing policy for
+        team
+    :vartype EventType.send_external_sharing_policy_changed: SendExternalSharingPolicyChangedType
+    :ivar EventType.send_for_signature_policy_changed:
+        (team_policies) Changed send for signature policy for team
+    :vartype EventType.send_for_signature_policy_changed: SendForSignaturePolicyChangedType
+    :ivar EventType.shared_link_default_permissions_policy_changed:
         (team_policies) Changed shared link default permissions policy for team
-    :ivar SharingChangeFolderJoinPolicyType
-        EventType.sharing_change_folder_join_policy: (team_policies) Changed
-        whether team members can join shared folders owned outside team
-    :ivar SharingChangeLinkAllowChangeExpirationPolicyType
-        EventType.sharing_change_link_allow_change_expiration_policy:
+    :vartype EventType.shared_link_default_permissions_policy_changed: SharedLinkDefaultPermissionsPolicyChangedType
+    :ivar EventType.sharing_change_folder_join_policy:
+        (team_policies) Changed whether team members can join shared folders
+        owned outside team
+    :vartype EventType.sharing_change_folder_join_policy: SharingChangeFolderJoinPolicyType
+    :ivar EventType.sharing_change_link_allow_change_expiration_policy:
         (team_policies) Changed the allow remove or change expiration policy for
         the links shared outside of the team
-    :ivar SharingChangeLinkDefaultExpirationPolicyType
-        EventType.sharing_change_link_default_expiration_policy: (team_policies)
-        Changed the default expiration for the links shared outside of the team
-    :ivar SharingChangeLinkEnforcePasswordPolicyType
-        EventType.sharing_change_link_enforce_password_policy: (team_policies)
-        Changed the password requirement for the links shared outside of the
-        team
-    :ivar SharingChangeLinkPolicyType EventType.sharing_change_link_policy:
+    :vartype EventType.sharing_change_link_allow_change_expiration_policy: SharingChangeLinkAllowChangeExpirationPolicyType
+    :ivar EventType.sharing_change_link_default_expiration_policy:
+        (team_policies) Changed the default expiration for the links shared
+        outside of the team
+    :vartype EventType.sharing_change_link_default_expiration_policy: SharingChangeLinkDefaultExpirationPolicyType
+    :ivar EventType.sharing_change_link_enforce_password_policy:
+        (team_policies) Changed the password requirement for the links shared
+        outside of the team
+    :vartype EventType.sharing_change_link_enforce_password_policy: SharingChangeLinkEnforcePasswordPolicyType
+    :ivar EventType.sharing_change_link_policy:
         (team_policies) Changed whether members can share links outside team,
         and if links are accessible only by team members or anyone by default
-    :ivar SharingChangeMemberPolicyType EventType.sharing_change_member_policy:
+    :vartype EventType.sharing_change_link_policy: SharingChangeLinkPolicyType
+    :ivar EventType.sharing_change_member_policy:
         (team_policies) Changed whether members can share files/folders outside
         team
-    :ivar ShowcaseChangeDownloadPolicyType
-        EventType.showcase_change_download_policy: (team_policies)
-        Enabled/disabled downloading files from Dropbox Showcase for team
-    :ivar ShowcaseChangeEnabledPolicyType
-        EventType.showcase_change_enabled_policy: (team_policies)
-        Enabled/disabled Dropbox Showcase for team
-    :ivar ShowcaseChangeExternalSharingPolicyType
-        EventType.showcase_change_external_sharing_policy: (team_policies)
-        Enabled/disabled sharing Dropbox Showcase externally for team
-    :ivar SignExternalSharingPolicyChangedType
-        EventType.sign_external_sharing_policy_changed: (team_policies) Changed
-        Signatures external sharing policy for team
-    :ivar SignTemplateCreationPermissionChangedType
-        EventType.sign_template_creation_permission_changed: (team_policies)
-        Changed template creation permission
-    :ivar SmarterSmartSyncPolicyChangedType
-        EventType.smarter_smart_sync_policy_changed: (team_policies) Changed
-        automatic Smart Sync setting for team
-    :ivar SmartSyncChangePolicyType EventType.smart_sync_change_policy:
+    :vartype EventType.sharing_change_member_policy: SharingChangeMemberPolicyType
+    :ivar EventType.showcase_change_download_policy:
+        (team_policies) Enabled/disabled downloading files from Dropbox Showcase
+        for team
+    :vartype EventType.showcase_change_download_policy: ShowcaseChangeDownloadPolicyType
+    :ivar EventType.showcase_change_enabled_policy:
+        (team_policies) Enabled/disabled Dropbox Showcase for team
+    :vartype EventType.showcase_change_enabled_policy: ShowcaseChangeEnabledPolicyType
+    :ivar EventType.showcase_change_external_sharing_policy:
+        (team_policies) Enabled/disabled sharing Dropbox Showcase externally for
+        team
+    :vartype EventType.showcase_change_external_sharing_policy: ShowcaseChangeExternalSharingPolicyType
+    :ivar EventType.sign_external_sharing_policy_changed:
+        (team_policies) Changed Signatures external sharing policy for team
+    :vartype EventType.sign_external_sharing_policy_changed: SignExternalSharingPolicyChangedType
+    :ivar EventType.sign_template_creation_permission_changed:
+        (team_policies) Changed template creation permission
+    :vartype EventType.sign_template_creation_permission_changed: SignTemplateCreationPermissionChangedType
+    :ivar EventType.smarter_smart_sync_policy_changed:
+        (team_policies) Changed automatic Smart Sync setting for team
+    :vartype EventType.smarter_smart_sync_policy_changed: SmarterSmartSyncPolicyChangedType
+    :ivar EventType.smart_sync_change_policy:
         (team_policies) Changed default Smart Sync setting for team members
-    :ivar SmartSyncNotOptOutType EventType.smart_sync_not_opt_out:
+    :vartype EventType.smart_sync_change_policy: SmartSyncChangePolicyType
+    :ivar EventType.smart_sync_not_opt_out:
         (team_policies) Opted team into Smart Sync
-    :ivar SmartSyncOptOutType EventType.smart_sync_opt_out: (team_policies)
-        Opted team out of Smart Sync
-    :ivar SsoChangePolicyType EventType.sso_change_policy: (team_policies)
-        Changed single sign-on setting for team
-    :ivar StackCrossTeamAccessPolicyChangedType
-        EventType.stack_cross_team_access_policy_changed: (team_policies)
-        Changed cross-team Stack access policy for team
-    :ivar TeamBrandingPolicyChangedType EventType.team_branding_policy_changed:
+    :vartype EventType.smart_sync_not_opt_out: SmartSyncNotOptOutType
+    :ivar EventType.smart_sync_opt_out:
+        (team_policies) Opted team out of Smart Sync
+    :vartype EventType.smart_sync_opt_out: SmartSyncOptOutType
+    :ivar EventType.sso_change_policy:
+        (team_policies) Changed single sign-on setting for team
+    :vartype EventType.sso_change_policy: SsoChangePolicyType
+    :ivar EventType.stack_cross_team_access_policy_changed:
+        (team_policies) Changed cross-team Stack access policy for team
+    :vartype EventType.stack_cross_team_access_policy_changed: StackCrossTeamAccessPolicyChangedType
+    :ivar EventType.team_branding_policy_changed:
         (team_policies) Changed team branding policy for team
-    :ivar TeamExtensionsPolicyChangedType
-        EventType.team_extensions_policy_changed: (team_policies) Changed App
-        Integrations setting for team
-    :ivar TeamMemberStorageRequestPolicyChangedType
-        EventType.team_member_storage_request_policy_changed: (team_policies)
-        Changed team member storage request policy for team
-    :ivar TeamSelectiveSyncPolicyChangedType
-        EventType.team_selective_sync_policy_changed: (team_policies)
-        Enabled/disabled Team Selective Sync for team
-    :ivar TeamSharingWhitelistSubjectsChangedType
-        EventType.team_sharing_whitelist_subjects_changed: (team_policies)
-        Edited the approved list for sharing externally
-    :ivar TfaAddExceptionType EventType.tfa_add_exception: (team_policies) Added
-        members to two factor authentication exception list
-    :ivar TfaChangePolicyType EventType.tfa_change_policy: (team_policies)
-        Changed two-factor authentication setting for team
-    :ivar TfaRemoveExceptionType EventType.tfa_remove_exception: (team_policies)
-        Removed members from two factor authentication exception list
-    :ivar TopLevelContentPolicyChangedType
-        EventType.top_level_content_policy_changed: (team_policies) Changed top
-        level content setting for team
-    :ivar TwoAccountChangePolicyType EventType.two_account_change_policy:
+    :vartype EventType.team_branding_policy_changed: TeamBrandingPolicyChangedType
+    :ivar EventType.team_extensions_policy_changed:
+        (team_policies) Changed App Integrations setting for team
+    :vartype EventType.team_extensions_policy_changed: TeamExtensionsPolicyChangedType
+    :ivar EventType.team_member_storage_request_policy_changed:
+        (team_policies) Changed team member storage request policy for team
+    :vartype EventType.team_member_storage_request_policy_changed: TeamMemberStorageRequestPolicyChangedType
+    :ivar EventType.team_selective_sync_policy_changed:
+        (team_policies) Enabled/disabled Team Selective Sync for team
+    :vartype EventType.team_selective_sync_policy_changed: TeamSelectiveSyncPolicyChangedType
+    :ivar EventType.team_sharing_whitelist_subjects_changed:
+        (team_policies) Edited the approved list for sharing externally
+    :vartype EventType.team_sharing_whitelist_subjects_changed: TeamSharingWhitelistSubjectsChangedType
+    :ivar EventType.tfa_add_exception:
+        (team_policies) Added members to two factor authentication exception
+        list
+    :vartype EventType.tfa_add_exception: TfaAddExceptionType
+    :ivar EventType.tfa_change_policy:
+        (team_policies) Changed two-factor authentication setting for team
+    :vartype EventType.tfa_change_policy: TfaChangePolicyType
+    :ivar EventType.tfa_remove_exception:
+        (team_policies) Removed members from two factor authentication exception
+        list
+    :vartype EventType.tfa_remove_exception: TfaRemoveExceptionType
+    :ivar EventType.top_level_content_policy_changed:
+        (team_policies) Changed top level content setting for team
+    :vartype EventType.top_level_content_policy_changed: TopLevelContentPolicyChangedType
+    :ivar EventType.two_account_change_policy:
         (team_policies) Enabled/disabled option for members to link personal
         Dropbox account and team account to same computer
-    :ivar ViewerInfoPolicyChangedType EventType.viewer_info_policy_changed:
+    :vartype EventType.two_account_change_policy: TwoAccountChangePolicyType
+    :ivar EventType.viewer_info_policy_changed:
         (team_policies) Changed team policy for viewer info
-    :ivar WatermarkingPolicyChangedType EventType.watermarking_policy_changed:
+    :vartype EventType.viewer_info_policy_changed: ViewerInfoPolicyChangedType
+    :ivar EventType.watermarking_policy_changed:
         (team_policies) Changed watermarking policy for team
-    :ivar WebSessionsChangeActiveSessionLimitType
-        EventType.web_sessions_change_active_session_limit: (team_policies)
-        Changed limit on active sessions per member
-    :ivar WebSessionsChangeFixedLengthPolicyType
-        EventType.web_sessions_change_fixed_length_policy: (team_policies)
-        Changed how long members can stay signed in to Dropbox.com
-    :ivar WebSessionsChangeIdleLengthPolicyType
-        EventType.web_sessions_change_idle_length_policy: (team_policies)
-        Changed how long team members can be idle while signed in to Dropbox.com
-    :ivar DataResidencyMigrationRequestSuccessfulType
-        EventType.data_residency_migration_request_successful: (team_profile)
-        Requested data residency migration for team data
-    :ivar DataResidencyMigrationRequestUnsuccessfulType
-        EventType.data_residency_migration_request_unsuccessful: (team_profile)
-        Request for data residency migration for team data has failed
-    :ivar TeamMergeFromType EventType.team_merge_from: (team_profile) Merged
-        another team into this team
-    :ivar TeamMergeToType EventType.team_merge_to: (team_profile) Merged this
-        team into another team
-    :ivar TeamProfileAddBackgroundType EventType.team_profile_add_background:
+    :vartype EventType.watermarking_policy_changed: WatermarkingPolicyChangedType
+    :ivar EventType.web_sessions_change_active_session_limit:
+        (team_policies) Changed limit on active sessions per member
+    :vartype EventType.web_sessions_change_active_session_limit: WebSessionsChangeActiveSessionLimitType
+    :ivar EventType.web_sessions_change_fixed_length_policy:
+        (team_policies) Changed how long members can stay signed in to
+        Dropbox.com
+    :vartype EventType.web_sessions_change_fixed_length_policy: WebSessionsChangeFixedLengthPolicyType
+    :ivar EventType.web_sessions_change_idle_length_policy:
+        (team_policies) Changed how long team members can be idle while signed
+        in to Dropbox.com
+    :vartype EventType.web_sessions_change_idle_length_policy: WebSessionsChangeIdleLengthPolicyType
+    :ivar EventType.data_residency_migration_request_successful:
+        (team_profile) Requested data residency migration for team data
+    :vartype EventType.data_residency_migration_request_successful: DataResidencyMigrationRequestSuccessfulType
+    :ivar EventType.data_residency_migration_request_unsuccessful:
+        (team_profile) Request for data residency migration for team data has
+        failed
+    :vartype EventType.data_residency_migration_request_unsuccessful: DataResidencyMigrationRequestUnsuccessfulType
+    :ivar EventType.team_merge_from:
+        (team_profile) Merged another team into this team
+    :vartype EventType.team_merge_from: TeamMergeFromType
+    :ivar EventType.team_merge_to:
+        (team_profile) Merged this team into another team
+    :vartype EventType.team_merge_to: TeamMergeToType
+    :ivar EventType.team_profile_add_background:
         (team_profile) Added team background to display on shared link headers
-    :ivar TeamProfileAddLogoType EventType.team_profile_add_logo: (team_profile)
-        Added team logo to display on shared link headers
-    :ivar TeamProfileChangeBackgroundType
-        EventType.team_profile_change_background: (team_profile) Changed team
-        background displayed on shared link headers
-    :ivar TeamProfileChangeDefaultLanguageType
-        EventType.team_profile_change_default_language: (team_profile) Changed
-        default language for team
-    :ivar TeamProfileChangeLogoType EventType.team_profile_change_logo:
+    :vartype EventType.team_profile_add_background: TeamProfileAddBackgroundType
+    :ivar EventType.team_profile_add_logo:
+        (team_profile) Added team logo to display on shared link headers
+    :vartype EventType.team_profile_add_logo: TeamProfileAddLogoType
+    :ivar EventType.team_profile_change_background:
+        (team_profile) Changed team background displayed on shared link headers
+    :vartype EventType.team_profile_change_background: TeamProfileChangeBackgroundType
+    :ivar EventType.team_profile_change_default_language:
+        (team_profile) Changed default language for team
+    :vartype EventType.team_profile_change_default_language: TeamProfileChangeDefaultLanguageType
+    :ivar EventType.team_profile_change_logo:
         (team_profile) Changed team logo displayed on shared link headers
-    :ivar TeamProfileChangeNameType EventType.team_profile_change_name:
+    :vartype EventType.team_profile_change_logo: TeamProfileChangeLogoType
+    :ivar EventType.team_profile_change_name:
         (team_profile) Changed team name
-    :ivar TeamProfileRemoveBackgroundType
-        EventType.team_profile_remove_background: (team_profile) Removed team
-        background displayed on shared link headers
-    :ivar TeamProfileRemoveLogoType EventType.team_profile_remove_logo:
+    :vartype EventType.team_profile_change_name: TeamProfileChangeNameType
+    :ivar EventType.team_profile_remove_background:
+        (team_profile) Removed team background displayed on shared link headers
+    :vartype EventType.team_profile_remove_background: TeamProfileRemoveBackgroundType
+    :ivar EventType.team_profile_remove_logo:
         (team_profile) Removed team logo displayed on shared link headers
-    :ivar PasskeyAddType EventType.passkey_add: (tfa) Added passkey for login
-    :ivar PasskeyRemoveType EventType.passkey_remove: (tfa) Removed passkey for
-        login
-    :ivar TfaAddBackupPhoneType EventType.tfa_add_backup_phone: (tfa) Added
-        backup phone for two-factor authentication
-    :ivar TfaAddSecurityKeyType EventType.tfa_add_security_key: (tfa) Added
-        security key for two-factor authentication
-    :ivar TfaChangeBackupPhoneType EventType.tfa_change_backup_phone: (tfa)
-        Changed backup phone for two-factor authentication
-    :ivar TfaChangeStatusType EventType.tfa_change_status: (tfa)
-        Enabled/disabled/changed two-factor authentication setting
-    :ivar TfaRemoveBackupPhoneType EventType.tfa_remove_backup_phone: (tfa)
-        Removed backup phone for two-factor authentication
-    :ivar TfaRemoveSecurityKeyType EventType.tfa_remove_security_key: (tfa)
-        Removed security key for two-factor authentication
-    :ivar TfaResetType EventType.tfa_reset: (tfa) Reset two-factor
-        authentication for team member
-    :ivar ChangedEnterpriseAdminRoleType
-        EventType.changed_enterprise_admin_role: (trusted_teams) Changed
-        enterprise admin role
-    :ivar ChangedEnterpriseConnectedTeamStatusType
-        EventType.changed_enterprise_connected_team_status: (trusted_teams)
-        Changed enterprise-connected team status
-    :ivar EndedEnterpriseAdminSessionType
-        EventType.ended_enterprise_admin_session: (trusted_teams) Ended
-        enterprise admin session
-    :ivar EndedEnterpriseAdminSessionDeprecatedType
-        EventType.ended_enterprise_admin_session_deprecated: (trusted_teams)
-        Ended enterprise admin session (deprecated, replaced by 'Ended
-        enterprise admin session')
-    :ivar EnterpriseSettingsLockingType EventType.enterprise_settings_locking:
+    :vartype EventType.team_profile_remove_logo: TeamProfileRemoveLogoType
+    :ivar EventType.passkey_add:
+        (tfa) Added passkey for login
+    :vartype EventType.passkey_add: PasskeyAddType
+    :ivar EventType.passkey_remove:
+        (tfa) Removed passkey for login
+    :vartype EventType.passkey_remove: PasskeyRemoveType
+    :ivar EventType.tfa_add_backup_phone:
+        (tfa) Added backup phone for two-factor authentication
+    :vartype EventType.tfa_add_backup_phone: TfaAddBackupPhoneType
+    :ivar EventType.tfa_add_security_key:
+        (tfa) Added security key for two-factor authentication
+    :vartype EventType.tfa_add_security_key: TfaAddSecurityKeyType
+    :ivar EventType.tfa_change_backup_phone:
+        (tfa) Changed backup phone for two-factor authentication
+    :vartype EventType.tfa_change_backup_phone: TfaChangeBackupPhoneType
+    :ivar EventType.tfa_change_status:
+        (tfa) Enabled/disabled/changed two-factor authentication setting
+    :vartype EventType.tfa_change_status: TfaChangeStatusType
+    :ivar EventType.tfa_remove_backup_phone:
+        (tfa) Removed backup phone for two-factor authentication
+    :vartype EventType.tfa_remove_backup_phone: TfaRemoveBackupPhoneType
+    :ivar EventType.tfa_remove_security_key:
+        (tfa) Removed security key for two-factor authentication
+    :vartype EventType.tfa_remove_security_key: TfaRemoveSecurityKeyType
+    :ivar EventType.tfa_reset:
+        (tfa) Reset two-factor authentication for team member
+    :vartype EventType.tfa_reset: TfaResetType
+    :ivar EventType.changed_enterprise_admin_role:
+        (trusted_teams) Changed enterprise admin role
+    :vartype EventType.changed_enterprise_admin_role: ChangedEnterpriseAdminRoleType
+    :ivar EventType.changed_enterprise_connected_team_status:
+        (trusted_teams) Changed enterprise-connected team status
+    :vartype EventType.changed_enterprise_connected_team_status: ChangedEnterpriseConnectedTeamStatusType
+    :ivar EventType.ended_enterprise_admin_session:
+        (trusted_teams) Ended enterprise admin session
+    :vartype EventType.ended_enterprise_admin_session: EndedEnterpriseAdminSessionType
+    :ivar EventType.ended_enterprise_admin_session_deprecated:
+        (trusted_teams) Ended enterprise admin session (deprecated, replaced by
+        'Ended enterprise admin session')
+    :vartype EventType.ended_enterprise_admin_session_deprecated: EndedEnterpriseAdminSessionDeprecatedType
+    :ivar EventType.enterprise_settings_locking:
         (trusted_teams) Changed who can update a setting
-    :ivar GuestAdminChangeStatusType EventType.guest_admin_change_status:
+    :vartype EventType.enterprise_settings_locking: EnterpriseSettingsLockingType
+    :ivar EventType.guest_admin_change_status:
         (trusted_teams) Changed guest team admin status
-    :ivar StartedEnterpriseAdminSessionType
-        EventType.started_enterprise_admin_session: (trusted_teams) Started
-        enterprise admin session
-    :ivar TeamMergeRequestAcceptedType EventType.team_merge_request_accepted:
+    :vartype EventType.guest_admin_change_status: GuestAdminChangeStatusType
+    :ivar EventType.started_enterprise_admin_session:
+        (trusted_teams) Started enterprise admin session
+    :vartype EventType.started_enterprise_admin_session: StartedEnterpriseAdminSessionType
+    :ivar EventType.team_merge_request_accepted:
         (trusted_teams) Accepted a team merge request
-    :ivar TeamMergeRequestAcceptedShownToPrimaryTeamType
-        EventType.team_merge_request_accepted_shown_to_primary_team:
+    :vartype EventType.team_merge_request_accepted: TeamMergeRequestAcceptedType
+    :ivar EventType.team_merge_request_accepted_shown_to_primary_team:
         (trusted_teams) Accepted a team merge request (deprecated, replaced by
         'Accepted a team merge request')
-    :ivar TeamMergeRequestAcceptedShownToSecondaryTeamType
-        EventType.team_merge_request_accepted_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_accepted_shown_to_primary_team: TeamMergeRequestAcceptedShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_accepted_shown_to_secondary_team:
         (trusted_teams) Accepted a team merge request (deprecated, replaced by
         'Accepted a team merge request')
-    :ivar TeamMergeRequestAutoCanceledType
-        EventType.team_merge_request_auto_canceled: (trusted_teams)
-        Automatically canceled team merge request
-    :ivar TeamMergeRequestCanceledType EventType.team_merge_request_canceled:
+    :vartype EventType.team_merge_request_accepted_shown_to_secondary_team: TeamMergeRequestAcceptedShownToSecondaryTeamType
+    :ivar EventType.team_merge_request_auto_canceled:
+        (trusted_teams) Automatically canceled team merge request
+    :vartype EventType.team_merge_request_auto_canceled: TeamMergeRequestAutoCanceledType
+    :ivar EventType.team_merge_request_canceled:
         (trusted_teams) Canceled a team merge request
-    :ivar TeamMergeRequestCanceledShownToPrimaryTeamType
-        EventType.team_merge_request_canceled_shown_to_primary_team:
+    :vartype EventType.team_merge_request_canceled: TeamMergeRequestCanceledType
+    :ivar EventType.team_merge_request_canceled_shown_to_primary_team:
         (trusted_teams) Canceled a team merge request (deprecated, replaced by
         'Canceled a team merge request')
-    :ivar TeamMergeRequestCanceledShownToSecondaryTeamType
-        EventType.team_merge_request_canceled_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_canceled_shown_to_primary_team: TeamMergeRequestCanceledShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_canceled_shown_to_secondary_team:
         (trusted_teams) Canceled a team merge request (deprecated, replaced by
         'Canceled a team merge request')
-    :ivar TeamMergeRequestExpiredType EventType.team_merge_request_expired:
+    :vartype EventType.team_merge_request_canceled_shown_to_secondary_team: TeamMergeRequestCanceledShownToSecondaryTeamType
+    :ivar EventType.team_merge_request_expired:
         (trusted_teams) Team merge request expired
-    :ivar TeamMergeRequestExpiredShownToPrimaryTeamType
-        EventType.team_merge_request_expired_shown_to_primary_team:
+    :vartype EventType.team_merge_request_expired: TeamMergeRequestExpiredType
+    :ivar EventType.team_merge_request_expired_shown_to_primary_team:
         (trusted_teams) Team merge request expired (deprecated, replaced by
         'Team merge request expired')
-    :ivar TeamMergeRequestExpiredShownToSecondaryTeamType
-        EventType.team_merge_request_expired_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_expired_shown_to_primary_team: TeamMergeRequestExpiredShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_expired_shown_to_secondary_team:
         (trusted_teams) Team merge request expired (deprecated, replaced by
         'Team merge request expired')
-    :ivar TeamMergeRequestRejectedShownToPrimaryTeamType
-        EventType.team_merge_request_rejected_shown_to_primary_team:
+    :vartype EventType.team_merge_request_expired_shown_to_secondary_team: TeamMergeRequestExpiredShownToSecondaryTeamType
+    :ivar EventType.team_merge_request_rejected_shown_to_primary_team:
         (trusted_teams) Rejected a team merge request (deprecated, no longer
         logged)
-    :ivar TeamMergeRequestRejectedShownToSecondaryTeamType
-        EventType.team_merge_request_rejected_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_rejected_shown_to_primary_team: TeamMergeRequestRejectedShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_rejected_shown_to_secondary_team:
         (trusted_teams) Rejected a team merge request (deprecated, no longer
         logged)
-    :ivar TeamMergeRequestReminderType EventType.team_merge_request_reminder:
+    :vartype EventType.team_merge_request_rejected_shown_to_secondary_team: TeamMergeRequestRejectedShownToSecondaryTeamType
+    :ivar EventType.team_merge_request_reminder:
         (trusted_teams) Sent a team merge request reminder
-    :ivar TeamMergeRequestReminderShownToPrimaryTeamType
-        EventType.team_merge_request_reminder_shown_to_primary_team:
+    :vartype EventType.team_merge_request_reminder: TeamMergeRequestReminderType
+    :ivar EventType.team_merge_request_reminder_shown_to_primary_team:
         (trusted_teams) Sent a team merge request reminder (deprecated, replaced
         by 'Sent a team merge request reminder')
-    :ivar TeamMergeRequestReminderShownToSecondaryTeamType
-        EventType.team_merge_request_reminder_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_reminder_shown_to_primary_team: TeamMergeRequestReminderShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_reminder_shown_to_secondary_team:
         (trusted_teams) Sent a team merge request reminder (deprecated, replaced
         by 'Sent a team merge request reminder')
-    :ivar TeamMergeRequestRevokedType EventType.team_merge_request_revoked:
+    :vartype EventType.team_merge_request_reminder_shown_to_secondary_team: TeamMergeRequestReminderShownToSecondaryTeamType
+    :ivar EventType.team_merge_request_revoked:
         (trusted_teams) Canceled the team merge
-    :ivar TeamMergeRequestSentShownToPrimaryTeamType
-        EventType.team_merge_request_sent_shown_to_primary_team: (trusted_teams)
-        Requested to merge their Dropbox team into yours
-    :ivar TeamMergeRequestSentShownToSecondaryTeamType
-        EventType.team_merge_request_sent_shown_to_secondary_team:
+    :vartype EventType.team_merge_request_revoked: TeamMergeRequestRevokedType
+    :ivar EventType.team_merge_request_sent_shown_to_primary_team:
+        (trusted_teams) Requested to merge their Dropbox team into yours
+    :vartype EventType.team_merge_request_sent_shown_to_primary_team: TeamMergeRequestSentShownToPrimaryTeamType
+    :ivar EventType.team_merge_request_sent_shown_to_secondary_team:
         (trusted_teams) Requested to merge your team into another Dropbox team
+    :vartype EventType.team_merge_request_sent_shown_to_secondary_team: TeamMergeRequestSentShownToSecondaryTeamType
     """
 
     _catch_all = 'other'
@@ -50840,1269 +51374,1328 @@ class EventTypeArg(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_log.EventTypeArg.admin_alerting_alert_state_changed:
+    :ivar EventTypeArg.admin_alerting_alert_state_changed:
         (admin_alerting) Changed an alert state
-    :ivar team_log.EventTypeArg.admin_alerting_changed_alert_config:
+    :ivar EventTypeArg.admin_alerting_changed_alert_config:
         (admin_alerting) Changed an alert setting
-    :ivar team_log.EventTypeArg.admin_alerting_triggered_alert: (admin_alerting)
-        Triggered security alert
-    :ivar team_log.EventTypeArg.ransomware_restore_process_completed:
+    :ivar EventTypeArg.admin_alerting_triggered_alert:
+        (admin_alerting) Triggered security alert
+    :ivar EventTypeArg.ransomware_restore_process_completed:
         (admin_alerting) Completed ransomware restore process
-    :ivar team_log.EventTypeArg.ransomware_restore_process_started:
+    :ivar EventTypeArg.ransomware_restore_process_started:
         (admin_alerting) Started ransomware restore process
-    :ivar team_log.EventTypeArg.app_blocked_by_permissions: (apps) Failed to
-        connect app for member
-    :ivar team_log.EventTypeArg.app_link_team: (apps) Linked app for team
-    :ivar team_log.EventTypeArg.app_link_user: (apps) Linked app for member
-    :ivar team_log.EventTypeArg.app_unlink_team: (apps) Unlinked app for team
-    :ivar team_log.EventTypeArg.app_unlink_user: (apps) Unlinked app for member
-    :ivar team_log.EventTypeArg.integration_connected: (apps) Connected
-        integration for member
-    :ivar team_log.EventTypeArg.integration_disconnected: (apps) Disconnected
-        integration for member
-    :ivar team_log.EventTypeArg.file_add_comment: (comments) Added file comment
-    :ivar team_log.EventTypeArg.file_change_comment_subscription: (comments)
-        Subscribed to or unsubscribed from comment notifications for file
-    :ivar team_log.EventTypeArg.file_delete_comment: (comments) Deleted file
-        comment
-    :ivar team_log.EventTypeArg.file_edit_comment: (comments) Edited file
-        comment
-    :ivar team_log.EventTypeArg.file_like_comment: (comments) Liked file comment
-        (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.file_resolve_comment: (comments) Resolved file
-        comment
-    :ivar team_log.EventTypeArg.file_unlike_comment: (comments) Unliked file
-        comment (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.file_unresolve_comment: (comments) Unresolved
-        file comment
-    :ivar team_log.EventTypeArg.dash_added_comment_to_stack: (dash) Added a
-        comment to a stack
-    :ivar team_log.EventTypeArg.dash_added_connector: (dash) Connected to a user
-        connector
-    :ivar team_log.EventTypeArg.dash_added_link_to_stack: (dash) Added a link to
-        a stack
-    :ivar team_log.EventTypeArg.dash_added_team_email_domain_allowlist: (dash)
-        Admin added an email domain to the team allowlist
-    :ivar team_log.EventTypeArg.dash_admin_added_org_wide_connector: (dash)
-        Admin added an admin connector
-    :ivar team_log.EventTypeArg.dash_admin_disabled_connector: (dash) Admin
-        disabled a user connector
-    :ivar team_log.EventTypeArg.dash_admin_enabled_connector: (dash) Admin
-        enabled a user connector
-    :ivar team_log.EventTypeArg.dash_admin_removed_org_wide_connector: (dash)
-        Admin removed an admin connector
-    :ivar team_log.EventTypeArg.dash_archived_stack: (dash) Archived a stack
-    :ivar team_log.EventTypeArg.dash_changed_audience_of_shared_link_to_stack:
+    :ivar EventTypeArg.app_blocked_by_permissions:
+        (apps) Failed to connect app for member
+    :ivar EventTypeArg.app_link_team:
+        (apps) Linked app for team
+    :ivar EventTypeArg.app_link_user:
+        (apps) Linked app for member
+    :ivar EventTypeArg.app_unlink_team:
+        (apps) Unlinked app for team
+    :ivar EventTypeArg.app_unlink_user:
+        (apps) Unlinked app for member
+    :ivar EventTypeArg.integration_connected:
+        (apps) Connected integration for member
+    :ivar EventTypeArg.integration_disconnected:
+        (apps) Disconnected integration for member
+    :ivar EventTypeArg.file_add_comment:
+        (comments) Added file comment
+    :ivar EventTypeArg.file_change_comment_subscription:
+        (comments) Subscribed to or unsubscribed from comment notifications for
+        file
+    :ivar EventTypeArg.file_delete_comment:
+        (comments) Deleted file comment
+    :ivar EventTypeArg.file_edit_comment:
+        (comments) Edited file comment
+    :ivar EventTypeArg.file_like_comment:
+        (comments) Liked file comment (deprecated, no longer logged)
+    :ivar EventTypeArg.file_resolve_comment:
+        (comments) Resolved file comment
+    :ivar EventTypeArg.file_unlike_comment:
+        (comments) Unliked file comment (deprecated, no longer logged)
+    :ivar EventTypeArg.file_unresolve_comment:
+        (comments) Unresolved file comment
+    :ivar EventTypeArg.dash_added_comment_to_stack:
+        (dash) Added a comment to a stack
+    :ivar EventTypeArg.dash_added_connector:
+        (dash) Connected to a user connector
+    :ivar EventTypeArg.dash_added_link_to_stack:
+        (dash) Added a link to a stack
+    :ivar EventTypeArg.dash_added_team_email_domain_allowlist:
+        (dash) Admin added an email domain to the team allowlist
+    :ivar EventTypeArg.dash_admin_added_org_wide_connector:
+        (dash) Admin added an admin connector
+    :ivar EventTypeArg.dash_admin_disabled_connector:
+        (dash) Admin disabled a user connector
+    :ivar EventTypeArg.dash_admin_enabled_connector:
+        (dash) Admin enabled a user connector
+    :ivar EventTypeArg.dash_admin_removed_org_wide_connector:
+        (dash) Admin removed an admin connector
+    :ivar EventTypeArg.dash_archived_stack:
+        (dash) Archived a stack
+    :ivar EventTypeArg.dash_changed_audience_of_shared_link_to_stack:
         (dash) Changed the audience of a shared link to a stack
-    :ivar team_log.EventTypeArg.dash_cloned_stack: (dash) Cloned stack
-    :ivar team_log.EventTypeArg.dash_connector_tools_call: (dash) Called a tool
-        on a connector
-    :ivar team_log.EventTypeArg.dash_created_stack: (dash) Created a stack
-    :ivar team_log.EventTypeArg.dash_deleted_comment_from_stack: (dash) Deleted
-        a comment from a stack
-    :ivar team_log.EventTypeArg.dash_deleted_stack: (dash) Deleted a stack
-    :ivar team_log.EventTypeArg.dash_edited_comment_in_stack: (dash) Edited a
-        comment in a stack
-    :ivar team_log.EventTypeArg.dash_external_user_opened_stack: (dash) External
-        user opened a stack
-    :ivar team_log.EventTypeArg.dash_first_launched_desktop: (dash) Opened the
-        desktop app for the first time
-    :ivar team_log.EventTypeArg.dash_first_launched_extension: (dash) Opened the
-        extension for the first time
-    :ivar team_log.EventTypeArg.dash_first_launched_web_start_page: (dash)
-        Opened the web Start Page for the first time
-    :ivar team_log.EventTypeArg.dash_opened_shared_link_to_stack: (dash) Checked
-        access permissions to a stack
-    :ivar team_log.EventTypeArg.dash_opened_stack: (dash) Opened a stack
-    :ivar team_log.EventTypeArg.dash_preview_opt_out_status_changed: (dash)
-        Changed the preview opt-out status
-    :ivar team_log.EventTypeArg.dash_removed_connector: (dash) Disconnected a
-        user connector
-    :ivar team_log.EventTypeArg.dash_removed_link_from_stack: (dash) Removed a
-        link from a stack
-    :ivar team_log.EventTypeArg.dash_removed_shared_link_to_stack: (dash)
-        Removed a shared link to a stack
-    :ivar team_log.EventTypeArg.dash_removed_team_email_domain_allowlist: (dash)
-        Admin removed an email domain from the team allowlist
-    :ivar team_log.EventTypeArg.dash_renamed_stack: (dash) Renamed a stack
-    :ivar team_log.EventTypeArg.dash_shared_link_to_stack: (dash) Shared a link
-        to a stack
-    :ivar team_log.EventTypeArg.dash_unarchived_stack: (dash) Unarchived a stack
-    :ivar team_log.EventTypeArg.dash_viewed_company_stack: (dash) Member viewed
-        a company stack
-    :ivar team_log.EventTypeArg.dash_viewed_external_ai_activity_report: (dash)
-        Admin viewed the external AI activity report
-    :ivar team_log.EventTypeArg.governance_policy_add_folders: (data_governance)
-        Added folders to policy
-    :ivar team_log.EventTypeArg.governance_policy_add_folder_failed:
+    :ivar EventTypeArg.dash_cloned_stack:
+        (dash) Cloned stack
+    :ivar EventTypeArg.dash_connector_tools_call:
+        (dash) Called a tool on a connector
+    :ivar EventTypeArg.dash_created_stack:
+        (dash) Created a stack
+    :ivar EventTypeArg.dash_deleted_comment_from_stack:
+        (dash) Deleted a comment from a stack
+    :ivar EventTypeArg.dash_deleted_stack:
+        (dash) Deleted a stack
+    :ivar EventTypeArg.dash_edited_comment_in_stack:
+        (dash) Edited a comment in a stack
+    :ivar EventTypeArg.dash_external_user_opened_stack:
+        (dash) External user opened a stack
+    :ivar EventTypeArg.dash_first_launched_desktop:
+        (dash) Opened the desktop app for the first time
+    :ivar EventTypeArg.dash_first_launched_extension:
+        (dash) Opened the extension for the first time
+    :ivar EventTypeArg.dash_first_launched_web_start_page:
+        (dash) Opened the web Start Page for the first time
+    :ivar EventTypeArg.dash_opened_shared_link_to_stack:
+        (dash) Checked access permissions to a stack
+    :ivar EventTypeArg.dash_opened_stack:
+        (dash) Opened a stack
+    :ivar EventTypeArg.dash_preview_opt_out_status_changed:
+        (dash) Changed the preview opt-out status
+    :ivar EventTypeArg.dash_removed_connector:
+        (dash) Disconnected a user connector
+    :ivar EventTypeArg.dash_removed_link_from_stack:
+        (dash) Removed a link from a stack
+    :ivar EventTypeArg.dash_removed_shared_link_to_stack:
+        (dash) Removed a shared link to a stack
+    :ivar EventTypeArg.dash_removed_team_email_domain_allowlist:
+        (dash) Admin removed an email domain from the team allowlist
+    :ivar EventTypeArg.dash_renamed_stack:
+        (dash) Renamed a stack
+    :ivar EventTypeArg.dash_shared_link_to_stack:
+        (dash) Shared a link to a stack
+    :ivar EventTypeArg.dash_unarchived_stack:
+        (dash) Unarchived a stack
+    :ivar EventTypeArg.dash_viewed_company_stack:
+        (dash) Member viewed a company stack
+    :ivar EventTypeArg.dash_viewed_external_ai_activity_report:
+        (dash) Admin viewed the external AI activity report
+    :ivar EventTypeArg.governance_policy_add_folders:
+        (data_governance) Added folders to policy
+    :ivar EventTypeArg.governance_policy_add_folder_failed:
         (data_governance) Couldn't add a folder to a policy
-    :ivar team_log.EventTypeArg.governance_policy_content_disposed:
+    :ivar EventTypeArg.governance_policy_content_disposed:
         (data_governance) Content disposed
-    :ivar team_log.EventTypeArg.governance_policy_create: (data_governance)
-        Activated a new policy
-    :ivar team_log.EventTypeArg.governance_policy_delete: (data_governance)
-        Deleted a policy
-    :ivar team_log.EventTypeArg.governance_policy_edit_details:
+    :ivar EventTypeArg.governance_policy_create:
+        (data_governance) Activated a new policy
+    :ivar EventTypeArg.governance_policy_delete:
+        (data_governance) Deleted a policy
+    :ivar EventTypeArg.governance_policy_edit_details:
         (data_governance) Edited policy
-    :ivar team_log.EventTypeArg.governance_policy_edit_duration:
+    :ivar EventTypeArg.governance_policy_edit_duration:
         (data_governance) Changed policy duration
-    :ivar team_log.EventTypeArg.governance_policy_export_created:
+    :ivar EventTypeArg.governance_policy_export_created:
         (data_governance) Created a policy download
-    :ivar team_log.EventTypeArg.governance_policy_export_removed:
+    :ivar EventTypeArg.governance_policy_export_removed:
         (data_governance) Removed a policy download
-    :ivar team_log.EventTypeArg.governance_policy_remove_folders:
+    :ivar EventTypeArg.governance_policy_remove_folders:
         (data_governance) Removed folders from policy
-    :ivar team_log.EventTypeArg.governance_policy_report_created:
+    :ivar EventTypeArg.governance_policy_report_created:
         (data_governance) Created a summary report for a policy
-    :ivar team_log.EventTypeArg.governance_policy_zip_part_downloaded:
+    :ivar EventTypeArg.governance_policy_zip_part_downloaded:
         (data_governance) Downloaded content from a policy
-    :ivar team_log.EventTypeArg.legal_holds_activate_a_hold: (data_governance)
-        Activated a hold
-    :ivar team_log.EventTypeArg.legal_holds_add_members: (data_governance) Added
-        members to a hold
-    :ivar team_log.EventTypeArg.legal_holds_change_hold_details:
+    :ivar EventTypeArg.legal_holds_activate_a_hold:
+        (data_governance) Activated a hold
+    :ivar EventTypeArg.legal_holds_add_members:
+        (data_governance) Added members to a hold
+    :ivar EventTypeArg.legal_holds_change_hold_details:
         (data_governance) Edited details for a hold
-    :ivar team_log.EventTypeArg.legal_holds_change_hold_name: (data_governance)
-        Renamed a hold
-    :ivar team_log.EventTypeArg.legal_holds_export_a_hold: (data_governance)
-        Exported hold
-    :ivar team_log.EventTypeArg.legal_holds_export_cancelled: (data_governance)
-        Canceled export for a hold
-    :ivar team_log.EventTypeArg.legal_holds_export_downloaded: (data_governance)
-        Downloaded export for a hold
-    :ivar team_log.EventTypeArg.legal_holds_export_removed: (data_governance)
-        Removed export for a hold
-    :ivar team_log.EventTypeArg.legal_holds_release_a_hold: (data_governance)
-        Released a hold
-    :ivar team_log.EventTypeArg.legal_holds_remove_members: (data_governance)
-        Removed members from a hold
-    :ivar team_log.EventTypeArg.legal_holds_report_a_hold: (data_governance)
-        Created a summary report for a hold
-    :ivar team_log.EventTypeArg.device_change_ip_desktop: (devices) Changed IP
-        address associated with active desktop session
-    :ivar team_log.EventTypeArg.device_change_ip_mobile: (devices) Changed IP
-        address associated with active mobile session
-    :ivar team_log.EventTypeArg.device_change_ip_web: (devices) Changed IP
-        address associated with active web session
-    :ivar team_log.EventTypeArg.device_delete_on_unlink_fail: (devices) Failed
-        to delete all files from unlinked device
-    :ivar team_log.EventTypeArg.device_delete_on_unlink_success: (devices)
-        Deleted all files from unlinked device
-    :ivar team_log.EventTypeArg.device_link_fail: (devices) Failed to link
-        device
-    :ivar team_log.EventTypeArg.device_link_success: (devices) Linked device
-    :ivar team_log.EventTypeArg.device_management_disabled: (devices) Disabled
-        device management (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.device_management_enabled: (devices) Enabled
-        device management (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.device_sync_backup_status_changed: (devices)
-        Enabled/disabled backup for computer
-    :ivar team_log.EventTypeArg.device_unlink: (devices) Disconnected device
-    :ivar team_log.EventTypeArg.dropbox_passwords_exported: (devices) Exported
-        passwords
-    :ivar team_log.EventTypeArg.dropbox_passwords_new_device_enrolled: (devices)
-        Enrolled new Dropbox Passwords device
-    :ivar team_log.EventTypeArg.emm_refresh_auth_token: (devices) Refreshed auth
-        token used for setting up EMM
-    :ivar
-        team_log.EventTypeArg.external_drive_backup_eligibility_status_checked:
+    :ivar EventTypeArg.legal_holds_change_hold_name:
+        (data_governance) Renamed a hold
+    :ivar EventTypeArg.legal_holds_export_a_hold:
+        (data_governance) Exported hold
+    :ivar EventTypeArg.legal_holds_export_cancelled:
+        (data_governance) Canceled export for a hold
+    :ivar EventTypeArg.legal_holds_export_downloaded:
+        (data_governance) Downloaded export for a hold
+    :ivar EventTypeArg.legal_holds_export_removed:
+        (data_governance) Removed export for a hold
+    :ivar EventTypeArg.legal_holds_release_a_hold:
+        (data_governance) Released a hold
+    :ivar EventTypeArg.legal_holds_remove_members:
+        (data_governance) Removed members from a hold
+    :ivar EventTypeArg.legal_holds_report_a_hold:
+        (data_governance) Created a summary report for a hold
+    :ivar EventTypeArg.device_change_ip_desktop:
+        (devices) Changed IP address associated with active desktop session
+    :ivar EventTypeArg.device_change_ip_mobile:
+        (devices) Changed IP address associated with active mobile session
+    :ivar EventTypeArg.device_change_ip_web:
+        (devices) Changed IP address associated with active web session
+    :ivar EventTypeArg.device_delete_on_unlink_fail:
+        (devices) Failed to delete all files from unlinked device
+    :ivar EventTypeArg.device_delete_on_unlink_success:
+        (devices) Deleted all files from unlinked device
+    :ivar EventTypeArg.device_link_fail:
+        (devices) Failed to link device
+    :ivar EventTypeArg.device_link_success:
+        (devices) Linked device
+    :ivar EventTypeArg.device_management_disabled:
+        (devices) Disabled device management (deprecated, no longer logged)
+    :ivar EventTypeArg.device_management_enabled:
+        (devices) Enabled device management (deprecated, no longer logged)
+    :ivar EventTypeArg.device_sync_backup_status_changed:
+        (devices) Enabled/disabled backup for computer
+    :ivar EventTypeArg.device_unlink:
+        (devices) Disconnected device
+    :ivar EventTypeArg.dropbox_passwords_exported:
+        (devices) Exported passwords
+    :ivar EventTypeArg.dropbox_passwords_new_device_enrolled:
+        (devices) Enrolled new Dropbox Passwords device
+    :ivar EventTypeArg.emm_refresh_auth_token:
+        (devices) Refreshed auth token used for setting up EMM
+    :ivar EventTypeArg.external_drive_backup_eligibility_status_checked:
         (devices) Checked external drive backup eligibility status
-    :ivar team_log.EventTypeArg.external_drive_backup_status_changed: (devices)
-        Modified external drive backup
-    :ivar team_log.EventTypeArg.account_capture_change_availability: (domains)
-        Granted/revoked option to enable account capture on team domains
-    :ivar team_log.EventTypeArg.account_capture_migrate_account: (domains)
-        Account-captured user migrated account to team
-    :ivar team_log.EventTypeArg.account_capture_notification_emails_sent:
+    :ivar EventTypeArg.external_drive_backup_status_changed:
+        (devices) Modified external drive backup
+    :ivar EventTypeArg.account_capture_change_availability:
+        (domains) Granted/revoked option to enable account capture on team
+        domains
+    :ivar EventTypeArg.account_capture_migrate_account:
+        (domains) Account-captured user migrated account to team
+    :ivar EventTypeArg.account_capture_notification_emails_sent:
         (domains) Sent account capture email to all unmanaged members
-    :ivar team_log.EventTypeArg.account_capture_relinquish_account: (domains)
-        Account-captured user changed account email to personal email
-    :ivar team_log.EventTypeArg.disabled_domain_invites: (domains) Disabled
-        domain invites (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.domain_invites_approve_request_to_join_team:
+    :ivar EventTypeArg.account_capture_relinquish_account:
+        (domains) Account-captured user changed account email to personal email
+    :ivar EventTypeArg.disabled_domain_invites:
+        (domains) Disabled domain invites (deprecated, no longer logged)
+    :ivar EventTypeArg.domain_invites_approve_request_to_join_team:
         (domains) Approved user's request to join team
-    :ivar team_log.EventTypeArg.domain_invites_decline_request_to_join_team:
+    :ivar EventTypeArg.domain_invites_decline_request_to_join_team:
         (domains) Declined user's request to join team
-    :ivar team_log.EventTypeArg.domain_invites_email_existing_users: (domains)
-        Sent domain invites to existing domain accounts (deprecated, no longer
-        logged)
-    :ivar team_log.EventTypeArg.domain_invites_request_to_join_team: (domains)
-        Requested to join team
-    :ivar team_log.EventTypeArg.domain_invites_set_invite_new_user_pref_to_no:
+    :ivar EventTypeArg.domain_invites_email_existing_users:
+        (domains) Sent domain invites to existing domain accounts (deprecated,
+        no longer logged)
+    :ivar EventTypeArg.domain_invites_request_to_join_team:
+        (domains) Requested to join team
+    :ivar EventTypeArg.domain_invites_set_invite_new_user_pref_to_no:
         (domains) Disabled "Automatically invite new users" (deprecated, no
         longer logged)
-    :ivar team_log.EventTypeArg.domain_invites_set_invite_new_user_pref_to_yes:
+    :ivar EventTypeArg.domain_invites_set_invite_new_user_pref_to_yes:
         (domains) Enabled "Automatically invite new users" (deprecated, no
         longer logged)
-    :ivar team_log.EventTypeArg.domain_verification_add_domain_fail: (domains)
-        Failed to verify team domain
-    :ivar team_log.EventTypeArg.domain_verification_add_domain_success:
+    :ivar EventTypeArg.domain_verification_add_domain_fail:
+        (domains) Failed to verify team domain
+    :ivar EventTypeArg.domain_verification_add_domain_success:
         (domains) Verified team domain
-    :ivar team_log.EventTypeArg.domain_verification_remove_domain: (domains)
-        Removed domain from list of verified team domains
-    :ivar team_log.EventTypeArg.enabled_domain_invites: (domains) Enabled domain
-        invites (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.encrypted_folder_cancel_team_key_rotation:
+    :ivar EventTypeArg.domain_verification_remove_domain:
+        (domains) Removed domain from list of verified team domains
+    :ivar EventTypeArg.enabled_domain_invites:
+        (domains) Enabled domain invites (deprecated, no longer logged)
+    :ivar EventTypeArg.encrypted_folder_cancel_team_key_rotation:
         (encryption) Canceled team key rotation
-    :ivar team_log.EventTypeArg.encrypted_folder_enroll_backup_key: (encryption)
-        Added recovery key
-    :ivar team_log.EventTypeArg.encrypted_folder_enroll_client: (encryption)
-        Enrolled device
-    :ivar team_log.EventTypeArg.encrypted_folder_enroll_team: (encryption)
-        Activated team folder encryption
-    :ivar team_log.EventTypeArg.encrypted_folder_finish_team_unenrollment:
+    :ivar EventTypeArg.encrypted_folder_enroll_backup_key:
+        (encryption) Added recovery key
+    :ivar EventTypeArg.encrypted_folder_enroll_client:
+        (encryption) Enrolled device
+    :ivar EventTypeArg.encrypted_folder_enroll_team:
+        (encryption) Activated team folder encryption
+    :ivar EventTypeArg.encrypted_folder_finish_team_unenrollment:
         (encryption) Deactivated team folder encryption
-    :ivar team_log.EventTypeArg.encrypted_folder_init_team_key_rotation:
+    :ivar EventTypeArg.encrypted_folder_init_team_key_rotation:
         (encryption) Initiated team key rotation
-    :ivar team_log.EventTypeArg.encrypted_folder_init_team_unenrollment:
+    :ivar EventTypeArg.encrypted_folder_init_team_unenrollment:
         (encryption) Initiated deactivation of team folder encryption
-    :ivar team_log.EventTypeArg.encrypted_folder_remove_backup_key: (encryption)
-        Removed recovery key
-    :ivar team_log.EventTypeArg.encrypted_folder_rotate_team_key: (encryption)
-        Rotated team key
-    :ivar team_log.EventTypeArg.encrypted_folder_unenroll_client: (encryption)
-        Unenrolled device
-    :ivar team_log.EventTypeArg.team_encryption_key_activate_key: (encryption)
-        Activated team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_cancel_key_deletion:
+    :ivar EventTypeArg.encrypted_folder_remove_backup_key:
+        (encryption) Removed recovery key
+    :ivar EventTypeArg.encrypted_folder_rotate_team_key:
+        (encryption) Rotated team key
+    :ivar EventTypeArg.encrypted_folder_unenroll_client:
+        (encryption) Unenrolled device
+    :ivar EventTypeArg.team_encryption_key_activate_key:
+        (encryption) Activated team encryption key
+    :ivar EventTypeArg.team_encryption_key_cancel_key_deletion:
         (encryption) Canceled team encryption key deletion
-    :ivar team_log.EventTypeArg.team_encryption_key_create_key: (encryption)
-        Created team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_deactivate_key: (encryption)
-        Deactivated team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_delete_key: (encryption)
-        Deleted team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_disable_key: (encryption)
-        Disabled team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_enable_key: (encryption)
-        Enabled team encryption key
-    :ivar team_log.EventTypeArg.team_encryption_key_rotate_key: (encryption)
-        Rotated team encryption key (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.team_encryption_key_schedule_key_deletion:
+    :ivar EventTypeArg.team_encryption_key_create_key:
+        (encryption) Created team encryption key
+    :ivar EventTypeArg.team_encryption_key_deactivate_key:
+        (encryption) Deactivated team encryption key
+    :ivar EventTypeArg.team_encryption_key_delete_key:
+        (encryption) Deleted team encryption key
+    :ivar EventTypeArg.team_encryption_key_disable_key:
+        (encryption) Disabled team encryption key
+    :ivar EventTypeArg.team_encryption_key_enable_key:
+        (encryption) Enabled team encryption key
+    :ivar EventTypeArg.team_encryption_key_rotate_key:
+        (encryption) Rotated team encryption key (deprecated, no longer logged)
+    :ivar EventTypeArg.team_encryption_key_schedule_key_deletion:
         (encryption) Scheduled encryption key deletion
-    :ivar team_log.EventTypeArg.apply_naming_convention: (file_operations)
-        Applied naming convention
-    :ivar team_log.EventTypeArg.create_folder: (file_operations) Created folders
-        (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.file_add: (file_operations) Added files and/or
-        folders
-    :ivar team_log.EventTypeArg.file_add_from_automation: (file_operations)
-        Added files and/or folders from automation
-    :ivar team_log.EventTypeArg.file_copy: (file_operations) Copied files and/or
-        folders
-    :ivar team_log.EventTypeArg.file_delete: (file_operations) Deleted files
-        and/or folders
-    :ivar team_log.EventTypeArg.file_download: (file_operations) Downloaded
-        files and/or folders
-    :ivar team_log.EventTypeArg.file_edit: (file_operations) Edited files
-    :ivar team_log.EventTypeArg.file_get_copy_reference: (file_operations)
-        Created copy reference to file/folder
-    :ivar team_log.EventTypeArg.file_locking_lock_status_changed:
+    :ivar EventTypeArg.apply_naming_convention:
+        (file_operations) Applied naming convention
+    :ivar EventTypeArg.create_folder:
+        (file_operations) Created folders (deprecated, no longer logged)
+    :ivar EventTypeArg.file_add:
+        (file_operations) Added files and/or folders
+    :ivar EventTypeArg.file_add_from_automation:
+        (file_operations) Added files and/or folders from automation
+    :ivar EventTypeArg.file_copy:
+        (file_operations) Copied files and/or folders
+    :ivar EventTypeArg.file_delete:
+        (file_operations) Deleted files and/or folders
+    :ivar EventTypeArg.file_download:
+        (file_operations) Downloaded files and/or folders
+    :ivar EventTypeArg.file_edit:
+        (file_operations) Edited files
+    :ivar EventTypeArg.file_get_copy_reference:
+        (file_operations) Created copy reference to file/folder
+    :ivar EventTypeArg.file_locking_lock_status_changed:
         (file_operations) Locked/unlocked editing for a file
-    :ivar team_log.EventTypeArg.file_move: (file_operations) Moved files and/or
-        folders
-    :ivar team_log.EventTypeArg.file_permanently_delete: (file_operations)
-        Permanently deleted files and/or folders
-    :ivar team_log.EventTypeArg.file_preview: (file_operations) Previewed files
-        and/or folders
-    :ivar team_log.EventTypeArg.file_rename: (file_operations) Renamed files
-        and/or folders
-    :ivar team_log.EventTypeArg.file_restore: (file_operations) Restored deleted
-        files and/or folders
-    :ivar team_log.EventTypeArg.file_revert: (file_operations) Reverted files to
-        previous version
-    :ivar team_log.EventTypeArg.file_rollback_changes: (file_operations) Rolled
-        back file actions
-    :ivar team_log.EventTypeArg.file_save_copy_reference: (file_operations)
-        Saved file/folder using copy reference
-    :ivar team_log.EventTypeArg.folder_overview_description_changed:
+    :ivar EventTypeArg.file_move:
+        (file_operations) Moved files and/or folders
+    :ivar EventTypeArg.file_permanently_delete:
+        (file_operations) Permanently deleted files and/or folders
+    :ivar EventTypeArg.file_preview:
+        (file_operations) Previewed files and/or folders
+    :ivar EventTypeArg.file_rename:
+        (file_operations) Renamed files and/or folders
+    :ivar EventTypeArg.file_restore:
+        (file_operations) Restored deleted files and/or folders
+    :ivar EventTypeArg.file_revert:
+        (file_operations) Reverted files to previous version
+    :ivar EventTypeArg.file_rollback_changes:
+        (file_operations) Rolled back file actions
+    :ivar EventTypeArg.file_save_copy_reference:
+        (file_operations) Saved file/folder using copy reference
+    :ivar EventTypeArg.folder_overview_description_changed:
         (file_operations) Updated folder overview
-    :ivar team_log.EventTypeArg.folder_overview_item_pinned: (file_operations)
-        Pinned item to folder overview
-    :ivar team_log.EventTypeArg.folder_overview_item_unpinned: (file_operations)
-        Unpinned item from folder overview
-    :ivar team_log.EventTypeArg.media_hub_file_downloaded: (file_operations)
-        Downloaded files in Media Hub
-    :ivar team_log.EventTypeArg.object_label_added: (file_operations) Added a
-        label
-    :ivar team_log.EventTypeArg.object_label_removed: (file_operations) Removed
-        a label
-    :ivar team_log.EventTypeArg.object_label_updated_value: (file_operations)
-        Updated a label's value
-    :ivar team_log.EventTypeArg.organize_folder_with_tidy: (file_operations)
-        Organized a folder with multi-file organize
-    :ivar team_log.EventTypeArg.replay_file_delete: (file_operations) Deleted
-        files in Replay
-    :ivar team_log.EventTypeArg.replay_file_downloaded: (file_operations)
-        Downloaded files in Replay
-    :ivar team_log.EventTypeArg.replay_team_project_created: (file_operations)
-        Created a team project in Replay
-    :ivar team_log.EventTypeArg.rewind_folder: (file_operations) Rewound a
-        folder
-    :ivar team_log.EventTypeArg.undo_naming_convention: (file_operations)
-        Reverted naming convention
-    :ivar team_log.EventTypeArg.undo_organize_folder_with_tidy:
+    :ivar EventTypeArg.folder_overview_item_pinned:
+        (file_operations) Pinned item to folder overview
+    :ivar EventTypeArg.folder_overview_item_unpinned:
+        (file_operations) Unpinned item from folder overview
+    :ivar EventTypeArg.media_hub_file_downloaded:
+        (file_operations) Downloaded files in Media Hub
+    :ivar EventTypeArg.object_label_added:
+        (file_operations) Added a label
+    :ivar EventTypeArg.object_label_removed:
+        (file_operations) Removed a label
+    :ivar EventTypeArg.object_label_updated_value:
+        (file_operations) Updated a label's value
+    :ivar EventTypeArg.organize_folder_with_tidy:
+        (file_operations) Organized a folder with multi-file organize
+    :ivar EventTypeArg.replay_file_delete:
+        (file_operations) Deleted files in Replay
+    :ivar EventTypeArg.replay_file_downloaded:
+        (file_operations) Downloaded files in Replay
+    :ivar EventTypeArg.replay_team_project_created:
+        (file_operations) Created a team project in Replay
+    :ivar EventTypeArg.rewind_folder:
+        (file_operations) Rewound a folder
+    :ivar EventTypeArg.undo_naming_convention:
+        (file_operations) Reverted naming convention
+    :ivar EventTypeArg.undo_organize_folder_with_tidy:
         (file_operations) Removed multi-file organize
-    :ivar team_log.EventTypeArg.user_tags_added: (file_operations) Tagged a file
-    :ivar team_log.EventTypeArg.user_tags_removed: (file_operations) Removed
-        tags
-    :ivar team_log.EventTypeArg.email_ingest_receive_file: (file_requests)
-        Received files via Email to Dropbox
-    :ivar team_log.EventTypeArg.file_request_auto_close: (file_requests) Auto
-        closed file request
-    :ivar team_log.EventTypeArg.file_request_change: (file_requests) Changed
-        file request
-    :ivar team_log.EventTypeArg.file_request_close: (file_requests) Closed file
-        request
-    :ivar team_log.EventTypeArg.file_request_create: (file_requests) Created
-        file request
-    :ivar team_log.EventTypeArg.file_request_delete: (file_requests) Delete file
-        request
-    :ivar team_log.EventTypeArg.file_request_receive_file: (file_requests)
-        Received files for file request
-    :ivar team_log.EventTypeArg.group_add_external_id: (groups) Added external
-        ID for group
-    :ivar team_log.EventTypeArg.group_add_member: (groups) Added team members to
-        group
-    :ivar team_log.EventTypeArg.group_change_external_id: (groups) Changed
-        external ID for group
-    :ivar team_log.EventTypeArg.group_change_management_type: (groups) Changed
-        group management type
-    :ivar team_log.EventTypeArg.group_change_member_role: (groups) Changed
-        manager permissions of group member
-    :ivar team_log.EventTypeArg.group_create: (groups) Created group
-    :ivar team_log.EventTypeArg.group_delete: (groups) Deleted group
-    :ivar team_log.EventTypeArg.group_description_updated: (groups) Updated
-        group (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.group_external_sharing_setting_override_changed:
+    :ivar EventTypeArg.user_tags_added:
+        (file_operations) Tagged a file
+    :ivar EventTypeArg.user_tags_removed:
+        (file_operations) Removed tags
+    :ivar EventTypeArg.email_ingest_receive_file:
+        (file_requests) Received files via Email to Dropbox
+    :ivar EventTypeArg.file_request_auto_close:
+        (file_requests) Auto closed file request
+    :ivar EventTypeArg.file_request_change:
+        (file_requests) Changed file request
+    :ivar EventTypeArg.file_request_close:
+        (file_requests) Closed file request
+    :ivar EventTypeArg.file_request_create:
+        (file_requests) Created file request
+    :ivar EventTypeArg.file_request_delete:
+        (file_requests) Delete file request
+    :ivar EventTypeArg.file_request_receive_file:
+        (file_requests) Received files for file request
+    :ivar EventTypeArg.group_add_external_id:
+        (groups) Added external ID for group
+    :ivar EventTypeArg.group_add_member:
+        (groups) Added team members to group
+    :ivar EventTypeArg.group_change_external_id:
+        (groups) Changed external ID for group
+    :ivar EventTypeArg.group_change_management_type:
+        (groups) Changed group management type
+    :ivar EventTypeArg.group_change_member_role:
+        (groups) Changed manager permissions of group member
+    :ivar EventTypeArg.group_create:
+        (groups) Created group
+    :ivar EventTypeArg.group_delete:
+        (groups) Deleted group
+    :ivar EventTypeArg.group_description_updated:
+        (groups) Updated group (deprecated, no longer logged)
+    :ivar EventTypeArg.group_external_sharing_setting_override_changed:
         (groups) Changed group's external sharing setting
-    :ivar team_log.EventTypeArg.group_join_policy_updated: (groups) Updated
-        group join policy (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.group_moved: (groups) Moved group (deprecated,
-        no longer logged)
-    :ivar team_log.EventTypeArg.group_remove_external_id: (groups) Removed
-        external ID for group
-    :ivar team_log.EventTypeArg.group_remove_member: (groups) Removed team
-        members from group
-    :ivar team_log.EventTypeArg.group_rename: (groups) Renamed group
-    :ivar team_log.EventTypeArg.account_lock_or_unlocked: (logins)
-        Unlocked/locked account after failed sign in attempts
-    :ivar team_log.EventTypeArg.emm_error: (logins) Failed to sign in via EMM
-        (deprecated, replaced by 'Failed to sign in')
-    :ivar team_log.EventTypeArg.guest_admin_signed_in_via_trusted_teams:
+    :ivar EventTypeArg.group_join_policy_updated:
+        (groups) Updated group join policy (deprecated, no longer logged)
+    :ivar EventTypeArg.group_moved:
+        (groups) Moved group (deprecated, no longer logged)
+    :ivar EventTypeArg.group_remove_external_id:
+        (groups) Removed external ID for group
+    :ivar EventTypeArg.group_remove_member:
+        (groups) Removed team members from group
+    :ivar EventTypeArg.group_rename:
+        (groups) Renamed group
+    :ivar EventTypeArg.account_lock_or_unlocked:
+        (logins) Unlocked/locked account after failed sign in attempts
+    :ivar EventTypeArg.emm_error:
+        (logins) Failed to sign in via EMM (deprecated, replaced by 'Failed to
+        sign in')
+    :ivar EventTypeArg.guest_admin_signed_in_via_trusted_teams:
         (logins) Started trusted team admin session
-    :ivar team_log.EventTypeArg.guest_admin_signed_out_via_trusted_teams:
+    :ivar EventTypeArg.guest_admin_signed_out_via_trusted_teams:
         (logins) Ended trusted team admin session
-    :ivar team_log.EventTypeArg.login_fail: (logins) Failed to sign in
-    :ivar team_log.EventTypeArg.login_success: (logins) Signed in
-    :ivar team_log.EventTypeArg.logout: (logins) Signed out
-    :ivar team_log.EventTypeArg.reseller_support_session_end: (logins) Ended
-        reseller support session
-    :ivar team_log.EventTypeArg.reseller_support_session_start: (logins) Started
-        reseller support session
-    :ivar team_log.EventTypeArg.sign_in_as_session_end: (logins) Ended admin
-        sign-in-as session
-    :ivar team_log.EventTypeArg.sign_in_as_session_start: (logins) Started admin
-        sign-in-as session
-    :ivar team_log.EventTypeArg.sso_error: (logins) Failed to sign in via SSO
-        (deprecated, replaced by 'Failed to sign in')
-    :ivar team_log.EventTypeArg.addon_assigned: (members) Add-on Assigned
-    :ivar team_log.EventTypeArg.addon_removed: (members) Add-on Removed
-    :ivar team_log.EventTypeArg.backup_admin_invitation_sent: (members) Invited
-        members to activate Backup
-    :ivar team_log.EventTypeArg.backup_invitation_opened: (members) Opened
-        Backup invite
-    :ivar team_log.EventTypeArg.create_team_invite_link: (members) Created team
-        invite link
-    :ivar team_log.EventTypeArg.delete_team_invite_link: (members) Deleted team
-        invite link
-    :ivar team_log.EventTypeArg.member_add_external_id: (members) Added an
-        external ID for team member
-    :ivar team_log.EventTypeArg.member_add_name: (members) Added team member
-        name
-    :ivar team_log.EventTypeArg.member_change_admin_role: (members) Changed team
-        member admin role
-    :ivar team_log.EventTypeArg.member_change_email: (members) Changed team
-        member email
-    :ivar team_log.EventTypeArg.member_change_external_id: (members) Changed the
-        external ID for team member
-    :ivar team_log.EventTypeArg.member_change_membership_type: (members) Changed
-        membership type (limited/full) of member (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.member_change_name: (members) Changed team
-        member name
-    :ivar team_log.EventTypeArg.member_change_reseller_role: (members) Changed
-        team member reseller role
-    :ivar team_log.EventTypeArg.member_change_status: (members) Changed member
-        status (invited, joined, suspended, etc.)
-    :ivar team_log.EventTypeArg.member_delete_manual_contacts: (members) Cleared
-        manually added contacts
-    :ivar team_log.EventTypeArg.member_delete_profile_photo: (members) Deleted
-        team member profile photo
-    :ivar team_log.EventTypeArg.member_permanently_delete_account_contents:
+    :ivar EventTypeArg.login_fail:
+        (logins) Failed to sign in
+    :ivar EventTypeArg.login_success:
+        (logins) Signed in
+    :ivar EventTypeArg.logout:
+        (logins) Signed out
+    :ivar EventTypeArg.reseller_support_session_end:
+        (logins) Ended reseller support session
+    :ivar EventTypeArg.reseller_support_session_start:
+        (logins) Started reseller support session
+    :ivar EventTypeArg.sign_in_as_session_end:
+        (logins) Ended admin sign-in-as session
+    :ivar EventTypeArg.sign_in_as_session_start:
+        (logins) Started admin sign-in-as session
+    :ivar EventTypeArg.sso_error:
+        (logins) Failed to sign in via SSO (deprecated, replaced by 'Failed to
+        sign in')
+    :ivar EventTypeArg.addon_assigned:
+        (members) Add-on Assigned
+    :ivar EventTypeArg.addon_removed:
+        (members) Add-on Removed
+    :ivar EventTypeArg.backup_admin_invitation_sent:
+        (members) Invited members to activate Backup
+    :ivar EventTypeArg.backup_invitation_opened:
+        (members) Opened Backup invite
+    :ivar EventTypeArg.create_team_invite_link:
+        (members) Created team invite link
+    :ivar EventTypeArg.delete_team_invite_link:
+        (members) Deleted team invite link
+    :ivar EventTypeArg.member_add_external_id:
+        (members) Added an external ID for team member
+    :ivar EventTypeArg.member_add_name:
+        (members) Added team member name
+    :ivar EventTypeArg.member_change_admin_role:
+        (members) Changed team member admin role
+    :ivar EventTypeArg.member_change_email:
+        (members) Changed team member email
+    :ivar EventTypeArg.member_change_external_id:
+        (members) Changed the external ID for team member
+    :ivar EventTypeArg.member_change_membership_type:
+        (members) Changed membership type (limited/full) of member (deprecated,
+        no longer logged)
+    :ivar EventTypeArg.member_change_name:
+        (members) Changed team member name
+    :ivar EventTypeArg.member_change_reseller_role:
+        (members) Changed team member reseller role
+    :ivar EventTypeArg.member_change_status:
+        (members) Changed member status (invited, joined, suspended, etc.)
+    :ivar EventTypeArg.member_delete_manual_contacts:
+        (members) Cleared manually added contacts
+    :ivar EventTypeArg.member_delete_profile_photo:
+        (members) Deleted team member profile photo
+    :ivar EventTypeArg.member_permanently_delete_account_contents:
         (members) Permanently deleted contents of deleted team member account
-    :ivar team_log.EventTypeArg.member_remove_external_id: (members) Removed the
-        external ID for team member
-    :ivar team_log.EventTypeArg.member_set_profile_photo: (members) Set team
-        member profile photo
-    :ivar team_log.EventTypeArg.member_space_limits_add_custom_quota: (members)
-        Set custom member space limit
-    :ivar team_log.EventTypeArg.member_space_limits_change_custom_quota:
+    :ivar EventTypeArg.member_remove_external_id:
+        (members) Removed the external ID for team member
+    :ivar EventTypeArg.member_set_profile_photo:
+        (members) Set team member profile photo
+    :ivar EventTypeArg.member_space_limits_add_custom_quota:
+        (members) Set custom member space limit
+    :ivar EventTypeArg.member_space_limits_change_custom_quota:
         (members) Changed custom member space limit
-    :ivar team_log.EventTypeArg.member_space_limits_change_status: (members)
-        Changed space limit status
-    :ivar team_log.EventTypeArg.member_space_limits_remove_custom_quota:
+    :ivar EventTypeArg.member_space_limits_change_status:
+        (members) Changed space limit status
+    :ivar EventTypeArg.member_space_limits_remove_custom_quota:
         (members) Removed custom member space limit
-    :ivar team_log.EventTypeArg.member_suggest: (members) Suggested person to
-        add to team
-    :ivar team_log.EventTypeArg.member_transfer_account_contents: (members)
-        Transferred contents of deleted member account to another member
-    :ivar team_log.EventTypeArg.pending_secondary_email_added: (members) Added
-        pending secondary email
-    :ivar team_log.EventTypeArg.product_assigned_to_member: (members) Product
-        assigned to team member
-    :ivar team_log.EventTypeArg.product_removed_from_member: (members) Product
-        removed from team member
-    :ivar team_log.EventTypeArg.secondary_email_deleted: (members) Deleted
-        secondary email
-    :ivar team_log.EventTypeArg.secondary_email_verified: (members) Verified
-        secondary email
-    :ivar team_log.EventTypeArg.secondary_mails_policy_changed: (members)
-        Secondary mails policy changed
-    :ivar team_log.EventTypeArg.binder_add_page: (paper) Added Binder page
-        (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_add_section: (paper) Added Binder section
-        (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_remove_page: (paper) Removed Binder page
-        (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_remove_section: (paper) Removed Binder
-        section (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_rename_page: (paper) Renamed Binder page
-        (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_rename_section: (paper) Renamed Binder
-        section (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_reorder_page: (paper) Reordered Binder
-        page (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.binder_reorder_section: (paper) Reordered Binder
-        section (deprecated, replaced by 'Edited files')
-    :ivar team_log.EventTypeArg.paper_content_add_member: (paper) Added users
-        and/or groups to Paper doc/folder
-    :ivar team_log.EventTypeArg.paper_content_add_to_folder: (paper) Added Paper
-        doc/folder to folder
-    :ivar team_log.EventTypeArg.paper_content_archive: (paper) Archived Paper
-        doc/folder
-    :ivar team_log.EventTypeArg.paper_content_create: (paper) Created Paper
-        doc/folder
-    :ivar team_log.EventTypeArg.paper_content_permanently_delete: (paper)
-        Permanently deleted Paper doc/folder
-    :ivar team_log.EventTypeArg.paper_content_remove_from_folder: (paper)
-        Removed Paper doc/folder from folder
-    :ivar team_log.EventTypeArg.paper_content_remove_member: (paper) Removed
-        users and/or groups from Paper doc/folder
-    :ivar team_log.EventTypeArg.paper_content_rename: (paper) Renamed Paper
-        doc/folder
-    :ivar team_log.EventTypeArg.paper_content_restore: (paper) Restored archived
-        Paper doc/folder
-    :ivar team_log.EventTypeArg.paper_doc_add_comment: (paper) Added Paper doc
-        comment
-    :ivar team_log.EventTypeArg.paper_doc_change_member_role: (paper) Changed
-        member permissions for Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_change_sharing_policy: (paper) Changed
-        sharing setting for Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_change_subscription: (paper)
-        Followed/unfollowed Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_deleted: (paper) Archived Paper doc
-        (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.paper_doc_delete_comment: (paper) Deleted Paper
-        doc comment
-    :ivar team_log.EventTypeArg.paper_doc_download: (paper) Downloaded Paper doc
-        in specific format
-    :ivar team_log.EventTypeArg.paper_doc_edit: (paper) Edited Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_edit_comment: (paper) Edited Paper doc
-        comment
-    :ivar team_log.EventTypeArg.paper_doc_followed: (paper) Followed Paper doc
-        (deprecated, replaced by 'Followed/unfollowed Paper doc')
-    :ivar team_log.EventTypeArg.paper_doc_mention: (paper) Mentioned user in
-        Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_ownership_changed: (paper) Transferred
-        ownership of Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_request_access: (paper) Requested
-        access to Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_resolve_comment: (paper) Resolved
-        Paper doc comment
-    :ivar team_log.EventTypeArg.paper_doc_revert: (paper) Restored Paper doc to
-        previous version
-    :ivar team_log.EventTypeArg.paper_doc_slack_share: (paper) Shared Paper doc
-        via Slack
-    :ivar team_log.EventTypeArg.paper_doc_team_invite: (paper) Shared Paper doc
-        with users and/or groups (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.paper_doc_trashed: (paper) Deleted Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_unresolve_comment: (paper) Unresolved
-        Paper doc comment
-    :ivar team_log.EventTypeArg.paper_doc_untrashed: (paper) Restored Paper doc
-    :ivar team_log.EventTypeArg.paper_doc_view: (paper) Viewed Paper doc
-    :ivar team_log.EventTypeArg.paper_external_view_allow: (paper) Changed Paper
-        external sharing setting to anyone (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.paper_external_view_default_team: (paper)
-        Changed Paper external sharing setting to default team (deprecated, no
-        longer logged)
-    :ivar team_log.EventTypeArg.paper_external_view_forbid: (paper) Changed
-        Paper external sharing setting to team-only (deprecated, no longer
+    :ivar EventTypeArg.member_suggest:
+        (members) Suggested person to add to team
+    :ivar EventTypeArg.member_transfer_account_contents:
+        (members) Transferred contents of deleted member account to another
+        member
+    :ivar EventTypeArg.pending_secondary_email_added:
+        (members) Added pending secondary email
+    :ivar EventTypeArg.product_assigned_to_member:
+        (members) Product assigned to team member
+    :ivar EventTypeArg.product_removed_from_member:
+        (members) Product removed from team member
+    :ivar EventTypeArg.secondary_email_deleted:
+        (members) Deleted secondary email
+    :ivar EventTypeArg.secondary_email_verified:
+        (members) Verified secondary email
+    :ivar EventTypeArg.secondary_mails_policy_changed:
+        (members) Secondary mails policy changed
+    :ivar EventTypeArg.binder_add_page:
+        (paper) Added Binder page (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_add_section:
+        (paper) Added Binder section (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_remove_page:
+        (paper) Removed Binder page (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_remove_section:
+        (paper) Removed Binder section (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_rename_page:
+        (paper) Renamed Binder page (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_rename_section:
+        (paper) Renamed Binder section (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_reorder_page:
+        (paper) Reordered Binder page (deprecated, replaced by 'Edited files')
+    :ivar EventTypeArg.binder_reorder_section:
+        (paper) Reordered Binder section (deprecated, replaced by 'Edited
+        files')
+    :ivar EventTypeArg.paper_content_add_member:
+        (paper) Added users and/or groups to Paper doc/folder
+    :ivar EventTypeArg.paper_content_add_to_folder:
+        (paper) Added Paper doc/folder to folder
+    :ivar EventTypeArg.paper_content_archive:
+        (paper) Archived Paper doc/folder
+    :ivar EventTypeArg.paper_content_create:
+        (paper) Created Paper doc/folder
+    :ivar EventTypeArg.paper_content_permanently_delete:
+        (paper) Permanently deleted Paper doc/folder
+    :ivar EventTypeArg.paper_content_remove_from_folder:
+        (paper) Removed Paper doc/folder from folder
+    :ivar EventTypeArg.paper_content_remove_member:
+        (paper) Removed users and/or groups from Paper doc/folder
+    :ivar EventTypeArg.paper_content_rename:
+        (paper) Renamed Paper doc/folder
+    :ivar EventTypeArg.paper_content_restore:
+        (paper) Restored archived Paper doc/folder
+    :ivar EventTypeArg.paper_doc_add_comment:
+        (paper) Added Paper doc comment
+    :ivar EventTypeArg.paper_doc_change_member_role:
+        (paper) Changed member permissions for Paper doc
+    :ivar EventTypeArg.paper_doc_change_sharing_policy:
+        (paper) Changed sharing setting for Paper doc
+    :ivar EventTypeArg.paper_doc_change_subscription:
+        (paper) Followed/unfollowed Paper doc
+    :ivar EventTypeArg.paper_doc_deleted:
+        (paper) Archived Paper doc (deprecated, no longer logged)
+    :ivar EventTypeArg.paper_doc_delete_comment:
+        (paper) Deleted Paper doc comment
+    :ivar EventTypeArg.paper_doc_download:
+        (paper) Downloaded Paper doc in specific format
+    :ivar EventTypeArg.paper_doc_edit:
+        (paper) Edited Paper doc
+    :ivar EventTypeArg.paper_doc_edit_comment:
+        (paper) Edited Paper doc comment
+    :ivar EventTypeArg.paper_doc_followed:
+        (paper) Followed Paper doc (deprecated, replaced by 'Followed/unfollowed
+        Paper doc')
+    :ivar EventTypeArg.paper_doc_mention:
+        (paper) Mentioned user in Paper doc
+    :ivar EventTypeArg.paper_doc_ownership_changed:
+        (paper) Transferred ownership of Paper doc
+    :ivar EventTypeArg.paper_doc_request_access:
+        (paper) Requested access to Paper doc
+    :ivar EventTypeArg.paper_doc_resolve_comment:
+        (paper) Resolved Paper doc comment
+    :ivar EventTypeArg.paper_doc_revert:
+        (paper) Restored Paper doc to previous version
+    :ivar EventTypeArg.paper_doc_slack_share:
+        (paper) Shared Paper doc via Slack
+    :ivar EventTypeArg.paper_doc_team_invite:
+        (paper) Shared Paper doc with users and/or groups (deprecated, no longer
         logged)
-    :ivar team_log.EventTypeArg.paper_folder_change_subscription: (paper)
-        Followed/unfollowed Paper folder
-    :ivar team_log.EventTypeArg.paper_folder_deleted: (paper) Archived Paper
-        folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.paper_folder_followed: (paper) Followed Paper
-        folder (deprecated, replaced by 'Followed/unfollowed Paper folder')
-    :ivar team_log.EventTypeArg.paper_folder_team_invite: (paper) Shared Paper
-        folder with users and/or groups (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.paper_published_link_change_permission: (paper)
-        Changed permissions for published doc
-    :ivar team_log.EventTypeArg.paper_published_link_create: (paper) Published
-        doc
-    :ivar team_log.EventTypeArg.paper_published_link_disabled: (paper)
-        Unpublished doc
-    :ivar team_log.EventTypeArg.paper_published_link_view: (paper) Viewed
-        published doc
-    :ivar team_log.EventTypeArg.password_change: (passwords) Changed password
-    :ivar team_log.EventTypeArg.password_reset: (passwords) Reset password
-    :ivar team_log.EventTypeArg.password_reset_all: (passwords) Reset all team
-        member passwords
-    :ivar team_log.EventTypeArg.protect_internal_domains_changed: (protect)
-        Modified Protect internal domains list
-    :ivar team_log.EventTypeArg.classification_create_report: (reports) Created
-        Classification report
-    :ivar team_log.EventTypeArg.classification_create_report_fail: (reports)
-        Couldn't create Classification report
-    :ivar team_log.EventTypeArg.emm_create_exceptions_report: (reports) Created
-        EMM-excluded users report
-    :ivar team_log.EventTypeArg.emm_create_usage_report: (reports) Created EMM
-        mobile app usage report
-    :ivar team_log.EventTypeArg.export_members_report: (reports) Created member
-        data report
-    :ivar team_log.EventTypeArg.export_members_report_fail: (reports) Failed to
-        create members data report
-    :ivar team_log.EventTypeArg.external_sharing_create_report: (reports)
-        Created External sharing report
-    :ivar team_log.EventTypeArg.external_sharing_report_failed: (reports)
-        Couldn't create External sharing report
-    :ivar team_log.EventTypeArg.member_access_details_create_report: (reports)
-        Created member access report
-    :ivar team_log.EventTypeArg.member_access_details_create_report_failed:
-        (reports) Couldn't generate member access report
-    :ivar team_log.EventTypeArg.no_expiration_link_gen_create_report: (reports)
-        Report created: Links created with no expiration
-    :ivar team_log.EventTypeArg.no_expiration_link_gen_report_failed: (reports)
-        Couldn't create report: Links created with no expiration
-    :ivar team_log.EventTypeArg.no_password_link_gen_create_report: (reports)
-        Report created: Links created without passwords
-    :ivar team_log.EventTypeArg.no_password_link_gen_report_failed: (reports)
-        Couldn't create report: Links created without passwords
-    :ivar team_log.EventTypeArg.no_password_link_view_create_report: (reports)
-        Report created: Views of links without passwords
-    :ivar team_log.EventTypeArg.no_password_link_view_report_failed: (reports)
-        Couldn't create report: Views of links without passwords
-    :ivar team_log.EventTypeArg.outdated_link_view_create_report: (reports)
-        Report created: Views of old links
-    :ivar team_log.EventTypeArg.outdated_link_view_report_failed: (reports)
-        Couldn't create report: Views of old links
-    :ivar team_log.EventTypeArg.paper_admin_export_start: (reports) Exported all
-        team Paper docs
-    :ivar team_log.EventTypeArg.ransomware_alert_create_report: (reports)
-        Created ransomware report
-    :ivar team_log.EventTypeArg.ransomware_alert_create_report_failed: (reports)
-        Couldn't generate ransomware report
-    :ivar team_log.EventTypeArg.shared_folders_create_report: (reports) Created
-        shared folders report
-    :ivar team_log.EventTypeArg.shared_folders_create_report_failed: (reports)
-        Couldn't generate shared folders report
-    :ivar team_log.EventTypeArg.smart_sync_create_admin_privilege_report:
-        (reports) Created Smart Sync non-admin devices report
-    :ivar team_log.EventTypeArg.team_activity_create_report: (reports) Created
-        team activity report
-    :ivar team_log.EventTypeArg.team_activity_create_report_fail: (reports)
-        Couldn't generate team activity report
-    :ivar team_log.EventTypeArg.team_folders_create_report: (reports) Created
-        team folders report
-    :ivar team_log.EventTypeArg.team_folders_create_report_failed: (reports)
-        Couldn't generate team folders report
-    :ivar team_log.EventTypeArg.team_storage_create_report: (reports) Created
-        team storage report
-    :ivar team_log.EventTypeArg.team_storage_create_report_failed: (reports)
-        Couldn't generate team storage report
-    :ivar team_log.EventTypeArg.collection_share: (sharing) Shared album
-    :ivar team_log.EventTypeArg.file_transfers_file_add: (sharing) Transfer
-        files added
-    :ivar team_log.EventTypeArg.file_transfers_transfer_delete: (sharing)
-        Deleted transfer
-    :ivar team_log.EventTypeArg.file_transfers_transfer_download: (sharing)
-        Transfer downloaded
-    :ivar team_log.EventTypeArg.file_transfers_transfer_send: (sharing) Sent
-        transfer
-    :ivar team_log.EventTypeArg.file_transfers_transfer_view: (sharing) Viewed
-        transfer
-    :ivar team_log.EventTypeArg.media_hub_project_team_add: (sharing) Added
-        member to Media Hub project
-    :ivar team_log.EventTypeArg.media_hub_project_team_delete: (sharing) Removed
-        member from Media Hub project
-    :ivar team_log.EventTypeArg.media_hub_project_team_role_changed: (sharing)
-        Changed member role in Media Hub project
-    :ivar team_log.EventTypeArg.media_hub_shared_link_audience_changed:
-        (sharing) Changed Media Hub shared link audience
-    :ivar team_log.EventTypeArg.media_hub_shared_link_created: (sharing) Created
-        Media Hub shared link
-    :ivar team_log.EventTypeArg.media_hub_shared_link_download_setting_changed:
-        (sharing) Changed Media Hub shared link download setting
-    :ivar team_log.EventTypeArg.media_hub_shared_link_revoked: (sharing) Revoked
-        Media Hub shared link
-    :ivar team_log.EventTypeArg.note_acl_invite_only: (sharing) Changed Paper
-        doc to invite-only (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.note_acl_link: (sharing) Changed Paper doc to
-        link-accessible (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.note_acl_team_link: (sharing) Changed Paper doc
-        to link-accessible for team (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.note_shared: (sharing) Shared Paper doc
+    :ivar EventTypeArg.paper_doc_trashed:
+        (paper) Deleted Paper doc
+    :ivar EventTypeArg.paper_doc_unresolve_comment:
+        (paper) Unresolved Paper doc comment
+    :ivar EventTypeArg.paper_doc_untrashed:
+        (paper) Restored Paper doc
+    :ivar EventTypeArg.paper_doc_view:
+        (paper) Viewed Paper doc
+    :ivar EventTypeArg.paper_external_view_allow:
+        (paper) Changed Paper external sharing setting to anyone (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.paper_external_view_default_team:
+        (paper) Changed Paper external sharing setting to default team
         (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.note_share_receive: (sharing) Shared received
-        Paper doc (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.open_note_shared: (sharing) Opened shared Paper
-        doc (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.replay_file_shared_link_created: (sharing)
-        Created shared link in Replay
-    :ivar team_log.EventTypeArg.replay_file_shared_link_modified: (sharing)
-        Changed shared link in Replay
-    :ivar team_log.EventTypeArg.replay_project_team_add: (sharing) Added member
-        to Replay Project
-    :ivar team_log.EventTypeArg.replay_project_team_delete: (sharing) Removed
-        member from Replay Project
-    :ivar team_log.EventTypeArg.send_and_track_file_added: (sharing) File added
-        to Send and Track
-    :ivar team_log.EventTypeArg.send_and_track_file_renamed: (sharing) File
-        renamed in Send and Track
-    :ivar team_log.EventTypeArg.send_and_track_file_updated: (sharing) File
-        updated in Send and Track
-    :ivar team_log.EventTypeArg.send_and_track_link_created: (sharing) Link
-        created in Send and Track
-    :ivar team_log.EventTypeArg.send_and_track_link_deleted: (sharing) Link
-        deleted in Send and Track
-    :ivar team_log.EventTypeArg.send_and_track_link_updated: (sharing) Send and
-        Track Link Updated
-    :ivar team_log.EventTypeArg.send_and_track_link_viewed: (sharing) Send and
-        Track Link Visited
-    :ivar
-        team_log.EventTypeArg.send_and_track_removed_file_and_associated_links:
+    :ivar EventTypeArg.paper_external_view_forbid:
+        (paper) Changed Paper external sharing setting to team-only (deprecated,
+        no longer logged)
+    :ivar EventTypeArg.paper_folder_change_subscription:
+        (paper) Followed/unfollowed Paper folder
+    :ivar EventTypeArg.paper_folder_deleted:
+        (paper) Archived Paper folder (deprecated, no longer logged)
+    :ivar EventTypeArg.paper_folder_followed:
+        (paper) Followed Paper folder (deprecated, replaced by
+        'Followed/unfollowed Paper folder')
+    :ivar EventTypeArg.paper_folder_team_invite:
+        (paper) Shared Paper folder with users and/or groups (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.paper_published_link_change_permission:
+        (paper) Changed permissions for published doc
+    :ivar EventTypeArg.paper_published_link_create:
+        (paper) Published doc
+    :ivar EventTypeArg.paper_published_link_disabled:
+        (paper) Unpublished doc
+    :ivar EventTypeArg.paper_published_link_view:
+        (paper) Viewed published doc
+    :ivar EventTypeArg.password_change:
+        (passwords) Changed password
+    :ivar EventTypeArg.password_reset:
+        (passwords) Reset password
+    :ivar EventTypeArg.password_reset_all:
+        (passwords) Reset all team member passwords
+    :ivar EventTypeArg.protect_internal_domains_changed:
+        (protect) Modified Protect internal domains list
+    :ivar EventTypeArg.classification_create_report:
+        (reports) Created Classification report
+    :ivar EventTypeArg.classification_create_report_fail:
+        (reports) Couldn't create Classification report
+    :ivar EventTypeArg.emm_create_exceptions_report:
+        (reports) Created EMM-excluded users report
+    :ivar EventTypeArg.emm_create_usage_report:
+        (reports) Created EMM mobile app usage report
+    :ivar EventTypeArg.export_members_report:
+        (reports) Created member data report
+    :ivar EventTypeArg.export_members_report_fail:
+        (reports) Failed to create members data report
+    :ivar EventTypeArg.external_sharing_create_report:
+        (reports) Created External sharing report
+    :ivar EventTypeArg.external_sharing_report_failed:
+        (reports) Couldn't create External sharing report
+    :ivar EventTypeArg.member_access_details_create_report:
+        (reports) Created member access report
+    :ivar EventTypeArg.member_access_details_create_report_failed:
+        (reports) Couldn't generate member access report
+    :ivar EventTypeArg.no_expiration_link_gen_create_report:
+        (reports) Report created: Links created with no expiration
+    :ivar EventTypeArg.no_expiration_link_gen_report_failed:
+        (reports) Couldn't create report: Links created with no expiration
+    :ivar EventTypeArg.no_password_link_gen_create_report:
+        (reports) Report created: Links created without passwords
+    :ivar EventTypeArg.no_password_link_gen_report_failed:
+        (reports) Couldn't create report: Links created without passwords
+    :ivar EventTypeArg.no_password_link_view_create_report:
+        (reports) Report created: Views of links without passwords
+    :ivar EventTypeArg.no_password_link_view_report_failed:
+        (reports) Couldn't create report: Views of links without passwords
+    :ivar EventTypeArg.outdated_link_view_create_report:
+        (reports) Report created: Views of old links
+    :ivar EventTypeArg.outdated_link_view_report_failed:
+        (reports) Couldn't create report: Views of old links
+    :ivar EventTypeArg.paper_admin_export_start:
+        (reports) Exported all team Paper docs
+    :ivar EventTypeArg.ransomware_alert_create_report:
+        (reports) Created ransomware report
+    :ivar EventTypeArg.ransomware_alert_create_report_failed:
+        (reports) Couldn't generate ransomware report
+    :ivar EventTypeArg.shared_folders_create_report:
+        (reports) Created shared folders report
+    :ivar EventTypeArg.shared_folders_create_report_failed:
+        (reports) Couldn't generate shared folders report
+    :ivar EventTypeArg.smart_sync_create_admin_privilege_report:
+        (reports) Created Smart Sync non-admin devices report
+    :ivar EventTypeArg.team_activity_create_report:
+        (reports) Created team activity report
+    :ivar EventTypeArg.team_activity_create_report_fail:
+        (reports) Couldn't generate team activity report
+    :ivar EventTypeArg.team_folders_create_report:
+        (reports) Created team folders report
+    :ivar EventTypeArg.team_folders_create_report_failed:
+        (reports) Couldn't generate team folders report
+    :ivar EventTypeArg.team_storage_create_report:
+        (reports) Created team storage report
+    :ivar EventTypeArg.team_storage_create_report_failed:
+        (reports) Couldn't generate team storage report
+    :ivar EventTypeArg.collection_share:
+        (sharing) Shared album
+    :ivar EventTypeArg.file_transfers_file_add:
+        (sharing) Transfer files added
+    :ivar EventTypeArg.file_transfers_transfer_delete:
+        (sharing) Deleted transfer
+    :ivar EventTypeArg.file_transfers_transfer_download:
+        (sharing) Transfer downloaded
+    :ivar EventTypeArg.file_transfers_transfer_send:
+        (sharing) Sent transfer
+    :ivar EventTypeArg.file_transfers_transfer_view:
+        (sharing) Viewed transfer
+    :ivar EventTypeArg.media_hub_project_team_add:
+        (sharing) Added member to Media Hub project
+    :ivar EventTypeArg.media_hub_project_team_delete:
+        (sharing) Removed member from Media Hub project
+    :ivar EventTypeArg.media_hub_project_team_role_changed:
+        (sharing) Changed member role in Media Hub project
+    :ivar EventTypeArg.media_hub_shared_link_audience_changed:
+        (sharing) Changed Media Hub shared link audience
+    :ivar EventTypeArg.media_hub_shared_link_created:
+        (sharing) Created Media Hub shared link
+    :ivar EventTypeArg.media_hub_shared_link_download_setting_changed:
+        (sharing) Changed Media Hub shared link download setting
+    :ivar EventTypeArg.media_hub_shared_link_revoked:
+        (sharing) Revoked Media Hub shared link
+    :ivar EventTypeArg.note_acl_invite_only:
+        (sharing) Changed Paper doc to invite-only (deprecated, no longer
+        logged)
+    :ivar EventTypeArg.note_acl_link:
+        (sharing) Changed Paper doc to link-accessible (deprecated, no longer
+        logged)
+    :ivar EventTypeArg.note_acl_team_link:
+        (sharing) Changed Paper doc to link-accessible for team (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.note_shared:
+        (sharing) Shared Paper doc (deprecated, no longer logged)
+    :ivar EventTypeArg.note_share_receive:
+        (sharing) Shared received Paper doc (deprecated, no longer logged)
+    :ivar EventTypeArg.open_note_shared:
+        (sharing) Opened shared Paper doc (deprecated, no longer logged)
+    :ivar EventTypeArg.replay_file_shared_link_created:
+        (sharing) Created shared link in Replay
+    :ivar EventTypeArg.replay_file_shared_link_modified:
+        (sharing) Changed shared link in Replay
+    :ivar EventTypeArg.replay_project_team_add:
+        (sharing) Added member to Replay Project
+    :ivar EventTypeArg.replay_project_team_delete:
+        (sharing) Removed member from Replay Project
+    :ivar EventTypeArg.send_and_track_file_added:
+        (sharing) File added to Send and Track
+    :ivar EventTypeArg.send_and_track_file_renamed:
+        (sharing) File renamed in Send and Track
+    :ivar EventTypeArg.send_and_track_file_updated:
+        (sharing) File updated in Send and Track
+    :ivar EventTypeArg.send_and_track_link_created:
+        (sharing) Link created in Send and Track
+    :ivar EventTypeArg.send_and_track_link_deleted:
+        (sharing) Link deleted in Send and Track
+    :ivar EventTypeArg.send_and_track_link_updated:
+        (sharing) Send and Track Link Updated
+    :ivar EventTypeArg.send_and_track_link_viewed:
+        (sharing) Send and Track Link Visited
+    :ivar EventTypeArg.send_and_track_removed_file_and_associated_links:
         (sharing) Send and Track file and associated links deleted
-    :ivar team_log.EventTypeArg.sf_add_group: (sharing) Added team to shared
-        folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_allow_non_members_to_view_shared_links:
+    :ivar EventTypeArg.sf_add_group:
+        (sharing) Added team to shared folder (deprecated, no longer logged)
+    :ivar EventTypeArg.sf_allow_non_members_to_view_shared_links:
         (sharing) Allowed non-collaborators to view links to files in shared
         folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_external_invite_warn: (sharing) Set team
-        members to see warning before sharing folders outside team (deprecated,
-        no longer logged)
-    :ivar team_log.EventTypeArg.sf_fb_invite: (sharing) Invited Facebook users
-        to shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_fb_invite_change_role: (sharing) Changed
-        Facebook user's role in shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_fb_uninvite: (sharing) Uninvited Facebook
-        user from shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_invite_group: (sharing) Invited group to
-        shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_team_grant_access: (sharing) Granted access
-        to shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_team_invite: (sharing) Invited team members
-        to shared folder (deprecated, replaced by 'Invited user to Dropbox and
-        added them to shared file/folder')
-    :ivar team_log.EventTypeArg.sf_team_invite_change_role: (sharing) Changed
-        team member's role in shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_team_join: (sharing) Joined team member's
-        shared folder (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_team_join_from_oob_link: (sharing) Joined
-        team member's shared folder from link (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.sf_team_uninvite: (sharing) Unshared folder with
-        team member (deprecated, replaced by 'Removed invitee from shared
-        file/folder before invite was accepted')
-    :ivar team_log.EventTypeArg.shared_content_add_invitees: (sharing) Invited
-        user to Dropbox and added them to shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_add_link_expiry: (sharing) Added
-        expiration date to link for shared file/folder (deprecated, no longer
+    :ivar EventTypeArg.sf_external_invite_warn:
+        (sharing) Set team members to see warning before sharing folders outside
+        team (deprecated, no longer logged)
+    :ivar EventTypeArg.sf_fb_invite:
+        (sharing) Invited Facebook users to shared folder (deprecated, no longer
         logged)
-    :ivar team_log.EventTypeArg.shared_content_add_link_password: (sharing)
-        Added password to link for shared file/folder (deprecated, no longer
+    :ivar EventTypeArg.sf_fb_invite_change_role:
+        (sharing) Changed Facebook user's role in shared folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.sf_fb_uninvite:
+        (sharing) Uninvited Facebook user from shared folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.sf_invite_group:
+        (sharing) Invited group to shared folder (deprecated, no longer logged)
+    :ivar EventTypeArg.sf_team_grant_access:
+        (sharing) Granted access to shared folder (deprecated, no longer logged)
+    :ivar EventTypeArg.sf_team_invite:
+        (sharing) Invited team members to shared folder (deprecated, replaced by
+        'Invited user to Dropbox and added them to shared file/folder')
+    :ivar EventTypeArg.sf_team_invite_change_role:
+        (sharing) Changed team member's role in shared folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.sf_team_join:
+        (sharing) Joined team member's shared folder (deprecated, no longer
         logged)
-    :ivar team_log.EventTypeArg.shared_content_add_member: (sharing) Added users
-        and/or groups to shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_change_downloads_policy:
+    :ivar EventTypeArg.sf_team_join_from_oob_link:
+        (sharing) Joined team member's shared folder from link (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.sf_team_uninvite:
+        (sharing) Unshared folder with team member (deprecated, replaced by
+        'Removed invitee from shared file/folder before invite was accepted')
+    :ivar EventTypeArg.shared_content_add_invitees:
+        (sharing) Invited user to Dropbox and added them to shared file/folder
+    :ivar EventTypeArg.shared_content_add_link_expiry:
+        (sharing) Added expiration date to link for shared file/folder
+        (deprecated, no longer logged)
+    :ivar EventTypeArg.shared_content_add_link_password:
+        (sharing) Added password to link for shared file/folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.shared_content_add_member:
+        (sharing) Added users and/or groups to shared file/folder
+    :ivar EventTypeArg.shared_content_change_downloads_policy:
         (sharing) Changed whether members can download shared file/folder
         (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.shared_content_change_invitee_role: (sharing)
-        Changed access type of invitee to shared file/folder before invite was
-        accepted
-    :ivar team_log.EventTypeArg.shared_content_change_link_audience: (sharing)
-        Changed link audience of shared file/folder (deprecated, no longer
-        logged)
-    :ivar team_log.EventTypeArg.shared_content_change_link_expiry: (sharing)
-        Changed link expiration of shared file/folder (deprecated, no longer
-        logged)
-    :ivar team_log.EventTypeArg.shared_content_change_link_password: (sharing)
-        Changed link password of shared file/folder (deprecated, no longer
-        logged)
-    :ivar team_log.EventTypeArg.shared_content_change_member_role: (sharing)
-        Changed access type of shared file/folder member
-    :ivar team_log.EventTypeArg.shared_content_change_viewer_info_policy:
-        (sharing) Changed whether members can see who viewed shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_claim_invitation: (sharing)
-        Acquired membership of shared file/folder by accepting invite
-    :ivar team_log.EventTypeArg.shared_content_copy: (sharing) Copied shared
-        file/folder to own Dropbox
-    :ivar team_log.EventTypeArg.shared_content_download: (sharing) Downloaded
-        shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_relinquish_membership: (sharing)
-        Left shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_remove_invitees: (sharing)
-        Removed invitee from shared file/folder before invite was accepted
-    :ivar team_log.EventTypeArg.shared_content_remove_link_expiry: (sharing)
-        Removed link expiration date of shared file/folder (deprecated, no
+    :ivar EventTypeArg.shared_content_change_invitee_role:
+        (sharing) Changed access type of invitee to shared file/folder before
+        invite was accepted
+    :ivar EventTypeArg.shared_content_change_link_audience:
+        (sharing) Changed link audience of shared file/folder (deprecated, no
         longer logged)
-    :ivar team_log.EventTypeArg.shared_content_remove_link_password: (sharing)
-        Removed link password of shared file/folder (deprecated, no longer
-        logged)
-    :ivar team_log.EventTypeArg.shared_content_remove_member: (sharing) Removed
-        user/group from shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_request_access: (sharing)
-        Requested access to shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_restore_invitees: (sharing)
-        Restored shared file/folder invitees
-    :ivar team_log.EventTypeArg.shared_content_restore_member: (sharing)
-        Restored users and/or groups to membership of shared file/folder
-    :ivar team_log.EventTypeArg.shared_content_unshare: (sharing) Unshared
-        file/folder by clearing membership
-    :ivar team_log.EventTypeArg.shared_content_view: (sharing) Previewed shared
+    :ivar EventTypeArg.shared_content_change_link_expiry:
+        (sharing) Changed link expiration of shared file/folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.shared_content_change_link_password:
+        (sharing) Changed link password of shared file/folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.shared_content_change_member_role:
+        (sharing) Changed access type of shared file/folder member
+    :ivar EventTypeArg.shared_content_change_viewer_info_policy:
+        (sharing) Changed whether members can see who viewed shared file/folder
+    :ivar EventTypeArg.shared_content_claim_invitation:
+        (sharing) Acquired membership of shared file/folder by accepting invite
+    :ivar EventTypeArg.shared_content_copy:
+        (sharing) Copied shared file/folder to own Dropbox
+    :ivar EventTypeArg.shared_content_download:
+        (sharing) Downloaded shared file/folder
+    :ivar EventTypeArg.shared_content_relinquish_membership:
+        (sharing) Left shared file/folder
+    :ivar EventTypeArg.shared_content_remove_invitees:
+        (sharing) Removed invitee from shared file/folder before invite was
+        accepted
+    :ivar EventTypeArg.shared_content_remove_link_expiry:
+        (sharing) Removed link expiration date of shared file/folder
+        (deprecated, no longer logged)
+    :ivar EventTypeArg.shared_content_remove_link_password:
+        (sharing) Removed link password of shared file/folder (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.shared_content_remove_member:
+        (sharing) Removed user/group from shared file/folder
+    :ivar EventTypeArg.shared_content_request_access:
+        (sharing) Requested access to shared file/folder
+    :ivar EventTypeArg.shared_content_restore_invitees:
+        (sharing) Restored shared file/folder invitees
+    :ivar EventTypeArg.shared_content_restore_member:
+        (sharing) Restored users and/or groups to membership of shared
         file/folder
-    :ivar team_log.EventTypeArg.shared_folder_change_link_policy: (sharing)
-        Changed who can access shared folder via link
-    :ivar team_log.EventTypeArg.shared_folder_change_members_inheritance_policy:
+    :ivar EventTypeArg.shared_content_unshare:
+        (sharing) Unshared file/folder by clearing membership
+    :ivar EventTypeArg.shared_content_view:
+        (sharing) Previewed shared file/folder
+    :ivar EventTypeArg.shared_folder_change_link_policy:
+        (sharing) Changed who can access shared folder via link
+    :ivar EventTypeArg.shared_folder_change_members_inheritance_policy:
         (sharing) Changed whether shared folder inherits members from parent
         folder
-    :ivar team_log.EventTypeArg.shared_folder_change_members_management_policy:
+    :ivar EventTypeArg.shared_folder_change_members_management_policy:
         (sharing) Changed who can add/remove members of shared folder
-    :ivar team_log.EventTypeArg.shared_folder_change_members_policy: (sharing)
-        Changed who can become member of shared folder
-    :ivar team_log.EventTypeArg.shared_folder_create: (sharing) Created shared
-        folder
-    :ivar team_log.EventTypeArg.shared_folder_decline_invitation: (sharing)
-        Declined team member's invite to shared folder
-    :ivar team_log.EventTypeArg.shared_folder_mount: (sharing) Added shared
-        folder to own Dropbox
-    :ivar team_log.EventTypeArg.shared_folder_nest: (sharing) Changed parent of
-        shared folder
-    :ivar team_log.EventTypeArg.shared_folder_transfer_ownership: (sharing)
-        Transferred ownership of shared folder to another member
-    :ivar team_log.EventTypeArg.shared_folder_unmount: (sharing) Deleted shared
-        folder from Dropbox
-    :ivar team_log.EventTypeArg.shared_link_add_expiry: (sharing) Added shared
-        link expiration date
-    :ivar team_log.EventTypeArg.shared_link_change_expiry: (sharing) Changed
-        shared link expiration date
-    :ivar team_log.EventTypeArg.shared_link_change_visibility: (sharing) Changed
-        visibility of shared link
-    :ivar team_log.EventTypeArg.shared_link_copy: (sharing) Added file/folder to
-        Dropbox from shared link
-    :ivar team_log.EventTypeArg.shared_link_create: (sharing) Created shared
-        link
-    :ivar team_log.EventTypeArg.shared_link_disable: (sharing) Removed shared
-        link
-    :ivar team_log.EventTypeArg.shared_link_download: (sharing) Downloaded
-        file/folder from shared link
-    :ivar team_log.EventTypeArg.shared_link_remove_expiry: (sharing) Removed
-        shared link expiration date
-    :ivar team_log.EventTypeArg.shared_link_remove_visitor: (sharing) Removed
-        link visitor
-    :ivar team_log.EventTypeArg.shared_link_settings_add_expiration: (sharing)
-        Added an expiration date to the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_add_password: (sharing)
-        Added a password to the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_allow_download_disabled:
+    :ivar EventTypeArg.shared_folder_change_members_policy:
+        (sharing) Changed who can become member of shared folder
+    :ivar EventTypeArg.shared_folder_create:
+        (sharing) Created shared folder
+    :ivar EventTypeArg.shared_folder_decline_invitation:
+        (sharing) Declined team member's invite to shared folder
+    :ivar EventTypeArg.shared_folder_mount:
+        (sharing) Added shared folder to own Dropbox
+    :ivar EventTypeArg.shared_folder_nest:
+        (sharing) Changed parent of shared folder
+    :ivar EventTypeArg.shared_folder_transfer_ownership:
+        (sharing) Transferred ownership of shared folder to another member
+    :ivar EventTypeArg.shared_folder_unmount:
+        (sharing) Deleted shared folder from Dropbox
+    :ivar EventTypeArg.shared_link_add_expiry:
+        (sharing) Added shared link expiration date
+    :ivar EventTypeArg.shared_link_change_expiry:
+        (sharing) Changed shared link expiration date
+    :ivar EventTypeArg.shared_link_change_visibility:
+        (sharing) Changed visibility of shared link
+    :ivar EventTypeArg.shared_link_copy:
+        (sharing) Added file/folder to Dropbox from shared link
+    :ivar EventTypeArg.shared_link_create:
+        (sharing) Created shared link
+    :ivar EventTypeArg.shared_link_disable:
+        (sharing) Removed shared link
+    :ivar EventTypeArg.shared_link_download:
+        (sharing) Downloaded file/folder from shared link
+    :ivar EventTypeArg.shared_link_remove_expiry:
+        (sharing) Removed shared link expiration date
+    :ivar EventTypeArg.shared_link_remove_visitor:
+        (sharing) Removed link visitor
+    :ivar EventTypeArg.shared_link_settings_add_expiration:
+        (sharing) Added an expiration date to the shared link
+    :ivar EventTypeArg.shared_link_settings_add_password:
+        (sharing) Added a password to the shared link
+    :ivar EventTypeArg.shared_link_settings_allow_download_disabled:
         (sharing) Disabled downloads
-    :ivar team_log.EventTypeArg.shared_link_settings_allow_download_enabled:
+    :ivar EventTypeArg.shared_link_settings_allow_download_enabled:
         (sharing) Enabled downloads
-    :ivar team_log.EventTypeArg.shared_link_settings_change_audience: (sharing)
-        Changed the audience of the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_change_expiration:
+    :ivar EventTypeArg.shared_link_settings_change_audience:
+        (sharing) Changed the audience of the shared link
+    :ivar EventTypeArg.shared_link_settings_change_expiration:
         (sharing) Changed the expiration date of the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_change_password: (sharing)
-        Changed the password of the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_remove_expiration:
+    :ivar EventTypeArg.shared_link_settings_change_password:
+        (sharing) Changed the password of the shared link
+    :ivar EventTypeArg.shared_link_settings_remove_expiration:
         (sharing) Removed the expiration date from the shared link
-    :ivar team_log.EventTypeArg.shared_link_settings_remove_password: (sharing)
-        Removed the password from the shared link
-    :ivar team_log.EventTypeArg.shared_link_share: (sharing) Added members as
-        audience of shared link
-    :ivar team_log.EventTypeArg.shared_link_view: (sharing) Opened shared link
-    :ivar team_log.EventTypeArg.shared_note_opened: (sharing) Opened shared
-        Paper doc (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.shmodel_disable_downloads: (sharing) Disabled
-        downloads for link (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.shmodel_enable_downloads: (sharing) Enabled
-        downloads for link (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.shmodel_group_share: (sharing) Shared link with
-        group (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.showcase_access_granted: (showcase) Granted
-        access to showcase
-    :ivar team_log.EventTypeArg.showcase_add_member: (showcase) Added member to
-        showcase
-    :ivar team_log.EventTypeArg.showcase_archived: (showcase) Archived showcase
-    :ivar team_log.EventTypeArg.showcase_created: (showcase) Created showcase
-    :ivar team_log.EventTypeArg.showcase_delete_comment: (showcase) Deleted
-        showcase comment
-    :ivar team_log.EventTypeArg.showcase_edited: (showcase) Edited showcase
-    :ivar team_log.EventTypeArg.showcase_edit_comment: (showcase) Edited
-        showcase comment
-    :ivar team_log.EventTypeArg.showcase_file_added: (showcase) Added file to
-        showcase
-    :ivar team_log.EventTypeArg.showcase_file_download: (showcase) Downloaded
-        file from showcase
-    :ivar team_log.EventTypeArg.showcase_file_removed: (showcase) Removed file
-        from showcase
-    :ivar team_log.EventTypeArg.showcase_file_view: (showcase) Viewed file in
-        showcase
-    :ivar team_log.EventTypeArg.showcase_permanently_deleted: (showcase)
-        Permanently deleted showcase
-    :ivar team_log.EventTypeArg.showcase_post_comment: (showcase) Added showcase
-        comment
-    :ivar team_log.EventTypeArg.showcase_remove_member: (showcase) Removed
-        member from showcase
-    :ivar team_log.EventTypeArg.showcase_renamed: (showcase) Renamed showcase
-    :ivar team_log.EventTypeArg.showcase_request_access: (showcase) Requested
-        access to showcase
-    :ivar team_log.EventTypeArg.showcase_resolve_comment: (showcase) Resolved
-        showcase comment
-    :ivar team_log.EventTypeArg.showcase_restored: (showcase) Unarchived
-        showcase
-    :ivar team_log.EventTypeArg.showcase_trashed: (showcase) Deleted showcase
-    :ivar team_log.EventTypeArg.showcase_trashed_deprecated: (showcase) Deleted
-        showcase (old version) (deprecated, replaced by 'Deleted showcase')
-    :ivar team_log.EventTypeArg.showcase_unresolve_comment: (showcase)
-        Unresolved showcase comment
-    :ivar team_log.EventTypeArg.showcase_untrashed: (showcase) Restored showcase
-    :ivar team_log.EventTypeArg.showcase_untrashed_deprecated: (showcase)
-        Restored showcase (old version) (deprecated, replaced by 'Restored
-        showcase')
-    :ivar team_log.EventTypeArg.showcase_view: (showcase) Viewed showcase
-    :ivar team_log.EventTypeArg.sign_signature_request_canceled: (signatures)
-        Canceled signature request
-    :ivar team_log.EventTypeArg.sign_signature_request_completed: (signatures)
-        Completed signature request
-    :ivar team_log.EventTypeArg.sign_signature_request_declined: (signatures)
-        Declined signature request
-    :ivar team_log.EventTypeArg.sign_signature_request_opened: (signatures)
-        Opened signature request
-    :ivar team_log.EventTypeArg.sign_signature_request_reminder_sent:
+    :ivar EventTypeArg.shared_link_settings_remove_password:
+        (sharing) Removed the password from the shared link
+    :ivar EventTypeArg.shared_link_share:
+        (sharing) Added members as audience of shared link
+    :ivar EventTypeArg.shared_link_view:
+        (sharing) Opened shared link
+    :ivar EventTypeArg.shared_note_opened:
+        (sharing) Opened shared Paper doc (deprecated, no longer logged)
+    :ivar EventTypeArg.shmodel_disable_downloads:
+        (sharing) Disabled downloads for link (deprecated, no longer logged)
+    :ivar EventTypeArg.shmodel_enable_downloads:
+        (sharing) Enabled downloads for link (deprecated, no longer logged)
+    :ivar EventTypeArg.shmodel_group_share:
+        (sharing) Shared link with group (deprecated, no longer logged)
+    :ivar EventTypeArg.showcase_access_granted:
+        (showcase) Granted access to showcase
+    :ivar EventTypeArg.showcase_add_member:
+        (showcase) Added member to showcase
+    :ivar EventTypeArg.showcase_archived:
+        (showcase) Archived showcase
+    :ivar EventTypeArg.showcase_created:
+        (showcase) Created showcase
+    :ivar EventTypeArg.showcase_delete_comment:
+        (showcase) Deleted showcase comment
+    :ivar EventTypeArg.showcase_edited:
+        (showcase) Edited showcase
+    :ivar EventTypeArg.showcase_edit_comment:
+        (showcase) Edited showcase comment
+    :ivar EventTypeArg.showcase_file_added:
+        (showcase) Added file to showcase
+    :ivar EventTypeArg.showcase_file_download:
+        (showcase) Downloaded file from showcase
+    :ivar EventTypeArg.showcase_file_removed:
+        (showcase) Removed file from showcase
+    :ivar EventTypeArg.showcase_file_view:
+        (showcase) Viewed file in showcase
+    :ivar EventTypeArg.showcase_permanently_deleted:
+        (showcase) Permanently deleted showcase
+    :ivar EventTypeArg.showcase_post_comment:
+        (showcase) Added showcase comment
+    :ivar EventTypeArg.showcase_remove_member:
+        (showcase) Removed member from showcase
+    :ivar EventTypeArg.showcase_renamed:
+        (showcase) Renamed showcase
+    :ivar EventTypeArg.showcase_request_access:
+        (showcase) Requested access to showcase
+    :ivar EventTypeArg.showcase_resolve_comment:
+        (showcase) Resolved showcase comment
+    :ivar EventTypeArg.showcase_restored:
+        (showcase) Unarchived showcase
+    :ivar EventTypeArg.showcase_trashed:
+        (showcase) Deleted showcase
+    :ivar EventTypeArg.showcase_trashed_deprecated:
+        (showcase) Deleted showcase (old version) (deprecated, replaced by
+        'Deleted showcase')
+    :ivar EventTypeArg.showcase_unresolve_comment:
+        (showcase) Unresolved showcase comment
+    :ivar EventTypeArg.showcase_untrashed:
+        (showcase) Restored showcase
+    :ivar EventTypeArg.showcase_untrashed_deprecated:
+        (showcase) Restored showcase (old version) (deprecated, replaced by
+        'Restored showcase')
+    :ivar EventTypeArg.showcase_view:
+        (showcase) Viewed showcase
+    :ivar EventTypeArg.sign_signature_request_canceled:
+        (signatures) Canceled signature request
+    :ivar EventTypeArg.sign_signature_request_completed:
+        (signatures) Completed signature request
+    :ivar EventTypeArg.sign_signature_request_declined:
+        (signatures) Declined signature request
+    :ivar EventTypeArg.sign_signature_request_opened:
+        (signatures) Opened signature request
+    :ivar EventTypeArg.sign_signature_request_reminder_sent:
         (signatures) Sent signature request reminder
-    :ivar team_log.EventTypeArg.sign_signature_request_sent: (signatures) Sent
-        signature request
-    :ivar team_log.EventTypeArg.sign_template_created: (signatures) Created
-        template
-    :ivar team_log.EventTypeArg.sign_template_shared: (signatures) Shared
-        template
-    :ivar team_log.EventTypeArg.risc_security_event: (sso) RISC security event
-        received from external provider
-    :ivar team_log.EventTypeArg.sso_add_cert: (sso) Added X.509 certificate for
-        SSO
-    :ivar team_log.EventTypeArg.sso_add_login_url: (sso) Added sign-in URL for
-        SSO
-    :ivar team_log.EventTypeArg.sso_add_logout_url: (sso) Added sign-out URL for
-        SSO
-    :ivar team_log.EventTypeArg.sso_change_cert: (sso) Changed X.509 certificate
-        for SSO
-    :ivar team_log.EventTypeArg.sso_change_login_url: (sso) Changed sign-in URL
-        for SSO
-    :ivar team_log.EventTypeArg.sso_change_logout_url: (sso) Changed sign-out
-        URL for SSO
-    :ivar team_log.EventTypeArg.sso_change_saml_identity_mode: (sso) Changed
-        SAML identity mode for SSO
-    :ivar team_log.EventTypeArg.sso_remove_cert: (sso) Removed X.509 certificate
-        for SSO
-    :ivar team_log.EventTypeArg.sso_remove_login_url: (sso) Removed sign-in URL
-        for SSO
-    :ivar team_log.EventTypeArg.sso_remove_logout_url: (sso) Removed sign-out
-        URL for SSO
-    :ivar team_log.EventTypeArg.team_folder_change_status: (team_folders)
-        Changed archival status of team folder
-    :ivar team_log.EventTypeArg.team_folder_create: (team_folders) Created team
-        folder in active status
-    :ivar team_log.EventTypeArg.team_folder_downgrade: (team_folders) Downgraded
-        team folder to regular shared folder
-    :ivar team_log.EventTypeArg.team_folder_permanently_delete: (team_folders)
-        Permanently deleted archived team folder
-    :ivar team_log.EventTypeArg.team_folder_rename: (team_folders) Renamed
-        active/archived team folder
-    :ivar team_log.EventTypeArg.team_folder_space_limits_change_caps_type:
+    :ivar EventTypeArg.sign_signature_request_sent:
+        (signatures) Sent signature request
+    :ivar EventTypeArg.sign_template_created:
+        (signatures) Created template
+    :ivar EventTypeArg.sign_template_shared:
+        (signatures) Shared template
+    :ivar EventTypeArg.risc_security_event:
+        (sso) RISC security event received from external provider
+    :ivar EventTypeArg.sso_add_cert:
+        (sso) Added X.509 certificate for SSO
+    :ivar EventTypeArg.sso_add_login_url:
+        (sso) Added sign-in URL for SSO
+    :ivar EventTypeArg.sso_add_logout_url:
+        (sso) Added sign-out URL for SSO
+    :ivar EventTypeArg.sso_change_cert:
+        (sso) Changed X.509 certificate for SSO
+    :ivar EventTypeArg.sso_change_login_url:
+        (sso) Changed sign-in URL for SSO
+    :ivar EventTypeArg.sso_change_logout_url:
+        (sso) Changed sign-out URL for SSO
+    :ivar EventTypeArg.sso_change_saml_identity_mode:
+        (sso) Changed SAML identity mode for SSO
+    :ivar EventTypeArg.sso_remove_cert:
+        (sso) Removed X.509 certificate for SSO
+    :ivar EventTypeArg.sso_remove_login_url:
+        (sso) Removed sign-in URL for SSO
+    :ivar EventTypeArg.sso_remove_logout_url:
+        (sso) Removed sign-out URL for SSO
+    :ivar EventTypeArg.team_folder_change_status:
+        (team_folders) Changed archival status of team folder
+    :ivar EventTypeArg.team_folder_create:
+        (team_folders) Created team folder in active status
+    :ivar EventTypeArg.team_folder_downgrade:
+        (team_folders) Downgraded team folder to regular shared folder
+    :ivar EventTypeArg.team_folder_permanently_delete:
+        (team_folders) Permanently deleted archived team folder
+    :ivar EventTypeArg.team_folder_rename:
+        (team_folders) Renamed active/archived team folder
+    :ivar EventTypeArg.team_folder_space_limits_change_caps_type:
         (team_folders) Changed team folder space limit enforcement type
-    :ivar team_log.EventTypeArg.team_folder_space_limits_change_limit:
+    :ivar EventTypeArg.team_folder_space_limits_change_limit:
         (team_folders) Changed team folder space limit
-    :ivar
-        team_log.EventTypeArg.team_folder_space_limits_change_notification_target:
+    :ivar EventTypeArg.team_folder_space_limits_change_notification_target:
         (team_folders) Changed team folder space limit notification target
-    :ivar team_log.EventTypeArg.team_selective_sync_settings_changed:
+    :ivar EventTypeArg.team_selective_sync_settings_changed:
         (team_folders) Changed sync default
-    :ivar team_log.EventTypeArg.account_capture_change_policy: (team_policies)
-        Changed account capture setting on team domain
-    :ivar team_log.EventTypeArg.admin_email_reminders_changed: (team_policies)
-        Changed admin reminder settings for requests to join the team
-    :ivar
-        team_log.EventTypeArg.ai_third_party_sharing_dropbox_base_policy_changed:
+    :ivar EventTypeArg.account_capture_change_policy:
+        (team_policies) Changed account capture setting on team domain
+    :ivar EventTypeArg.admin_email_reminders_changed:
+        (team_policies) Changed admin reminder settings for requests to join the
+        team
+    :ivar EventTypeArg.ai_third_party_sharing_dropbox_base_policy_changed:
         (team_policies) Changed AI third party sharing policy for team
-    :ivar team_log.EventTypeArg.allow_download_disabled: (team_policies)
-        Disabled downloads (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.allow_download_enabled: (team_policies) Enabled
-        downloads (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.apple_login_change_policy: (team_policies)
-        Enabled/disabled Apple login for team
-    :ivar team_log.EventTypeArg.app_permissions_changed: (team_policies) Changed
-        app permissions
-    :ivar team_log.EventTypeArg.camera_uploads_policy_changed: (team_policies)
-        Changed camera uploads setting for team
-    :ivar team_log.EventTypeArg.capture_team_space_policy_changed:
+    :ivar EventTypeArg.allow_download_disabled:
+        (team_policies) Disabled downloads (deprecated, no longer logged)
+    :ivar EventTypeArg.allow_download_enabled:
+        (team_policies) Enabled downloads (deprecated, no longer logged)
+    :ivar EventTypeArg.apple_login_change_policy:
+        (team_policies) Enabled/disabled Apple login for team
+    :ivar EventTypeArg.app_permissions_changed:
+        (team_policies) Changed app permissions
+    :ivar EventTypeArg.camera_uploads_policy_changed:
+        (team_policies) Changed camera uploads setting for team
+    :ivar EventTypeArg.capture_team_space_policy_changed:
         (team_policies) Changed Capture team space policy for team
-    :ivar team_log.EventTypeArg.capture_transcript_policy_changed:
+    :ivar EventTypeArg.capture_transcript_policy_changed:
         (team_policies) Changed Capture transcription policy for team
-    :ivar team_log.EventTypeArg.classification_change_policy: (team_policies)
-        Changed classification policy for team
-    :ivar team_log.EventTypeArg.computer_backup_policy_changed: (team_policies)
-        Changed computer backup policy for team
-    :ivar team_log.EventTypeArg.content_administration_policy_changed:
+    :ivar EventTypeArg.classification_change_policy:
+        (team_policies) Changed classification policy for team
+    :ivar EventTypeArg.computer_backup_policy_changed:
+        (team_policies) Changed computer backup policy for team
+    :ivar EventTypeArg.content_administration_policy_changed:
         (team_policies) Changed content management setting
-    :ivar team_log.EventTypeArg.content_deletion_protection_change_policy:
+    :ivar EventTypeArg.content_deletion_protection_change_policy:
         (team_policies) Changed content deletion protection policy for team
-    :ivar team_log.EventTypeArg.dash_external_sharing_policy_changed:
+    :ivar EventTypeArg.dash_external_sharing_policy_changed:
         (team_policies) Changed Dash external sharing policy for team
-    :ivar team_log.EventTypeArg.data_placement_restriction_change_policy:
+    :ivar EventTypeArg.data_placement_restriction_change_policy:
         (team_policies) Set restrictions on data center locations where team
         data resides
-    :ivar team_log.EventTypeArg.data_placement_restriction_satisfy_policy:
+    :ivar EventTypeArg.data_placement_restriction_satisfy_policy:
         (team_policies) Completed restrictions on data center locations where
         team data resides
-    :ivar team_log.EventTypeArg.device_approvals_add_exception: (team_policies)
-        Added members to device approvals exception list
-    :ivar team_log.EventTypeArg.device_approvals_change_desktop_policy:
+    :ivar EventTypeArg.device_approvals_add_exception:
+        (team_policies) Added members to device approvals exception list
+    :ivar EventTypeArg.device_approvals_change_desktop_policy:
         (team_policies) Set/removed limit on number of computers member can link
         to team Dropbox account
-    :ivar team_log.EventTypeArg.device_approvals_change_mobile_policy:
+    :ivar EventTypeArg.device_approvals_change_mobile_policy:
         (team_policies) Set/removed limit on number of mobile devices member can
         link to team Dropbox account
-    :ivar team_log.EventTypeArg.device_approvals_change_overage_action:
+    :ivar EventTypeArg.device_approvals_change_overage_action:
         (team_policies) Changed device approvals setting when member is over
         limit
-    :ivar team_log.EventTypeArg.device_approvals_change_unlink_action:
+    :ivar EventTypeArg.device_approvals_change_unlink_action:
         (team_policies) Changed device approvals setting when member unlinks
         approved device
-    :ivar team_log.EventTypeArg.device_approvals_remove_exception:
+    :ivar EventTypeArg.device_approvals_remove_exception:
         (team_policies) Removed members from device approvals exception list
-    :ivar team_log.EventTypeArg.directory_restrictions_add_members:
+    :ivar EventTypeArg.directory_restrictions_add_members:
         (team_policies) Added members to directory restrictions list
-    :ivar team_log.EventTypeArg.directory_restrictions_remove_members:
+    :ivar EventTypeArg.directory_restrictions_remove_members:
         (team_policies) Removed members from directory restrictions list
-    :ivar team_log.EventTypeArg.dropbox_passwords_policy_changed:
+    :ivar EventTypeArg.dropbox_passwords_policy_changed:
         (team_policies) Changed Dropbox Passwords policy for team
-    :ivar team_log.EventTypeArg.email_ingest_policy_changed: (team_policies)
-        Changed email to Dropbox policy for team
-    :ivar team_log.EventTypeArg.emm_add_exception: (team_policies) Added members
-        to EMM exception list
-    :ivar team_log.EventTypeArg.emm_change_policy: (team_policies)
-        Enabled/disabled enterprise mobility management for members
-    :ivar team_log.EventTypeArg.emm_remove_exception: (team_policies) Removed
-        members from EMM exception list
-    :ivar team_log.EventTypeArg.extended_version_history_change_policy:
+    :ivar EventTypeArg.email_ingest_policy_changed:
+        (team_policies) Changed email to Dropbox policy for team
+    :ivar EventTypeArg.emm_add_exception:
+        (team_policies) Added members to EMM exception list
+    :ivar EventTypeArg.emm_change_policy:
+        (team_policies) Enabled/disabled enterprise mobility management for
+        members
+    :ivar EventTypeArg.emm_remove_exception:
+        (team_policies) Removed members from EMM exception list
+    :ivar EventTypeArg.extended_version_history_change_policy:
         (team_policies) Accepted/opted out of extended version history
-    :ivar team_log.EventTypeArg.external_drive_backup_policy_changed:
+    :ivar EventTypeArg.external_drive_backup_policy_changed:
         (team_policies) Changed external drive backup policy for team
-    :ivar team_log.EventTypeArg.file_comments_change_policy: (team_policies)
-        Enabled/disabled commenting on team files
-    :ivar team_log.EventTypeArg.file_locking_policy_changed: (team_policies)
-        Changed file locking policy for team
-    :ivar team_log.EventTypeArg.file_provider_migration_policy_changed:
+    :ivar EventTypeArg.file_comments_change_policy:
+        (team_policies) Enabled/disabled commenting on team files
+    :ivar EventTypeArg.file_locking_policy_changed:
+        (team_policies) Changed file locking policy for team
+    :ivar EventTypeArg.file_provider_migration_policy_changed:
         (team_policies) Changed File Provider Migration policy for team
-    :ivar team_log.EventTypeArg.file_requests_change_policy: (team_policies)
-        Enabled/disabled file requests
-    :ivar team_log.EventTypeArg.file_requests_emails_enabled: (team_policies)
-        Enabled file request emails for everyone (deprecated, no longer logged)
-    :ivar team_log.EventTypeArg.file_requests_emails_restricted_to_team_only:
+    :ivar EventTypeArg.file_requests_change_policy:
+        (team_policies) Enabled/disabled file requests
+    :ivar EventTypeArg.file_requests_emails_enabled:
+        (team_policies) Enabled file request emails for everyone (deprecated, no
+        longer logged)
+    :ivar EventTypeArg.file_requests_emails_restricted_to_team_only:
         (team_policies) Enabled file request emails for team (deprecated, no
         longer logged)
-    :ivar team_log.EventTypeArg.file_transfers_policy_changed: (team_policies)
-        Changed file transfers policy for team
-    :ivar team_log.EventTypeArg.flexible_file_names_policy_changed:
+    :ivar EventTypeArg.file_transfers_policy_changed:
+        (team_policies) Changed file transfers policy for team
+    :ivar EventTypeArg.flexible_file_names_policy_changed:
         (team_policies) Changed flexible file names policy for team
-    :ivar team_log.EventTypeArg.folder_link_restriction_policy_changed:
+    :ivar EventTypeArg.folder_link_restriction_policy_changed:
         (team_policies) Changed folder link restrictions policy for team
-    :ivar team_log.EventTypeArg.google_sso_change_policy: (team_policies)
-        Enabled/disabled Google single sign-on for team
-    :ivar team_log.EventTypeArg.group_user_management_change_policy:
+    :ivar EventTypeArg.google_sso_change_policy:
+        (team_policies) Enabled/disabled Google single sign-on for team
+    :ivar EventTypeArg.group_user_management_change_policy:
         (team_policies) Changed who can create groups
-    :ivar team_log.EventTypeArg.integration_policy_changed: (team_policies)
-        Changed integration policy for team
-    :ivar team_log.EventTypeArg.invite_acceptance_email_policy_changed:
+    :ivar EventTypeArg.integration_policy_changed:
+        (team_policies) Changed integration policy for team
+    :ivar EventTypeArg.invite_acceptance_email_policy_changed:
         (team_policies) Changed invite accept email policy for team
-    :ivar team_log.EventTypeArg.media_hub_adding_people_policy_changed:
+    :ivar EventTypeArg.media_hub_adding_people_policy_changed:
         (team_policies) Changed the policy for adding people to Media Hub
         content
-    :ivar team_log.EventTypeArg.media_hub_download_policy_changed:
+    :ivar EventTypeArg.media_hub_download_policy_changed:
         (team_policies) Changed the policy for downloading Media Hub content
-    :ivar team_log.EventTypeArg.media_hub_link_sharing_policy_changed:
+    :ivar EventTypeArg.media_hub_link_sharing_policy_changed:
         (team_policies) Changed the policy for sharing Media Hub content
-    :ivar team_log.EventTypeArg.member_requests_change_policy: (team_policies)
-        Changed whether users can find team when not invited
-    :ivar team_log.EventTypeArg.member_send_invite_policy_changed:
+    :ivar EventTypeArg.member_requests_change_policy:
+        (team_policies) Changed whether users can find team when not invited
+    :ivar EventTypeArg.member_send_invite_policy_changed:
         (team_policies) Changed member send invite policy for team
-    :ivar team_log.EventTypeArg.member_space_limits_add_exception:
+    :ivar EventTypeArg.member_space_limits_add_exception:
         (team_policies) Added members to member space limit exception list
-    :ivar team_log.EventTypeArg.member_space_limits_change_caps_type_policy:
+    :ivar EventTypeArg.member_space_limits_change_caps_type_policy:
         (team_policies) Changed member space limit type for team
-    :ivar team_log.EventTypeArg.member_space_limits_change_policy:
+    :ivar EventTypeArg.member_space_limits_change_policy:
         (team_policies) Changed team default member space limit
-    :ivar team_log.EventTypeArg.member_space_limits_remove_exception:
+    :ivar EventTypeArg.member_space_limits_remove_exception:
         (team_policies) Removed members from member space limit exception list
-    :ivar team_log.EventTypeArg.member_suggestions_change_policy:
+    :ivar EventTypeArg.member_suggestions_change_policy:
         (team_policies) Enabled/disabled option for team members to suggest
         people to add to team
-    :ivar team_log.EventTypeArg.microsoft_login_change_policy: (team_policies)
-        Enabled/disabled Microsoft login for team
-    :ivar team_log.EventTypeArg.microsoft_office_addin_change_policy:
+    :ivar EventTypeArg.microsoft_login_change_policy:
+        (team_policies) Enabled/disabled Microsoft login for team
+    :ivar EventTypeArg.microsoft_office_addin_change_policy:
         (team_policies) Enabled/disabled Microsoft Office add-in
-    :ivar team_log.EventTypeArg.multi_team_identity_policy_changed:
+    :ivar EventTypeArg.multi_team_identity_policy_changed:
         (team_policies) Changed multi-team identity policy for team
-    :ivar team_log.EventTypeArg.network_control_change_policy: (team_policies)
-        Enabled/disabled network control
-    :ivar team_log.EventTypeArg.paper_change_deployment_policy: (team_policies)
-        Changed whether Dropbox Paper, when enabled, is deployed to all members
-        or to specific members
-    :ivar team_log.EventTypeArg.paper_change_member_link_policy: (team_policies)
-        Changed whether non-members can view Paper docs with link (deprecated,
-        no longer logged)
-    :ivar team_log.EventTypeArg.paper_change_member_policy: (team_policies)
-        Changed whether members can share Paper docs outside team, and if docs
-        are accessible only by team members or anyone by default
-    :ivar team_log.EventTypeArg.paper_change_policy: (team_policies)
-        Enabled/disabled Dropbox Paper for team
-    :ivar team_log.EventTypeArg.paper_default_folder_policy_changed:
+    :ivar EventTypeArg.network_control_change_policy:
+        (team_policies) Enabled/disabled network control
+    :ivar EventTypeArg.paper_change_deployment_policy:
+        (team_policies) Changed whether Dropbox Paper, when enabled, is deployed
+        to all members or to specific members
+    :ivar EventTypeArg.paper_change_member_link_policy:
+        (team_policies) Changed whether non-members can view Paper docs with
+        link (deprecated, no longer logged)
+    :ivar EventTypeArg.paper_change_member_policy:
+        (team_policies) Changed whether members can share Paper docs outside
+        team, and if docs are accessible only by team members or anyone by
+        default
+    :ivar EventTypeArg.paper_change_policy:
+        (team_policies) Enabled/disabled Dropbox Paper for team
+    :ivar EventTypeArg.paper_default_folder_policy_changed:
         (team_policies) Changed Paper Default Folder Policy setting for team
-    :ivar team_log.EventTypeArg.paper_desktop_policy_changed: (team_policies)
-        Enabled/disabled Paper Desktop for team
-    :ivar team_log.EventTypeArg.paper_enabled_users_group_addition:
+    :ivar EventTypeArg.paper_desktop_policy_changed:
+        (team_policies) Enabled/disabled Paper Desktop for team
+    :ivar EventTypeArg.paper_enabled_users_group_addition:
         (team_policies) Added users to Paper-enabled users list
-    :ivar team_log.EventTypeArg.paper_enabled_users_group_removal:
+    :ivar EventTypeArg.paper_enabled_users_group_removal:
         (team_policies) Removed users from Paper-enabled users list
-    :ivar team_log.EventTypeArg.passkey_login_policy_changed: (team_policies)
-        Changed passkey login policy for team
-    :ivar team_log.EventTypeArg.password_strength_requirements_change_policy:
+    :ivar EventTypeArg.passkey_login_policy_changed:
+        (team_policies) Changed passkey login policy for team
+    :ivar EventTypeArg.password_strength_requirements_change_policy:
         (team_policies) Changed team password strength requirements
-    :ivar team_log.EventTypeArg.permanent_delete_change_policy: (team_policies)
-        Enabled/disabled ability of team members to permanently delete content
-    :ivar team_log.EventTypeArg.previews_ai_policy_changed: (team_policies)
-        Changed Dropbox AI policy for team
-    :ivar team_log.EventTypeArg.replay_adding_people_policy_changed:
+    :ivar EventTypeArg.permanent_delete_change_policy:
+        (team_policies) Enabled/disabled ability of team members to permanently
+        delete content
+    :ivar EventTypeArg.previews_ai_policy_changed:
+        (team_policies) Changed Dropbox AI policy for team
+    :ivar EventTypeArg.replay_adding_people_policy_changed:
         (team_policies) Changed the policy for adding people to Replay content
-    :ivar team_log.EventTypeArg.replay_sharing_policy_changed: (team_policies)
-        Changed the policy for sharing Replay content
-    :ivar team_log.EventTypeArg.reseller_support_change_policy: (team_policies)
-        Enabled/disabled reseller support
-    :ivar team_log.EventTypeArg.rewind_policy_changed: (team_policies) Changed
-        Rewind policy for team
-    :ivar team_log.EventTypeArg.send_and_track_policy_changed: (team_policies)
-        Changed “Send and track” policy for team
-    :ivar team_log.EventTypeArg.send_external_sharing_policy_changed:
+    :ivar EventTypeArg.replay_sharing_policy_changed:
+        (team_policies) Changed the policy for sharing Replay content
+    :ivar EventTypeArg.reseller_support_change_policy:
+        (team_policies) Enabled/disabled reseller support
+    :ivar EventTypeArg.rewind_policy_changed:
+        (team_policies) Changed Rewind policy for team
+    :ivar EventTypeArg.send_and_track_policy_changed:
+        (team_policies) Changed “Send and track” policy for team
+    :ivar EventTypeArg.send_external_sharing_policy_changed:
         (team_policies) Changed “Send and track” external sharing policy for
         team
-    :ivar team_log.EventTypeArg.send_for_signature_policy_changed:
+    :ivar EventTypeArg.send_for_signature_policy_changed:
         (team_policies) Changed send for signature policy for team
-    :ivar team_log.EventTypeArg.shared_link_default_permissions_policy_changed:
+    :ivar EventTypeArg.shared_link_default_permissions_policy_changed:
         (team_policies) Changed shared link default permissions policy for team
-    :ivar team_log.EventTypeArg.sharing_change_folder_join_policy:
+    :ivar EventTypeArg.sharing_change_folder_join_policy:
         (team_policies) Changed whether team members can join shared folders
         owned outside team
-    :ivar
-        team_log.EventTypeArg.sharing_change_link_allow_change_expiration_policy:
+    :ivar EventTypeArg.sharing_change_link_allow_change_expiration_policy:
         (team_policies) Changed the allow remove or change expiration policy for
         the links shared outside of the team
-    :ivar team_log.EventTypeArg.sharing_change_link_default_expiration_policy:
+    :ivar EventTypeArg.sharing_change_link_default_expiration_policy:
         (team_policies) Changed the default expiration for the links shared
         outside of the team
-    :ivar team_log.EventTypeArg.sharing_change_link_enforce_password_policy:
+    :ivar EventTypeArg.sharing_change_link_enforce_password_policy:
         (team_policies) Changed the password requirement for the links shared
         outside of the team
-    :ivar team_log.EventTypeArg.sharing_change_link_policy: (team_policies)
-        Changed whether members can share links outside team, and if links are
-        accessible only by team members or anyone by default
-    :ivar team_log.EventTypeArg.sharing_change_member_policy: (team_policies)
-        Changed whether members can share files/folders outside team
-    :ivar team_log.EventTypeArg.showcase_change_download_policy: (team_policies)
-        Enabled/disabled downloading files from Dropbox Showcase for team
-    :ivar team_log.EventTypeArg.showcase_change_enabled_policy: (team_policies)
-        Enabled/disabled Dropbox Showcase for team
-    :ivar team_log.EventTypeArg.showcase_change_external_sharing_policy:
+    :ivar EventTypeArg.sharing_change_link_policy:
+        (team_policies) Changed whether members can share links outside team,
+        and if links are accessible only by team members or anyone by default
+    :ivar EventTypeArg.sharing_change_member_policy:
+        (team_policies) Changed whether members can share files/folders outside
+        team
+    :ivar EventTypeArg.showcase_change_download_policy:
+        (team_policies) Enabled/disabled downloading files from Dropbox Showcase
+        for team
+    :ivar EventTypeArg.showcase_change_enabled_policy:
+        (team_policies) Enabled/disabled Dropbox Showcase for team
+    :ivar EventTypeArg.showcase_change_external_sharing_policy:
         (team_policies) Enabled/disabled sharing Dropbox Showcase externally for
         team
-    :ivar team_log.EventTypeArg.sign_external_sharing_policy_changed:
+    :ivar EventTypeArg.sign_external_sharing_policy_changed:
         (team_policies) Changed Signatures external sharing policy for team
-    :ivar team_log.EventTypeArg.sign_template_creation_permission_changed:
+    :ivar EventTypeArg.sign_template_creation_permission_changed:
         (team_policies) Changed template creation permission
-    :ivar team_log.EventTypeArg.smarter_smart_sync_policy_changed:
+    :ivar EventTypeArg.smarter_smart_sync_policy_changed:
         (team_policies) Changed automatic Smart Sync setting for team
-    :ivar team_log.EventTypeArg.smart_sync_change_policy: (team_policies)
-        Changed default Smart Sync setting for team members
-    :ivar team_log.EventTypeArg.smart_sync_not_opt_out: (team_policies) Opted
-        team into Smart Sync
-    :ivar team_log.EventTypeArg.smart_sync_opt_out: (team_policies) Opted team
-        out of Smart Sync
-    :ivar team_log.EventTypeArg.sso_change_policy: (team_policies) Changed
-        single sign-on setting for team
-    :ivar team_log.EventTypeArg.stack_cross_team_access_policy_changed:
+    :ivar EventTypeArg.smart_sync_change_policy:
+        (team_policies) Changed default Smart Sync setting for team members
+    :ivar EventTypeArg.smart_sync_not_opt_out:
+        (team_policies) Opted team into Smart Sync
+    :ivar EventTypeArg.smart_sync_opt_out:
+        (team_policies) Opted team out of Smart Sync
+    :ivar EventTypeArg.sso_change_policy:
+        (team_policies) Changed single sign-on setting for team
+    :ivar EventTypeArg.stack_cross_team_access_policy_changed:
         (team_policies) Changed cross-team Stack access policy for team
-    :ivar team_log.EventTypeArg.team_branding_policy_changed: (team_policies)
-        Changed team branding policy for team
-    :ivar team_log.EventTypeArg.team_extensions_policy_changed: (team_policies)
-        Changed App Integrations setting for team
-    :ivar team_log.EventTypeArg.team_member_storage_request_policy_changed:
+    :ivar EventTypeArg.team_branding_policy_changed:
+        (team_policies) Changed team branding policy for team
+    :ivar EventTypeArg.team_extensions_policy_changed:
+        (team_policies) Changed App Integrations setting for team
+    :ivar EventTypeArg.team_member_storage_request_policy_changed:
         (team_policies) Changed team member storage request policy for team
-    :ivar team_log.EventTypeArg.team_selective_sync_policy_changed:
+    :ivar EventTypeArg.team_selective_sync_policy_changed:
         (team_policies) Enabled/disabled Team Selective Sync for team
-    :ivar team_log.EventTypeArg.team_sharing_whitelist_subjects_changed:
+    :ivar EventTypeArg.team_sharing_whitelist_subjects_changed:
         (team_policies) Edited the approved list for sharing externally
-    :ivar team_log.EventTypeArg.tfa_add_exception: (team_policies) Added members
-        to two factor authentication exception list
-    :ivar team_log.EventTypeArg.tfa_change_policy: (team_policies) Changed
-        two-factor authentication setting for team
-    :ivar team_log.EventTypeArg.tfa_remove_exception: (team_policies) Removed
-        members from two factor authentication exception list
-    :ivar team_log.EventTypeArg.top_level_content_policy_changed:
+    :ivar EventTypeArg.tfa_add_exception:
+        (team_policies) Added members to two factor authentication exception
+        list
+    :ivar EventTypeArg.tfa_change_policy:
+        (team_policies) Changed two-factor authentication setting for team
+    :ivar EventTypeArg.tfa_remove_exception:
+        (team_policies) Removed members from two factor authentication exception
+        list
+    :ivar EventTypeArg.top_level_content_policy_changed:
         (team_policies) Changed top level content setting for team
-    :ivar team_log.EventTypeArg.two_account_change_policy: (team_policies)
-        Enabled/disabled option for members to link personal Dropbox account and
-        team account to same computer
-    :ivar team_log.EventTypeArg.viewer_info_policy_changed: (team_policies)
-        Changed team policy for viewer info
-    :ivar team_log.EventTypeArg.watermarking_policy_changed: (team_policies)
-        Changed watermarking policy for team
-    :ivar team_log.EventTypeArg.web_sessions_change_active_session_limit:
+    :ivar EventTypeArg.two_account_change_policy:
+        (team_policies) Enabled/disabled option for members to link personal
+        Dropbox account and team account to same computer
+    :ivar EventTypeArg.viewer_info_policy_changed:
+        (team_policies) Changed team policy for viewer info
+    :ivar EventTypeArg.watermarking_policy_changed:
+        (team_policies) Changed watermarking policy for team
+    :ivar EventTypeArg.web_sessions_change_active_session_limit:
         (team_policies) Changed limit on active sessions per member
-    :ivar team_log.EventTypeArg.web_sessions_change_fixed_length_policy:
+    :ivar EventTypeArg.web_sessions_change_fixed_length_policy:
         (team_policies) Changed how long members can stay signed in to
         Dropbox.com
-    :ivar team_log.EventTypeArg.web_sessions_change_idle_length_policy:
+    :ivar EventTypeArg.web_sessions_change_idle_length_policy:
         (team_policies) Changed how long team members can be idle while signed
         in to Dropbox.com
-    :ivar team_log.EventTypeArg.data_residency_migration_request_successful:
+    :ivar EventTypeArg.data_residency_migration_request_successful:
         (team_profile) Requested data residency migration for team data
-    :ivar team_log.EventTypeArg.data_residency_migration_request_unsuccessful:
+    :ivar EventTypeArg.data_residency_migration_request_unsuccessful:
         (team_profile) Request for data residency migration for team data has
         failed
-    :ivar team_log.EventTypeArg.team_merge_from: (team_profile) Merged another
-        team into this team
-    :ivar team_log.EventTypeArg.team_merge_to: (team_profile) Merged this team
-        into another team
-    :ivar team_log.EventTypeArg.team_profile_add_background: (team_profile)
-        Added team background to display on shared link headers
-    :ivar team_log.EventTypeArg.team_profile_add_logo: (team_profile) Added team
-        logo to display on shared link headers
-    :ivar team_log.EventTypeArg.team_profile_change_background: (team_profile)
-        Changed team background displayed on shared link headers
-    :ivar team_log.EventTypeArg.team_profile_change_default_language:
+    :ivar EventTypeArg.team_merge_from:
+        (team_profile) Merged another team into this team
+    :ivar EventTypeArg.team_merge_to:
+        (team_profile) Merged this team into another team
+    :ivar EventTypeArg.team_profile_add_background:
+        (team_profile) Added team background to display on shared link headers
+    :ivar EventTypeArg.team_profile_add_logo:
+        (team_profile) Added team logo to display on shared link headers
+    :ivar EventTypeArg.team_profile_change_background:
+        (team_profile) Changed team background displayed on shared link headers
+    :ivar EventTypeArg.team_profile_change_default_language:
         (team_profile) Changed default language for team
-    :ivar team_log.EventTypeArg.team_profile_change_logo: (team_profile) Changed
-        team logo displayed on shared link headers
-    :ivar team_log.EventTypeArg.team_profile_change_name: (team_profile) Changed
-        team name
-    :ivar team_log.EventTypeArg.team_profile_remove_background: (team_profile)
-        Removed team background displayed on shared link headers
-    :ivar team_log.EventTypeArg.team_profile_remove_logo: (team_profile) Removed
-        team logo displayed on shared link headers
-    :ivar team_log.EventTypeArg.passkey_add: (tfa) Added passkey for login
-    :ivar team_log.EventTypeArg.passkey_remove: (tfa) Removed passkey for login
-    :ivar team_log.EventTypeArg.tfa_add_backup_phone: (tfa) Added backup phone
-        for two-factor authentication
-    :ivar team_log.EventTypeArg.tfa_add_security_key: (tfa) Added security key
-        for two-factor authentication
-    :ivar team_log.EventTypeArg.tfa_change_backup_phone: (tfa) Changed backup
-        phone for two-factor authentication
-    :ivar team_log.EventTypeArg.tfa_change_status: (tfa)
-        Enabled/disabled/changed two-factor authentication setting
-    :ivar team_log.EventTypeArg.tfa_remove_backup_phone: (tfa) Removed backup
-        phone for two-factor authentication
-    :ivar team_log.EventTypeArg.tfa_remove_security_key: (tfa) Removed security
-        key for two-factor authentication
-    :ivar team_log.EventTypeArg.tfa_reset: (tfa) Reset two-factor authentication
-        for team member
-    :ivar team_log.EventTypeArg.changed_enterprise_admin_role: (trusted_teams)
-        Changed enterprise admin role
-    :ivar team_log.EventTypeArg.changed_enterprise_connected_team_status:
+    :ivar EventTypeArg.team_profile_change_logo:
+        (team_profile) Changed team logo displayed on shared link headers
+    :ivar EventTypeArg.team_profile_change_name:
+        (team_profile) Changed team name
+    :ivar EventTypeArg.team_profile_remove_background:
+        (team_profile) Removed team background displayed on shared link headers
+    :ivar EventTypeArg.team_profile_remove_logo:
+        (team_profile) Removed team logo displayed on shared link headers
+    :ivar EventTypeArg.passkey_add:
+        (tfa) Added passkey for login
+    :ivar EventTypeArg.passkey_remove:
+        (tfa) Removed passkey for login
+    :ivar EventTypeArg.tfa_add_backup_phone:
+        (tfa) Added backup phone for two-factor authentication
+    :ivar EventTypeArg.tfa_add_security_key:
+        (tfa) Added security key for two-factor authentication
+    :ivar EventTypeArg.tfa_change_backup_phone:
+        (tfa) Changed backup phone for two-factor authentication
+    :ivar EventTypeArg.tfa_change_status:
+        (tfa) Enabled/disabled/changed two-factor authentication setting
+    :ivar EventTypeArg.tfa_remove_backup_phone:
+        (tfa) Removed backup phone for two-factor authentication
+    :ivar EventTypeArg.tfa_remove_security_key:
+        (tfa) Removed security key for two-factor authentication
+    :ivar EventTypeArg.tfa_reset:
+        (tfa) Reset two-factor authentication for team member
+    :ivar EventTypeArg.changed_enterprise_admin_role:
+        (trusted_teams) Changed enterprise admin role
+    :ivar EventTypeArg.changed_enterprise_connected_team_status:
         (trusted_teams) Changed enterprise-connected team status
-    :ivar team_log.EventTypeArg.ended_enterprise_admin_session: (trusted_teams)
-        Ended enterprise admin session
-    :ivar team_log.EventTypeArg.ended_enterprise_admin_session_deprecated:
+    :ivar EventTypeArg.ended_enterprise_admin_session:
+        (trusted_teams) Ended enterprise admin session
+    :ivar EventTypeArg.ended_enterprise_admin_session_deprecated:
         (trusted_teams) Ended enterprise admin session (deprecated, replaced by
         'Ended enterprise admin session')
-    :ivar team_log.EventTypeArg.enterprise_settings_locking: (trusted_teams)
-        Changed who can update a setting
-    :ivar team_log.EventTypeArg.guest_admin_change_status: (trusted_teams)
-        Changed guest team admin status
-    :ivar team_log.EventTypeArg.started_enterprise_admin_session:
+    :ivar EventTypeArg.enterprise_settings_locking:
+        (trusted_teams) Changed who can update a setting
+    :ivar EventTypeArg.guest_admin_change_status:
+        (trusted_teams) Changed guest team admin status
+    :ivar EventTypeArg.started_enterprise_admin_session:
         (trusted_teams) Started enterprise admin session
-    :ivar team_log.EventTypeArg.team_merge_request_accepted: (trusted_teams)
-        Accepted a team merge request
-    :ivar
-        team_log.EventTypeArg.team_merge_request_accepted_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_accepted:
+        (trusted_teams) Accepted a team merge request
+    :ivar EventTypeArg.team_merge_request_accepted_shown_to_primary_team:
         (trusted_teams) Accepted a team merge request (deprecated, replaced by
         'Accepted a team merge request')
-    :ivar
-        team_log.EventTypeArg.team_merge_request_accepted_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_accepted_shown_to_secondary_team:
         (trusted_teams) Accepted a team merge request (deprecated, replaced by
         'Accepted a team merge request')
-    :ivar team_log.EventTypeArg.team_merge_request_auto_canceled:
+    :ivar EventTypeArg.team_merge_request_auto_canceled:
         (trusted_teams) Automatically canceled team merge request
-    :ivar team_log.EventTypeArg.team_merge_request_canceled: (trusted_teams)
-        Canceled a team merge request
-    :ivar
-        team_log.EventTypeArg.team_merge_request_canceled_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_canceled:
+        (trusted_teams) Canceled a team merge request
+    :ivar EventTypeArg.team_merge_request_canceled_shown_to_primary_team:
         (trusted_teams) Canceled a team merge request (deprecated, replaced by
         'Canceled a team merge request')
-    :ivar
-        team_log.EventTypeArg.team_merge_request_canceled_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_canceled_shown_to_secondary_team:
         (trusted_teams) Canceled a team merge request (deprecated, replaced by
         'Canceled a team merge request')
-    :ivar team_log.EventTypeArg.team_merge_request_expired: (trusted_teams) Team
-        merge request expired
-    :ivar
-        team_log.EventTypeArg.team_merge_request_expired_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_expired:
+        (trusted_teams) Team merge request expired
+    :ivar EventTypeArg.team_merge_request_expired_shown_to_primary_team:
         (trusted_teams) Team merge request expired (deprecated, replaced by
         'Team merge request expired')
-    :ivar
-        team_log.EventTypeArg.team_merge_request_expired_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_expired_shown_to_secondary_team:
         (trusted_teams) Team merge request expired (deprecated, replaced by
         'Team merge request expired')
-    :ivar
-        team_log.EventTypeArg.team_merge_request_rejected_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_rejected_shown_to_primary_team:
         (trusted_teams) Rejected a team merge request (deprecated, no longer
         logged)
-    :ivar
-        team_log.EventTypeArg.team_merge_request_rejected_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_rejected_shown_to_secondary_team:
         (trusted_teams) Rejected a team merge request (deprecated, no longer
         logged)
-    :ivar team_log.EventTypeArg.team_merge_request_reminder: (trusted_teams)
-        Sent a team merge request reminder
-    :ivar
-        team_log.EventTypeArg.team_merge_request_reminder_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_reminder:
+        (trusted_teams) Sent a team merge request reminder
+    :ivar EventTypeArg.team_merge_request_reminder_shown_to_primary_team:
         (trusted_teams) Sent a team merge request reminder (deprecated, replaced
         by 'Sent a team merge request reminder')
-    :ivar
-        team_log.EventTypeArg.team_merge_request_reminder_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_reminder_shown_to_secondary_team:
         (trusted_teams) Sent a team merge request reminder (deprecated, replaced
         by 'Sent a team merge request reminder')
-    :ivar team_log.EventTypeArg.team_merge_request_revoked: (trusted_teams)
-        Canceled the team merge
-    :ivar team_log.EventTypeArg.team_merge_request_sent_shown_to_primary_team:
+    :ivar EventTypeArg.team_merge_request_revoked:
+        (trusted_teams) Canceled the team merge
+    :ivar EventTypeArg.team_merge_request_sent_shown_to_primary_team:
         (trusted_teams) Requested to merge their Dropbox team into yours
-    :ivar team_log.EventTypeArg.team_merge_request_sent_shown_to_secondary_team:
+    :ivar EventTypeArg.team_merge_request_sent_shown_to_secondary_team:
         (trusted_teams) Requested to merge your team into another Dropbox team
     """
 
@@ -58325,8 +58918,8 @@ class ExportMembersReportFailDetails(bb.Struct):
     """
     Failed to create members data report.
 
-    :ivar team_log.ExportMembersReportFailDetails.failure_reason: Failure
-        reason.
+    :ivar ExportMembersReportFailDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -58397,9 +58990,9 @@ class ExtendedVersionHistoryChangePolicyDetails(bb.Struct):
     """
     Accepted/opted out of extended version history.
 
-    :ivar team_log.ExtendedVersionHistoryChangePolicyDetails.new_value: New
-        extended version history policy.
-    :ivar team_log.ExtendedVersionHistoryChangePolicyDetails.previous_value:
+    :ivar ExtendedVersionHistoryChangePolicyDetails.new_value:
+        New extended version history policy.
+    :ivar ExtendedVersionHistoryChangePolicyDetails.previous_value:
         Previous extended version history policy. Might be missing due to
         historical data gap.
     """
@@ -58578,13 +59171,11 @@ class ExternalDriveBackupEligibilityStatusCheckedDetails(bb.Struct):
     """
     Checked external drive backup eligibility status.
 
-    :ivar
-        team_log.ExternalDriveBackupEligibilityStatusCheckedDetails.desktop_device_session_info:
+    :ivar ExternalDriveBackupEligibilityStatusCheckedDetails.desktop_device_session_info:
         Device's session logged information.
-    :ivar team_log.ExternalDriveBackupEligibilityStatusCheckedDetails.status:
+    :ivar ExternalDriveBackupEligibilityStatusCheckedDetails.status:
         Current eligibility status of external drive backup.
-    :ivar
-        team_log.ExternalDriveBackupEligibilityStatusCheckedDetails.number_of_external_drive_backup:
+    :ivar ExternalDriveBackupEligibilityStatusCheckedDetails.number_of_external_drive_backup:
         Total number of valid external drive backup for all the team members.
     """
 
@@ -58706,9 +59297,9 @@ class ExternalDriveBackupPolicyChangedDetails(bb.Struct):
     """
     Changed external drive backup policy for team.
 
-    :ivar team_log.ExternalDriveBackupPolicyChangedDetails.new_value: New
-        external drive backup policy.
-    :ivar team_log.ExternalDriveBackupPolicyChangedDetails.previous_value:
+    :ivar ExternalDriveBackupPolicyChangedDetails.new_value:
+        New external drive backup policy.
+    :ivar ExternalDriveBackupPolicyChangedDetails.previous_value:
         Previous external drive backup policy.
     """
 
@@ -58852,13 +59443,12 @@ class ExternalDriveBackupStatusChangedDetails(bb.Struct):
     """
     Modified external drive backup.
 
-    :ivar
-        team_log.ExternalDriveBackupStatusChangedDetails.desktop_device_session_info:
+    :ivar ExternalDriveBackupStatusChangedDetails.desktop_device_session_info:
         Device's session logged information.
-    :ivar team_log.ExternalDriveBackupStatusChangedDetails.previous_value:
+    :ivar ExternalDriveBackupStatusChangedDetails.previous_value:
         Previous status of this external drive backup.
-    :ivar team_log.ExternalDriveBackupStatusChangedDetails.new_value: Next
-        status of this external drive backup.
+    :ivar ExternalDriveBackupStatusChangedDetails.new_value:
+        Next status of this external drive backup.
     """
 
     __slots__ = [
@@ -58963,8 +59553,8 @@ class ExternalSharingReportFailedDetails(bb.Struct):
     """
     Couldn't create External sharing report.
 
-    :ivar team_log.ExternalSharingReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar ExternalSharingReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -59069,9 +59659,10 @@ class ExternalUserLogInfo(bb.Struct):
     """
     A user without a Dropbox account.
 
-    :ivar team_log.ExternalUserLogInfo.user_identifier: An external user
-        identifier.
-    :ivar team_log.ExternalUserLogInfo.identifier_type: Identifier type.
+    :ivar ExternalUserLogInfo.user_identifier:
+        An external user identifier.
+    :ivar ExternalUserLogInfo.identifier_type:
+        Identifier type.
     """
 
     __slots__ = [
@@ -59106,10 +59697,10 @@ class FailureDetailsLogInfo(bb.Struct):
     """
     Provides details about a failure
 
-    :ivar team_log.FailureDetailsLogInfo.user_friendly_message: A user friendly
-        explanation of the error.
-    :ivar team_log.FailureDetailsLogInfo.technical_error_message: A technical
-        explanation of the error. This is relevant for some errors.
+    :ivar FailureDetailsLogInfo.user_friendly_message:
+        A user friendly explanation of the error.
+    :ivar FailureDetailsLogInfo.technical_error_message:
+        A technical explanation of the error. This is relevant for some errors.
     """
 
     __slots__ = [
@@ -59192,9 +59783,12 @@ class FedExtraDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar OrganizationDetails FedExtraDetails.organization: More details about
-        the organization.
-    :ivar TeamDetails FedExtraDetails.team: More details about the team.
+    :ivar FedExtraDetails.organization:
+        More details about the organization.
+    :vartype FedExtraDetails.organization: OrganizationDetails
+    :ivar FedExtraDetails.team:
+        More details about the team.
+    :vartype FedExtraDetails.team: TeamDetails
     """
 
     _catch_all = 'other'
@@ -59368,15 +59962,15 @@ class FederationStatusChangeAdditionalInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar ConnectedTeamName
-        FederationStatusChangeAdditionalInfo.connected_team_name: The name of
-        the team
-    :ivar NonTrustedTeamDetails
-        FederationStatusChangeAdditionalInfo.non_trusted_team_details: The email
-        to which the request was sent
-    :ivar OrganizationName
-        FederationStatusChangeAdditionalInfo.organization_name: The name of the
-        organization
+    :ivar FederationStatusChangeAdditionalInfo.connected_team_name:
+        The name of the team
+    :vartype FederationStatusChangeAdditionalInfo.connected_team_name: ConnectedTeamName
+    :ivar FederationStatusChangeAdditionalInfo.non_trusted_team_details:
+        The email to which the request was sent
+    :vartype FederationStatusChangeAdditionalInfo.non_trusted_team_details: NonTrustedTeamDetails
+    :ivar FederationStatusChangeAdditionalInfo.organization_name:
+        The name of the organization
+    :vartype FederationStatusChangeAdditionalInfo.organization_name: OrganizationName
     """
 
     _catch_all = 'other'
@@ -59493,7 +60087,8 @@ class FileAddCommentDetails(bb.Struct):
     """
     Added file comment.
 
-    :ivar team_log.FileAddCommentDetails.comment_text: Comment text.
+    :ivar FileAddCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -59622,10 +60217,11 @@ class FileChangeCommentSubscriptionDetails(bb.Struct):
     """
     Subscribed to or unsubscribed from comment notifications for file.
 
-    :ivar team_log.FileChangeCommentSubscriptionDetails.new_value: New file
-        comment subscription.
-    :ivar team_log.FileChangeCommentSubscriptionDetails.previous_value: Previous
-        file comment subscription. Might be missing due to historical data gap.
+    :ivar FileChangeCommentSubscriptionDetails.new_value:
+        New file comment subscription.
+    :ivar FileChangeCommentSubscriptionDetails.previous_value:
+        Previous file comment subscription. Might be missing due to historical
+        data gap.
     """
 
     __slots__ = [
@@ -59728,11 +60324,11 @@ class FileCommentsChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled commenting on team files.
 
-    :ivar team_log.FileCommentsChangePolicyDetails.new_value: New commenting on
-        team files policy.
-    :ivar team_log.FileCommentsChangePolicyDetails.previous_value: Previous
-        commenting on team files policy. Might be missing due to historical data
-        gap.
+    :ivar FileCommentsChangePolicyDetails.new_value:
+        New commenting on team files policy.
+    :ivar FileCommentsChangePolicyDetails.previous_value:
+        Previous commenting on team files policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -59835,8 +60431,8 @@ class FileCopyDetails(bb.Struct):
     """
     Copied files and/or folders.
 
-    :ivar team_log.FileCopyDetails.relocate_action_details: Relocate action
-        details.
+    :ivar FileCopyDetails.relocate_action_details:
+        Relocate action details.
     """
 
     __slots__ = [
@@ -59885,7 +60481,8 @@ class FileDeleteCommentDetails(bb.Struct):
     """
     Deleted file comment.
 
-    :ivar team_log.FileDeleteCommentDetails.comment_text: Comment text.
+    :ivar FileDeleteCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -60014,9 +60611,10 @@ class FileEditCommentDetails(bb.Struct):
     """
     Edited file comment.
 
-    :ivar team_log.FileEditCommentDetails.comment_text: Comment text.
-    :ivar team_log.FileEditCommentDetails.previous_comment_text: Previous
-        comment text.
+    :ivar FileEditCommentDetails.comment_text:
+        Comment text.
+    :ivar FileEditCommentDetails.previous_comment_text:
+        Previous comment text.
     """
 
     __slots__ = [
@@ -60153,7 +60751,8 @@ class FileLikeCommentDetails(bb.Struct):
     """
     Liked file comment.
 
-    :ivar team_log.FileLikeCommentDetails.comment_text: Comment text.
+    :ivar FileLikeCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -60202,10 +60801,10 @@ class FileLockingLockStatusChangedDetails(bb.Struct):
     """
     Locked/unlocked editing for a file.
 
-    :ivar team_log.FileLockingLockStatusChangedDetails.previous_value: Previous
-        lock status of the file.
-    :ivar team_log.FileLockingLockStatusChangedDetails.new_value: New lock
-        status of the file.
+    :ivar FileLockingLockStatusChangedDetails.previous_value:
+        Previous lock status of the file.
+    :ivar FileLockingLockStatusChangedDetails.new_value:
+        New lock status of the file.
     """
 
     __slots__ = [
@@ -60262,10 +60861,10 @@ class FileLockingPolicyChangedDetails(bb.Struct):
     """
     Changed file locking policy for team.
 
-    :ivar team_log.FileLockingPolicyChangedDetails.new_value: New file locking
-        policy.
-    :ivar team_log.FileLockingPolicyChangedDetails.previous_value: Previous file
-        locking policy.
+    :ivar FileLockingPolicyChangedDetails.new_value:
+        New file locking policy.
+    :ivar FileLockingPolicyChangedDetails.previous_value:
+        Previous file locking policy.
     """
 
     __slots__ = [
@@ -60322,10 +60921,14 @@ class FileOrFolderLogInfo(bb.Struct):
     """
     Generic information relevant both for files and folders
 
-    :ivar team_log.FileOrFolderLogInfo.path: Path relative to event context.
-    :ivar team_log.FileOrFolderLogInfo.display_name: Display name.
-    :ivar team_log.FileOrFolderLogInfo.file_id: Unique ID.
-    :ivar team_log.FileOrFolderLogInfo.file_size: File or folder size in bytes.
+    :ivar FileOrFolderLogInfo.path:
+        Path relative to event context.
+    :ivar FileOrFolderLogInfo.display_name:
+        Display name.
+    :ivar FileOrFolderLogInfo.file_id:
+        Unique ID.
+    :ivar FileOrFolderLogInfo.file_size:
+        File or folder size in bytes.
     """
 
     __slots__ = [
@@ -60401,8 +61004,8 @@ class FileMoveDetails(bb.Struct):
     """
     Moved files and/or folders.
 
-    :ivar team_log.FileMoveDetails.relocate_action_details: Relocate action
-        details.
+    :ivar FileMoveDetails.relocate_action_details:
+        Relocate action details.
     """
 
     __slots__ = [
@@ -60531,8 +61134,9 @@ class FileProviderMigrationPolicyChangedDetails(bb.Struct):
     """
     Changed File Provider Migration policy for team.
 
-    :ivar team_log.FileProviderMigrationPolicyChangedDetails.new_value: To.
-    :ivar team_log.FileProviderMigrationPolicyChangedDetails.previous_value:
+    :ivar FileProviderMigrationPolicyChangedDetails.new_value:
+        To.
+    :ivar FileProviderMigrationPolicyChangedDetails.previous_value:
         From.
     """
 
@@ -60590,8 +61194,8 @@ class FileRenameDetails(bb.Struct):
     """
     Renamed files and/or folders.
 
-    :ivar team_log.FileRenameDetails.relocate_action_details: Relocate action
-        details.
+    :ivar FileRenameDetails.relocate_action_details:
+        Relocate action details.
     """
 
     __slots__ = [
@@ -60640,12 +61244,13 @@ class FileRequestAutoCloseDetails(bb.Struct):
     """
     Auto closed file request.
 
-    :ivar team_log.FileRequestAutoCloseDetails.file_request_id: File request id.
-        Might be missing due to historical data gap.
-    :ivar team_log.FileRequestAutoCloseDetails.reason: Reason for the auto
-        close.
-    :ivar team_log.FileRequestAutoCloseDetails.previous_details: Previous file
-        request details. Might be missing due to historical data gap.
+    :ivar FileRequestAutoCloseDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestAutoCloseDetails.reason:
+        Reason for the auto close.
+    :ivar FileRequestAutoCloseDetails.previous_details:
+        Previous file request details. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -60710,12 +61315,13 @@ class FileRequestChangeDetails(bb.Struct):
     """
     Changed file request.
 
-    :ivar team_log.FileRequestChangeDetails.file_request_id: File request id.
-        Might be missing due to historical data gap.
-    :ivar team_log.FileRequestChangeDetails.previous_details: Previous file
-        request details. Might be missing due to historical data gap.
-    :ivar team_log.FileRequestChangeDetails.new_details: New file request
-        details.
+    :ivar FileRequestChangeDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestChangeDetails.previous_details:
+        Previous file request details. Might be missing due to historical data
+        gap.
+    :ivar FileRequestChangeDetails.new_details:
+        New file request details.
     """
 
     __slots__ = [
@@ -60780,10 +61386,11 @@ class FileRequestCloseDetails(bb.Struct):
     """
     Closed file request.
 
-    :ivar team_log.FileRequestCloseDetails.file_request_id: File request id.
-        Might be missing due to historical data gap.
-    :ivar team_log.FileRequestCloseDetails.previous_details: Previous file
-        request details. Might be missing due to historical data gap.
+    :ivar FileRequestCloseDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestCloseDetails.previous_details:
+        Previous file request details. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -60840,10 +61447,10 @@ class FileRequestCreateDetails(bb.Struct):
     """
     Created file request.
 
-    :ivar team_log.FileRequestCreateDetails.file_request_id: File request id.
-        Might be missing due to historical data gap.
-    :ivar team_log.FileRequestCreateDetails.request_details: File request
-        details. Might be missing due to historical data gap.
+    :ivar FileRequestCreateDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestCreateDetails.request_details:
+        File request details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -60900,10 +61507,11 @@ class FileRequestDeadline(bb.Struct):
     """
     File request deadline
 
-    :ivar team_log.FileRequestDeadline.deadline: The deadline for this file
-        request. Might be missing due to historical data gap.
-    :ivar team_log.FileRequestDeadline.allow_late_uploads: If set, allow uploads
-        after the deadline has passed.
+    :ivar FileRequestDeadline.deadline:
+        The deadline for this file request. Might be missing due to historical
+        data gap.
+    :ivar FileRequestDeadline.allow_late_uploads:
+        If set, allow uploads after the deadline has passed.
     """
 
     __slots__ = [
@@ -60938,10 +61546,11 @@ class FileRequestDeleteDetails(bb.Struct):
     """
     Delete file request.
 
-    :ivar team_log.FileRequestDeleteDetails.file_request_id: File request id.
-        Might be missing due to historical data gap.
-    :ivar team_log.FileRequestDeleteDetails.previous_details: Previous file
-        request details. Might be missing due to historical data gap.
+    :ivar FileRequestDeleteDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestDeleteDetails.previous_details:
+        Previous file request details. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -60998,11 +61607,12 @@ class FileRequestDetails(bb.Struct):
     """
     File request details
 
-    :ivar team_log.FileRequestDetails.asset_index: Asset position in the Assets
-        list.
-    :ivar team_log.FileRequestDetails.deadline: File request deadline.
-    :ivar team_log.FileRequestDetails.has_password: Flag represents if this file
-        request has password.
+    :ivar FileRequestDetails.asset_index:
+        Asset position in the Assets list.
+    :ivar FileRequestDetails.deadline:
+        File request deadline.
+    :ivar FileRequestDetails.has_password:
+        Flag represents if this file request has password.
     """
 
     __slots__ = [
@@ -61045,16 +61655,16 @@ class FileRequestReceiveFileDetails(bb.Struct):
     """
     Received files for file request.
 
-    :ivar team_log.FileRequestReceiveFileDetails.file_request_id: File request
-        id. Might be missing due to historical data gap.
-    :ivar team_log.FileRequestReceiveFileDetails.file_request_details: File
-        request details. Might be missing due to historical data gap.
-    :ivar team_log.FileRequestReceiveFileDetails.submitted_file_names: Submitted
-        file names.
-    :ivar team_log.FileRequestReceiveFileDetails.submitter_name: The name as
-        provided by the submitter.
-    :ivar team_log.FileRequestReceiveFileDetails.submitter_email: The email as
-        provided by the submitter.
+    :ivar FileRequestReceiveFileDetails.file_request_id:
+        File request id. Might be missing due to historical data gap.
+    :ivar FileRequestReceiveFileDetails.file_request_details:
+        File request details. Might be missing due to historical data gap.
+    :ivar FileRequestReceiveFileDetails.submitted_file_names:
+        Submitted file names.
+    :ivar FileRequestReceiveFileDetails.submitter_name:
+        The name as provided by the submitter.
+    :ivar FileRequestReceiveFileDetails.submitter_email:
+        The email as provided by the submitter.
     """
 
     __slots__ = [
@@ -61135,10 +61745,11 @@ class FileRequestsChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled file requests.
 
-    :ivar team_log.FileRequestsChangePolicyDetails.new_value: New file requests
-        policy.
-    :ivar team_log.FileRequestsChangePolicyDetails.previous_value: Previous file
-        requests policy. Might be missing due to historical data gap.
+    :ivar FileRequestsChangePolicyDetails.new_value:
+        New file requests policy.
+    :ivar FileRequestsChangePolicyDetails.previous_value:
+        Previous file requests policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -61321,7 +61932,8 @@ class FileResolveCommentDetails(bb.Struct):
     """
     Resolved file comment.
 
-    :ivar team_log.FileResolveCommentDetails.comment_text: Comment text.
+    :ivar FileResolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -61490,7 +62102,7 @@ class FileSaveCopyReferenceDetails(bb.Struct):
     """
     Saved file/folder using copy reference.
 
-    :ivar team_log.FileSaveCopyReferenceDetails.relocate_action_details:
+    :ivar FileSaveCopyReferenceDetails.relocate_action_details:
         Relocate action details.
     """
 
@@ -61540,7 +62152,8 @@ class FileTransfersFileAddDetails(bb.Struct):
     """
     Transfer files added.
 
-    :ivar team_log.FileTransfersFileAddDetails.file_transfer_id: Transfer id.
+    :ivar FileTransfersFileAddDetails.file_transfer_id:
+        Transfer id.
     """
 
     __slots__ = [
@@ -61635,10 +62248,10 @@ class FileTransfersPolicyChangedDetails(bb.Struct):
     """
     Changed file transfers policy for team.
 
-    :ivar team_log.FileTransfersPolicyChangedDetails.new_value: New file
-        transfers policy.
-    :ivar team_log.FileTransfersPolicyChangedDetails.previous_value: Previous
-        file transfers policy.
+    :ivar FileTransfersPolicyChangedDetails.new_value:
+        New file transfers policy.
+    :ivar FileTransfersPolicyChangedDetails.previous_value:
+        Previous file transfers policy.
     """
 
     __slots__ = [
@@ -61695,8 +62308,8 @@ class FileTransfersTransferDeleteDetails(bb.Struct):
     """
     Deleted transfer.
 
-    :ivar team_log.FileTransfersTransferDeleteDetails.file_transfer_id: Transfer
-        id.
+    :ivar FileTransfersTransferDeleteDetails.file_transfer_id:
+        Transfer id.
     """
 
     __slots__ = [
@@ -61745,7 +62358,7 @@ class FileTransfersTransferDownloadDetails(bb.Struct):
     """
     Transfer downloaded.
 
-    :ivar team_log.FileTransfersTransferDownloadDetails.file_transfer_id:
+    :ivar FileTransfersTransferDownloadDetails.file_transfer_id:
         Transfer id.
     """
 
@@ -61795,8 +62408,8 @@ class FileTransfersTransferSendDetails(bb.Struct):
     """
     Sent transfer.
 
-    :ivar team_log.FileTransfersTransferSendDetails.file_transfer_id: Transfer
-        id.
+    :ivar FileTransfersTransferSendDetails.file_transfer_id:
+        Transfer id.
     """
 
     __slots__ = [
@@ -61845,8 +62458,8 @@ class FileTransfersTransferViewDetails(bb.Struct):
     """
     Viewed transfer.
 
-    :ivar team_log.FileTransfersTransferViewDetails.file_transfer_id: Transfer
-        id.
+    :ivar FileTransfersTransferViewDetails.file_transfer_id:
+        Transfer id.
     """
 
     __slots__ = [
@@ -61895,7 +62508,8 @@ class FileUnlikeCommentDetails(bb.Struct):
     """
     Unliked file comment.
 
-    :ivar team_log.FileUnlikeCommentDetails.comment_text: Comment text.
+    :ivar FileUnlikeCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -61944,7 +62558,8 @@ class FileUnresolveCommentDetails(bb.Struct):
     """
     Unresolved file comment.
 
-    :ivar team_log.FileUnresolveCommentDetails.comment_text: Comment text.
+    :ivar FileUnresolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -62079,9 +62694,9 @@ class FlexibleFileNamesPolicyChangedDetails(bb.Struct):
     """
     Changed flexible file names policy for team.
 
-    :ivar team_log.FlexibleFileNamesPolicyChangedDetails.new_value: New flexible
-        file names policy.
-    :ivar team_log.FlexibleFileNamesPolicyChangedDetails.previous_value:
+    :ivar FlexibleFileNamesPolicyChangedDetails.new_value:
+        New flexible file names policy.
+    :ivar FlexibleFileNamesPolicyChangedDetails.previous_value:
         Previous flexible file names policy. Might be missing due to historical
         data gap.
     """
@@ -62187,8 +62802,9 @@ class FolderLinkRestrictionPolicyChangedDetails(bb.Struct):
     """
     Changed folder link restrictions policy for team.
 
-    :ivar team_log.FolderLinkRestrictionPolicyChangedDetails.new_value: To.
-    :ivar team_log.FolderLinkRestrictionPolicyChangedDetails.previous_value:
+    :ivar FolderLinkRestrictionPolicyChangedDetails.new_value:
+        To.
+    :ivar FolderLinkRestrictionPolicyChangedDetails.previous_value:
         From.
     """
 
@@ -62246,7 +62862,8 @@ class FolderLogInfo(FileOrFolderLogInfo):
     """
     Folder's logged information.
 
-    :ivar team_log.FolderLogInfo.file_count: Number of files within the folder.
+    :ivar FolderLogInfo.file_count:
+        Number of files within the folder.
     """
 
     __slots__ = [
@@ -62281,8 +62898,7 @@ class FolderOverviewDescriptionChangedDetails(bb.Struct):
     """
     Updated folder overview.
 
-    :ivar
-        team_log.FolderOverviewDescriptionChangedDetails.folder_overview_location_asset:
+    :ivar FolderOverviewDescriptionChangedDetails.folder_overview_location_asset:
         Folder Overview location position in the Assets list.
     """
 
@@ -62332,10 +62948,9 @@ class FolderOverviewItemPinnedDetails(bb.Struct):
     """
     Pinned item to folder overview.
 
-    :ivar
-        team_log.FolderOverviewItemPinnedDetails.folder_overview_location_asset:
+    :ivar FolderOverviewItemPinnedDetails.folder_overview_location_asset:
         Folder Overview location position in the Assets list.
-    :ivar team_log.FolderOverviewItemPinnedDetails.pinned_items_asset_indices:
+    :ivar FolderOverviewItemPinnedDetails.pinned_items_asset_indices:
         Pinned items positions in the Assets list.
     """
 
@@ -62393,10 +63008,9 @@ class FolderOverviewItemUnpinnedDetails(bb.Struct):
     """
     Unpinned item from folder overview.
 
-    :ivar
-        team_log.FolderOverviewItemUnpinnedDetails.folder_overview_location_asset:
+    :ivar FolderOverviewItemUnpinnedDetails.folder_overview_location_asset:
         Folder Overview location position in the Assets list.
-    :ivar team_log.FolderOverviewItemUnpinnedDetails.pinned_items_asset_indices:
+    :ivar FolderOverviewItemUnpinnedDetails.pinned_items_asset_indices:
         Pinned items positions in the Assets list.
     """
 
@@ -62454,10 +63068,14 @@ class GeoLocationLogInfo(bb.Struct):
     """
     Geographic location details.
 
-    :ivar team_log.GeoLocationLogInfo.city: City name.
-    :ivar team_log.GeoLocationLogInfo.region: Region name.
-    :ivar team_log.GeoLocationLogInfo.country: Country code.
-    :ivar team_log.GeoLocationLogInfo.ip_address: IP address.
+    :ivar GeoLocationLogInfo.city:
+        City name.
+    :ivar GeoLocationLogInfo.region:
+        Region name.
+    :ivar GeoLocationLogInfo.country:
+        Country code.
+    :ivar GeoLocationLogInfo.ip_address:
+        IP address.
     """
 
     __slots__ = [
@@ -62506,21 +63124,23 @@ GeoLocationLogInfo_validator = bv.Struct(GeoLocationLogInfo)
 
 class GetTeamEventsArg(bb.Struct):
     """
-    :ivar team_log.GetTeamEventsArg.limit: The maximal number of results to
-        return per call. Note that some calls may not return ``limit`` number of
-        events, and may even return no events, even with `has_more` set to true.
-        In this case, callers should fetch again using
+    :ivar GetTeamEventsArg.limit:
+        The maximal number of results to return per call. Note that some calls
+        may not return ``limit`` number of events, and may even return no
+        events, even with `has_more` set to true. In this case, callers should
+        fetch again using
         :meth:`dropbox.dropbox_client.Dropbox.team_log_get_events_continue`.
-    :ivar team_log.GetTeamEventsArg.account_id: Filter the events by account ID.
-        Return only events with this account_id as either Actor, Context, or
-        Participants.
-    :ivar team_log.GetTeamEventsArg.time: Filter by time range.
-    :ivar team_log.GetTeamEventsArg.category: Filter the returned events to a
-        single category. Note that category shouldn't be provided together with
-        event_type.
-    :ivar team_log.GetTeamEventsArg.event_type: Filter the returned events to a
-        single event type. Note that event_type shouldn't be provided together
-        with category.
+    :ivar GetTeamEventsArg.account_id:
+        Filter the events by account ID. Return only events with this account_id
+        as either Actor, Context, or Participants.
+    :ivar GetTeamEventsArg.time:
+        Filter by time range.
+    :ivar GetTeamEventsArg.category:
+        Filter the returned events to a single category. Note that category
+        shouldn't be provided together with event_type.
+    :ivar GetTeamEventsArg.event_type:
+        Filter the returned events to a single event type. Note that event_type
+        shouldn't be provided together with category.
     """
 
     __slots__ = [
@@ -62577,8 +63197,8 @@ GetTeamEventsArg_validator = bv.Struct(GetTeamEventsArg)
 
 class GetTeamEventsContinueArg(bb.Struct):
     """
-    :ivar team_log.GetTeamEventsContinueArg.cursor: Indicates from what point to
-        get the next set of events.
+    :ivar GetTeamEventsContinueArg.cursor:
+        Indicates from what point to get the next set of events.
     """
 
     __slots__ = [
@@ -62610,15 +63230,18 @@ class GetTeamEventsContinueError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_log.GetTeamEventsContinueError.bad_cursor: Bad cursor.
-    :ivar datetime.datetime team_log.GetTeamEventsContinueError.reset: Cursors
-        are intended to be used quickly. Individual cursor values are normally
-        valid for days, but in rare cases may be reset sooner. Cursor reset
-        errors should be handled by fetching a new cursor from
-        :route:`get_events`. The associated value is the approximate timestamp
-        of the most recent event returned by the cursor. This should be used as
-        a resumption point when calling :route:`get_events` to obtain a new
-        cursor.
+    :ivar GetTeamEventsContinueError.bad_cursor:
+        Bad cursor.
+    :ivar GetTeamEventsContinueError.reset:
+        Cursors are intended to be used quickly. Individual cursor values are
+        normally valid for days, but in rare cases may be reset sooner. Cursor
+        reset errors should be handled by fetching a new cursor from
+        :meth:`dropbox.dropbox_client.Dropbox.team_log_get_events`. The
+        associated value is the approximate timestamp of the most recent event
+        returned by the cursor. This should be used as a resumption point when
+        calling :meth:`dropbox.dropbox_client.Dropbox.team_log_get_events` to
+        obtain a new cursor.
+    :vartype GetTeamEventsContinueError.reset: datetime.datetime
     """
 
     _catch_all = 'other'
@@ -62695,11 +63318,13 @@ class GetTeamEventsError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_log.GetTeamEventsError.account_id_not_found: No user found
-        matching the provided account_id.
-    :ivar team_log.GetTeamEventsError.invalid_time_range: Invalid time range.
-    :ivar team_log.GetTeamEventsError.invalid_filters: Invalid filters. Do not
-        specify both event_type and category parameters for the same call.
+    :ivar GetTeamEventsError.account_id_not_found:
+        No user found matching the provided account_id.
+    :ivar GetTeamEventsError.invalid_time_range:
+        Invalid time range.
+    :ivar GetTeamEventsError.invalid_filters:
+        Invalid filters. Do not specify both event_type and category parameters
+        for the same call.
     """
 
     _catch_all = 'other'
@@ -62751,9 +63376,11 @@ GetTeamEventsError_validator = bv.Union(GetTeamEventsError)
 
 class GetTeamEventsResult(bb.Struct):
     """
-    :ivar team_log.GetTeamEventsResult.events: List of events. Note that events
-        are not guaranteed to be sorted by their timestamp value.
-    :ivar team_log.GetTeamEventsResult.cursor: Pass the cursor into
+    :ivar GetTeamEventsResult.events:
+        List of events. Note that events are not guaranteed to be sorted by
+        their timestamp value.
+    :ivar GetTeamEventsResult.cursor:
+        Pass the cursor into
         :meth:`dropbox.dropbox_client.Dropbox.team_log_get_events_continue` to
         obtain additional events. The value of ``cursor`` may change for each
         response from
@@ -62763,8 +63390,9 @@ class GetTeamEventsResult(bb.Struct):
         on the latest value of ``cursor`` after each call, and poll regularly if
         they wish to poll for new events. Callers should handle reset exceptions
         for expired cursors.
-    :ivar team_log.GetTeamEventsResult.has_more: Is true if there may be
-        additional events that have not been returned yet. An additional call to
+    :ivar GetTeamEventsResult.has_more:
+        Is true if there may be additional events that have not been returned
+        yet. An additional call to
         :meth:`dropbox.dropbox_client.Dropbox.team_log_get_events_continue` can
         retrieve them. Note that ``has_more`` may be ``True``, even if
         ``events`` is empty.
@@ -62810,10 +63438,11 @@ class GoogleSsoChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled Google single sign-on for team.
 
-    :ivar team_log.GoogleSsoChangePolicyDetails.new_value: New Google single
-        sign-on policy.
-    :ivar team_log.GoogleSsoChangePolicyDetails.previous_value: Previous Google
-        single sign-on policy. Might be missing due to historical data gap.
+    :ivar GoogleSsoChangePolicyDetails.new_value:
+        New Google single sign-on policy.
+    :ivar GoogleSsoChangePolicyDetails.previous_value:
+        Previous Google single sign-on policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -62916,13 +63545,16 @@ class GovernancePolicyAddFolderFailedDetails(bb.Struct):
     """
     Couldn't add a folder to a policy.
 
-    :ivar team_log.GovernancePolicyAddFolderFailedDetails.governance_policy_id:
+    :ivar GovernancePolicyAddFolderFailedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyAddFolderFailedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyAddFolderFailedDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyAddFolderFailedDetails.folder: Folder.
-    :ivar team_log.GovernancePolicyAddFolderFailedDetails.reason: Reason.
+    :ivar GovernancePolicyAddFolderFailedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyAddFolderFailedDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyAddFolderFailedDetails.folder:
+        Folder.
+    :ivar GovernancePolicyAddFolderFailedDetails.reason:
+        Reason.
     """
 
     __slots__ = [
@@ -63003,11 +63635,14 @@ class GovernancePolicyAddFoldersDetails(bb.Struct):
     """
     Added folders to policy.
 
-    :ivar team_log.GovernancePolicyAddFoldersDetails.governance_policy_id:
+    :ivar GovernancePolicyAddFoldersDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyAddFoldersDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyAddFoldersDetails.policy_type: Policy type.
-    :ivar team_log.GovernancePolicyAddFoldersDetails.folders: Folders.
+    :ivar GovernancePolicyAddFoldersDetails.name:
+        Policy name.
+    :ivar GovernancePolicyAddFoldersDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyAddFoldersDetails.folders:
+        Folders.
     """
 
     __slots__ = [
@@ -63080,12 +63715,13 @@ class GovernancePolicyContentDisposedDetails(bb.Struct):
     """
     Content disposed.
 
-    :ivar team_log.GovernancePolicyContentDisposedDetails.governance_policy_id:
+    :ivar GovernancePolicyContentDisposedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyContentDisposedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyContentDisposedDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyContentDisposedDetails.disposition_type:
+    :ivar GovernancePolicyContentDisposedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyContentDisposedDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyContentDisposedDetails.disposition_type:
         Disposition type.
     """
 
@@ -63159,12 +63795,16 @@ class GovernancePolicyCreateDetails(bb.Struct):
     """
     Activated a new policy.
 
-    :ivar team_log.GovernancePolicyCreateDetails.governance_policy_id: Policy
-        ID.
-    :ivar team_log.GovernancePolicyCreateDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyCreateDetails.policy_type: Policy type.
-    :ivar team_log.GovernancePolicyCreateDetails.duration: Duration in days.
-    :ivar team_log.GovernancePolicyCreateDetails.folders: Folders.
+    :ivar GovernancePolicyCreateDetails.governance_policy_id:
+        Policy ID.
+    :ivar GovernancePolicyCreateDetails.name:
+        Policy name.
+    :ivar GovernancePolicyCreateDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyCreateDetails.duration:
+        Duration in days.
+    :ivar GovernancePolicyCreateDetails.folders:
+        Folders.
     """
 
     __slots__ = [
@@ -63245,10 +63885,12 @@ class GovernancePolicyDeleteDetails(bb.Struct):
     """
     Deleted a policy.
 
-    :ivar team_log.GovernancePolicyDeleteDetails.governance_policy_id: Policy
-        ID.
-    :ivar team_log.GovernancePolicyDeleteDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyDeleteDetails.policy_type: Policy type.
+    :ivar GovernancePolicyDeleteDetails.governance_policy_id:
+        Policy ID.
+    :ivar GovernancePolicyDeleteDetails.name:
+        Policy name.
+    :ivar GovernancePolicyDeleteDetails.policy_type:
+        Policy type.
     """
 
     __slots__ = [
@@ -63313,13 +63955,18 @@ class GovernancePolicyEditDetailsDetails(bb.Struct):
     """
     Edited policy.
 
-    :ivar team_log.GovernancePolicyEditDetailsDetails.governance_policy_id:
+    :ivar GovernancePolicyEditDetailsDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyEditDetailsDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyEditDetailsDetails.policy_type: Policy type.
-    :ivar team_log.GovernancePolicyEditDetailsDetails.attribute: Attribute.
-    :ivar team_log.GovernancePolicyEditDetailsDetails.previous_value: From.
-    :ivar team_log.GovernancePolicyEditDetailsDetails.new_value: To.
+    :ivar GovernancePolicyEditDetailsDetails.name:
+        Policy name.
+    :ivar GovernancePolicyEditDetailsDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyEditDetailsDetails.attribute:
+        Attribute.
+    :ivar GovernancePolicyEditDetailsDetails.previous_value:
+        From.
+    :ivar GovernancePolicyEditDetailsDetails.new_value:
+        To.
     """
 
     __slots__ = [
@@ -63408,12 +64055,16 @@ class GovernancePolicyEditDurationDetails(bb.Struct):
     """
     Changed policy duration.
 
-    :ivar team_log.GovernancePolicyEditDurationDetails.governance_policy_id:
+    :ivar GovernancePolicyEditDurationDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyEditDurationDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyEditDurationDetails.policy_type: Policy type.
-    :ivar team_log.GovernancePolicyEditDurationDetails.previous_value: From.
-    :ivar team_log.GovernancePolicyEditDurationDetails.new_value: To.
+    :ivar GovernancePolicyEditDurationDetails.name:
+        Policy name.
+    :ivar GovernancePolicyEditDurationDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyEditDurationDetails.previous_value:
+        From.
+    :ivar GovernancePolicyEditDurationDetails.new_value:
+        To.
     """
 
     __slots__ = [
@@ -63494,13 +64145,14 @@ class GovernancePolicyExportCreatedDetails(bb.Struct):
     """
     Created a policy download.
 
-    :ivar team_log.GovernancePolicyExportCreatedDetails.governance_policy_id:
+    :ivar GovernancePolicyExportCreatedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyExportCreatedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyExportCreatedDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyExportCreatedDetails.export_name: Export
-        name.
+    :ivar GovernancePolicyExportCreatedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyExportCreatedDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyExportCreatedDetails.export_name:
+        Export name.
     """
 
     __slots__ = [
@@ -63573,13 +64225,14 @@ class GovernancePolicyExportRemovedDetails(bb.Struct):
     """
     Removed a policy download.
 
-    :ivar team_log.GovernancePolicyExportRemovedDetails.governance_policy_id:
+    :ivar GovernancePolicyExportRemovedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyExportRemovedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyExportRemovedDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyExportRemovedDetails.export_name: Export
-        name.
+    :ivar GovernancePolicyExportRemovedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyExportRemovedDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyExportRemovedDetails.export_name:
+        Export name.
     """
 
     __slots__ = [
@@ -63652,13 +64305,16 @@ class GovernancePolicyRemoveFoldersDetails(bb.Struct):
     """
     Removed folders from policy.
 
-    :ivar team_log.GovernancePolicyRemoveFoldersDetails.governance_policy_id:
+    :ivar GovernancePolicyRemoveFoldersDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyRemoveFoldersDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyRemoveFoldersDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyRemoveFoldersDetails.folders: Folders.
-    :ivar team_log.GovernancePolicyRemoveFoldersDetails.reason: Reason.
+    :ivar GovernancePolicyRemoveFoldersDetails.name:
+        Policy name.
+    :ivar GovernancePolicyRemoveFoldersDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyRemoveFoldersDetails.folders:
+        Folders.
+    :ivar GovernancePolicyRemoveFoldersDetails.reason:
+        Reason.
     """
 
     __slots__ = [
@@ -63739,11 +64395,12 @@ class GovernancePolicyReportCreatedDetails(bb.Struct):
     """
     Created a summary report for a policy.
 
-    :ivar team_log.GovernancePolicyReportCreatedDetails.governance_policy_id:
+    :ivar GovernancePolicyReportCreatedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyReportCreatedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyReportCreatedDetails.policy_type: Policy
-        type.
+    :ivar GovernancePolicyReportCreatedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyReportCreatedDetails.policy_type:
+        Policy type.
     """
 
     __slots__ = [
@@ -63808,15 +64465,16 @@ class GovernancePolicyZipPartDownloadedDetails(bb.Struct):
     """
     Downloaded content from a policy.
 
-    :ivar
-        team_log.GovernancePolicyZipPartDownloadedDetails.governance_policy_id:
+    :ivar GovernancePolicyZipPartDownloadedDetails.governance_policy_id:
         Policy ID.
-    :ivar team_log.GovernancePolicyZipPartDownloadedDetails.name: Policy name.
-    :ivar team_log.GovernancePolicyZipPartDownloadedDetails.policy_type: Policy
-        type.
-    :ivar team_log.GovernancePolicyZipPartDownloadedDetails.export_name: Export
-        name.
-    :ivar team_log.GovernancePolicyZipPartDownloadedDetails.part: Part.
+    :ivar GovernancePolicyZipPartDownloadedDetails.name:
+        Policy name.
+    :ivar GovernancePolicyZipPartDownloadedDetails.policy_type:
+        Policy type.
+    :ivar GovernancePolicyZipPartDownloadedDetails.export_name:
+        Export name.
+    :ivar GovernancePolicyZipPartDownloadedDetails.part:
+        Part.
     """
 
     __slots__ = [
@@ -63897,7 +64555,8 @@ class GroupAddExternalIdDetails(bb.Struct):
     """
     Added external ID for group.
 
-    :ivar team_log.GroupAddExternalIdDetails.new_value: Current external id.
+    :ivar GroupAddExternalIdDetails.new_value:
+        Current external id.
     """
 
     __slots__ = [
@@ -63946,7 +64605,8 @@ class GroupAddMemberDetails(bb.Struct):
     """
     Added team members to group.
 
-    :ivar team_log.GroupAddMemberDetails.is_group_owner: Is group owner.
+    :ivar GroupAddMemberDetails.is_group_owner:
+        Is group owner.
     """
 
     __slots__ = [
@@ -63995,8 +64655,10 @@ class GroupChangeExternalIdDetails(bb.Struct):
     """
     Changed external ID for group.
 
-    :ivar team_log.GroupChangeExternalIdDetails.new_value: Current external id.
-    :ivar team_log.GroupChangeExternalIdDetails.previous_value: Old external id.
+    :ivar GroupChangeExternalIdDetails.new_value:
+        Current external id.
+    :ivar GroupChangeExternalIdDetails.previous_value:
+        Old external id.
     """
 
     __slots__ = [
@@ -64053,10 +64715,11 @@ class GroupChangeManagementTypeDetails(bb.Struct):
     """
     Changed group management type.
 
-    :ivar team_log.GroupChangeManagementTypeDetails.new_value: New group
-        management type.
-    :ivar team_log.GroupChangeManagementTypeDetails.previous_value: Previous
-        group management type. Might be missing due to historical data gap.
+    :ivar GroupChangeManagementTypeDetails.new_value:
+        New group management type.
+    :ivar GroupChangeManagementTypeDetails.previous_value:
+        Previous group management type. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -64113,7 +64776,8 @@ class GroupChangeMemberRoleDetails(bb.Struct):
     """
     Changed manager permissions of group member.
 
-    :ivar team_log.GroupChangeMemberRoleDetails.is_group_owner: Is group owner.
+    :ivar GroupChangeMemberRoleDetails.is_group_owner:
+        Is group owner.
     """
 
     __slots__ = [
@@ -64162,9 +64826,10 @@ class GroupCreateDetails(bb.Struct):
     """
     Created group.
 
-    :ivar team_log.GroupCreateDetails.is_company_managed: Is company managed
-        group.
-    :ivar team_log.GroupCreateDetails.join_policy: Group join policy.
+    :ivar GroupCreateDetails.is_company_managed:
+        Is company managed group.
+    :ivar GroupCreateDetails.join_policy:
+        Group join policy.
     """
 
     __slots__ = [
@@ -64221,8 +64886,8 @@ class GroupDeleteDetails(bb.Struct):
     """
     Deleted group.
 
-    :ivar team_log.GroupDeleteDetails.is_company_managed: Is company managed
-        group.
+    :ivar GroupDeleteDetails.is_company_managed:
+        Is company managed group.
     """
 
     __slots__ = [
@@ -64311,10 +64976,9 @@ class GroupExternalSharingSettingOverrideChangedDetails(bb.Struct):
     """
     Changed group's external sharing setting.
 
-    :ivar team_log.GroupExternalSharingSettingOverrideChangedDetails.new_value:
+    :ivar GroupExternalSharingSettingOverrideChangedDetails.new_value:
         New external sharing setting.
-    :ivar
-        team_log.GroupExternalSharingSettingOverrideChangedDetails.previous_value:
+    :ivar GroupExternalSharingSettingOverrideChangedDetails.previous_value:
         Previous external sharing setting.
     """
 
@@ -64416,9 +65080,10 @@ class GroupJoinPolicyUpdatedDetails(bb.Struct):
     """
     Updated group join policy.
 
-    :ivar team_log.GroupJoinPolicyUpdatedDetails.is_company_managed: Is company
-        managed group.
-    :ivar team_log.GroupJoinPolicyUpdatedDetails.join_policy: Group join policy.
+    :ivar GroupJoinPolicyUpdatedDetails.is_company_managed:
+        Is company managed group.
+    :ivar GroupJoinPolicyUpdatedDetails.join_policy:
+        Group join policy.
     """
 
     __slots__ = [
@@ -64475,9 +65140,12 @@ class GroupLogInfo(bb.Struct):
     """
     Group's logged information.
 
-    :ivar team_log.GroupLogInfo.group_id: The unique id of this group.
-    :ivar team_log.GroupLogInfo.display_name: The name of this group.
-    :ivar team_log.GroupLogInfo.external_id: External group ID.
+    :ivar GroupLogInfo.group_id:
+        The unique id of this group.
+    :ivar GroupLogInfo.display_name:
+        The name of this group.
+    :ivar GroupLogInfo.external_id:
+        External group ID.
     """
 
     __slots__ = [
@@ -64560,7 +65228,8 @@ class GroupRemoveExternalIdDetails(bb.Struct):
     """
     Removed external ID for group.
 
-    :ivar team_log.GroupRemoveExternalIdDetails.previous_value: Old external id.
+    :ivar GroupRemoveExternalIdDetails.previous_value:
+        Old external id.
     """
 
     __slots__ = [
@@ -64649,8 +65318,10 @@ class GroupRenameDetails(bb.Struct):
     """
     Renamed group.
 
-    :ivar team_log.GroupRenameDetails.previous_value: Previous display name.
-    :ivar team_log.GroupRenameDetails.new_value: New display name.
+    :ivar GroupRenameDetails.previous_value:
+        Previous display name.
+    :ivar GroupRenameDetails.new_value:
+        New display name.
     """
 
     __slots__ = [
@@ -64707,9 +65378,9 @@ class GroupUserManagementChangePolicyDetails(bb.Struct):
     """
     Changed who can create groups.
 
-    :ivar team_log.GroupUserManagementChangePolicyDetails.new_value: New group
-        users management policy.
-    :ivar team_log.GroupUserManagementChangePolicyDetails.previous_value:
+    :ivar GroupUserManagementChangePolicyDetails.new_value:
+        New group users management policy.
+    :ivar GroupUserManagementChangePolicyDetails.previous_value:
         Previous group users management policy. Might be missing due to
         historical data gap.
     """
@@ -64768,16 +65439,18 @@ class GuestAdminChangeStatusDetails(bb.Struct):
     """
     Changed guest team admin status.
 
-    :ivar team_log.GuestAdminChangeStatusDetails.is_guest: True for guest, false
-        for host.
-    :ivar team_log.GuestAdminChangeStatusDetails.guest_team_name: The name of
-        the guest team.
-    :ivar team_log.GuestAdminChangeStatusDetails.host_team_name: The name of the
-        host team.
-    :ivar team_log.GuestAdminChangeStatusDetails.previous_value: Previous
-        request state.
-    :ivar team_log.GuestAdminChangeStatusDetails.new_value: New request state.
-    :ivar team_log.GuestAdminChangeStatusDetails.action_details: Action details.
+    :ivar GuestAdminChangeStatusDetails.is_guest:
+        True for guest, false for host.
+    :ivar GuestAdminChangeStatusDetails.guest_team_name:
+        The name of the guest team.
+    :ivar GuestAdminChangeStatusDetails.host_team_name:
+        The name of the host team.
+    :ivar GuestAdminChangeStatusDetails.previous_value:
+        Previous request state.
+    :ivar GuestAdminChangeStatusDetails.new_value:
+        New request state.
+    :ivar GuestAdminChangeStatusDetails.action_details:
+        Action details.
     """
 
     __slots__ = [
@@ -64866,9 +65539,9 @@ class GuestAdminSignedInViaTrustedTeamsDetails(bb.Struct):
     """
     Started trusted team admin session.
 
-    :ivar team_log.GuestAdminSignedInViaTrustedTeamsDetails.team_name: Host team
-        name.
-    :ivar team_log.GuestAdminSignedInViaTrustedTeamsDetails.trusted_team_name:
+    :ivar GuestAdminSignedInViaTrustedTeamsDetails.team_name:
+        Host team name.
+    :ivar GuestAdminSignedInViaTrustedTeamsDetails.trusted_team_name:
         Trusted team name.
     """
 
@@ -64926,9 +65599,9 @@ class GuestAdminSignedOutViaTrustedTeamsDetails(bb.Struct):
     """
     Ended trusted team admin session.
 
-    :ivar team_log.GuestAdminSignedOutViaTrustedTeamsDetails.team_name: Host
-        team name.
-    :ivar team_log.GuestAdminSignedOutViaTrustedTeamsDetails.trusted_team_name:
+    :ivar GuestAdminSignedOutViaTrustedTeamsDetails.team_name:
+        Host team name.
+    :ivar GuestAdminSignedOutViaTrustedTeamsDetails.trusted_team_name:
         Trusted team name.
     """
 
@@ -65030,8 +65703,8 @@ class IntegrationConnectedDetails(bb.Struct):
     """
     Connected integration for member.
 
-    :ivar team_log.IntegrationConnectedDetails.integration_name: Name of the
-        third-party integration.
+    :ivar IntegrationConnectedDetails.integration_name:
+        Name of the third-party integration.
     """
 
     __slots__ = [
@@ -65080,8 +65753,8 @@ class IntegrationDisconnectedDetails(bb.Struct):
     """
     Disconnected integration for member.
 
-    :ivar team_log.IntegrationDisconnectedDetails.integration_name: Name of the
-        third-party integration.
+    :ivar IntegrationDisconnectedDetails.integration_name:
+        Name of the third-party integration.
     """
 
     __slots__ = [
@@ -65177,12 +65850,12 @@ class IntegrationPolicyChangedDetails(bb.Struct):
     """
     Changed integration policy for team.
 
-    :ivar team_log.IntegrationPolicyChangedDetails.integration_name: Name of the
-        third-party integration.
-    :ivar team_log.IntegrationPolicyChangedDetails.new_value: New integration
-        policy.
-    :ivar team_log.IntegrationPolicyChangedDetails.previous_value: Previous
-        integration policy.
+    :ivar IntegrationPolicyChangedDetails.integration_name:
+        Name of the third-party integration.
+    :ivar IntegrationPolicyChangedDetails.new_value:
+        New integration policy.
+    :ivar IntegrationPolicyChangedDetails.previous_value:
+        Previous integration policy.
     """
 
     __slots__ = [
@@ -65294,8 +65967,9 @@ class InviteAcceptanceEmailPolicyChangedDetails(bb.Struct):
     """
     Changed invite accept email policy for team.
 
-    :ivar team_log.InviteAcceptanceEmailPolicyChangedDetails.new_value: To.
-    :ivar team_log.InviteAcceptanceEmailPolicyChangedDetails.previous_value:
+    :ivar InviteAcceptanceEmailPolicyChangedDetails.new_value:
+        To.
+    :ivar InviteAcceptanceEmailPolicyChangedDetails.previous_value:
         From.
     """
 
@@ -65417,30 +66091,30 @@ class JoinTeamDetails(bb.Struct):
     """
     Additional information relevant when a new member joins the team.
 
-    :ivar team_log.JoinTeamDetails.linked_apps: Field is deprecated. Linked
-        applications. (Deprecated) Please use has_linked_apps boolean field
-        instead.
-    :ivar team_log.JoinTeamDetails.linked_devices: Field is deprecated. Linked
-        devices. (Deprecated) Please use has_linked_devices boolean field
-        instead.
-    :ivar team_log.JoinTeamDetails.linked_shared_folders: Field is deprecated.
-        Linked shared folders. (Deprecated) Please use has_linked_shared_folders
-        boolean field instead.
-    :ivar team_log.JoinTeamDetails.was_linked_apps_truncated: Field is
-        deprecated. (Deprecated) True if the linked_apps list was truncated to
-        the maximum supported length (50).
-    :ivar team_log.JoinTeamDetails.was_linked_devices_truncated: Field is
-        deprecated. (Deprecated) True if the linked_devices list was truncated
-        to the maximum supported length (50).
-    :ivar team_log.JoinTeamDetails.was_linked_shared_folders_truncated: Field is
-        deprecated. (Deprecated) True if the linked_shared_folders list was
+    :ivar JoinTeamDetails.linked_apps:
+        Field is deprecated. Linked applications. (Deprecated) Please use
+        has_linked_apps boolean field instead.
+    :ivar JoinTeamDetails.linked_devices:
+        Field is deprecated. Linked devices. (Deprecated) Please use
+        has_linked_devices boolean field instead.
+    :ivar JoinTeamDetails.linked_shared_folders:
+        Field is deprecated. Linked shared folders. (Deprecated) Please use
+        has_linked_shared_folders boolean field instead.
+    :ivar JoinTeamDetails.was_linked_apps_truncated:
+        Field is deprecated. (Deprecated) True if the linked_apps list was
         truncated to the maximum supported length (50).
-    :ivar team_log.JoinTeamDetails.has_linked_apps: True if the user had linked
-        apps at event time.
-    :ivar team_log.JoinTeamDetails.has_linked_devices: True if the user had
-        linked apps at event time.
-    :ivar team_log.JoinTeamDetails.has_linked_shared_folders: True if the user
-        had linked shared folders at event time.
+    :ivar JoinTeamDetails.was_linked_devices_truncated:
+        Field is deprecated. (Deprecated) True if the linked_devices list was
+        truncated to the maximum supported length (50).
+    :ivar JoinTeamDetails.was_linked_shared_folders_truncated:
+        Field is deprecated. (Deprecated) True if the linked_shared_folders list
+        was truncated to the maximum supported length (50).
+    :ivar JoinTeamDetails.has_linked_apps:
+        True if the user had linked apps at event time.
+    :ivar JoinTeamDetails.has_linked_devices:
+        True if the user had linked apps at event time.
+    :ivar JoinTeamDetails.has_linked_shared_folders:
+        True if the user had linked shared folders at event time.
     """
 
     __slots__ = [
@@ -65587,25 +66261,28 @@ class LegacyDeviceSessionLogInfo(DeviceSessionLogInfo):
     """
     Information on sessions, in legacy format
 
-    :ivar team_log.LegacyDeviceSessionLogInfo.session_info: Session unique id.
-    :ivar team_log.LegacyDeviceSessionLogInfo.display_name: The device name.
-        Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.is_emm_managed: Is device managed
-        by emm. Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.platform: Information on the
-        hosting platform. Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.mac_address: The mac address of
-        the last activity from this session. Might be missing due to historical
+    :ivar LegacyDeviceSessionLogInfo.session_info:
+        Session unique id.
+    :ivar LegacyDeviceSessionLogInfo.display_name:
+        The device name. Might be missing due to historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.is_emm_managed:
+        Is device managed by emm. Might be missing due to historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.platform:
+        Information on the hosting platform. Might be missing due to historical
         data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.os_version: The hosting OS
-        version. Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.device_type: Information on the
-        hosting device type. Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.client_version: The Dropbox client
-        version. Might be missing due to historical data gap.
-    :ivar team_log.LegacyDeviceSessionLogInfo.legacy_uniq_id: Alternative unique
-        device session id, instead of session id field. Might be missing due to
+    :ivar LegacyDeviceSessionLogInfo.mac_address:
+        The mac address of the last activity from this session. Might be missing
+        due to historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.os_version:
+        The hosting OS version. Might be missing due to historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.device_type:
+        Information on the hosting device type. Might be missing due to
         historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.client_version:
+        The Dropbox client version. Might be missing due to historical data gap.
+    :ivar LegacyDeviceSessionLogInfo.legacy_uniq_id:
+        Alternative unique device session id, instead of session id field. Might
+        be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -65702,10 +66379,14 @@ class LegalHoldsActivateAHoldDetails(bb.Struct):
     """
     Activated a hold.
 
-    :ivar team_log.LegalHoldsActivateAHoldDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsActivateAHoldDetails.name: Hold name.
-    :ivar team_log.LegalHoldsActivateAHoldDetails.start_date: Hold start date.
-    :ivar team_log.LegalHoldsActivateAHoldDetails.end_date: Hold end date.
+    :ivar LegalHoldsActivateAHoldDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsActivateAHoldDetails.name:
+        Hold name.
+    :ivar LegalHoldsActivateAHoldDetails.start_date:
+        Hold start date.
+    :ivar LegalHoldsActivateAHoldDetails.end_date:
+        Hold end date.
     """
 
     __slots__ = [
@@ -65778,8 +66459,10 @@ class LegalHoldsAddMembersDetails(bb.Struct):
     """
     Added members to a hold.
 
-    :ivar team_log.LegalHoldsAddMembersDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsAddMembersDetails.name: Hold name.
+    :ivar LegalHoldsAddMembersDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsAddMembersDetails.name:
+        Hold name.
     """
 
     __slots__ = [
@@ -65836,11 +66519,14 @@ class LegalHoldsChangeHoldDetailsDetails(bb.Struct):
     """
     Edited details for a hold.
 
-    :ivar team_log.LegalHoldsChangeHoldDetailsDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsChangeHoldDetailsDetails.name: Hold name.
-    :ivar team_log.LegalHoldsChangeHoldDetailsDetails.previous_value: Previous
-        details.
-    :ivar team_log.LegalHoldsChangeHoldDetailsDetails.new_value: New details.
+    :ivar LegalHoldsChangeHoldDetailsDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsChangeHoldDetailsDetails.name:
+        Hold name.
+    :ivar LegalHoldsChangeHoldDetailsDetails.previous_value:
+        Previous details.
+    :ivar LegalHoldsChangeHoldDetailsDetails.new_value:
+        New details.
     """
 
     __slots__ = [
@@ -65913,10 +66599,12 @@ class LegalHoldsChangeHoldNameDetails(bb.Struct):
     """
     Renamed a hold.
 
-    :ivar team_log.LegalHoldsChangeHoldNameDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsChangeHoldNameDetails.previous_value: Previous
-        Name.
-    :ivar team_log.LegalHoldsChangeHoldNameDetails.new_value: New Name.
+    :ivar LegalHoldsChangeHoldNameDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsChangeHoldNameDetails.previous_value:
+        Previous Name.
+    :ivar LegalHoldsChangeHoldNameDetails.new_value:
+        New Name.
     """
 
     __slots__ = [
@@ -65981,9 +66669,12 @@ class LegalHoldsExportAHoldDetails(bb.Struct):
     """
     Exported hold.
 
-    :ivar team_log.LegalHoldsExportAHoldDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsExportAHoldDetails.name: Hold name.
-    :ivar team_log.LegalHoldsExportAHoldDetails.export_name: Export name.
+    :ivar LegalHoldsExportAHoldDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsExportAHoldDetails.name:
+        Hold name.
+    :ivar LegalHoldsExportAHoldDetails.export_name:
+        Export name.
     """
 
     __slots__ = [
@@ -66048,9 +66739,12 @@ class LegalHoldsExportCancelledDetails(bb.Struct):
     """
     Canceled export for a hold.
 
-    :ivar team_log.LegalHoldsExportCancelledDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsExportCancelledDetails.name: Hold name.
-    :ivar team_log.LegalHoldsExportCancelledDetails.export_name: Export name.
+    :ivar LegalHoldsExportCancelledDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsExportCancelledDetails.name:
+        Hold name.
+    :ivar LegalHoldsExportCancelledDetails.export_name:
+        Export name.
     """
 
     __slots__ = [
@@ -66115,11 +66809,16 @@ class LegalHoldsExportDownloadedDetails(bb.Struct):
     """
     Downloaded export for a hold.
 
-    :ivar team_log.LegalHoldsExportDownloadedDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsExportDownloadedDetails.name: Hold name.
-    :ivar team_log.LegalHoldsExportDownloadedDetails.export_name: Export name.
-    :ivar team_log.LegalHoldsExportDownloadedDetails.part: Part.
-    :ivar team_log.LegalHoldsExportDownloadedDetails.file_name: Filename.
+    :ivar LegalHoldsExportDownloadedDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsExportDownloadedDetails.name:
+        Hold name.
+    :ivar LegalHoldsExportDownloadedDetails.export_name:
+        Export name.
+    :ivar LegalHoldsExportDownloadedDetails.part:
+        Part.
+    :ivar LegalHoldsExportDownloadedDetails.file_name:
+        Filename.
     """
 
     __slots__ = [
@@ -66200,9 +66899,12 @@ class LegalHoldsExportRemovedDetails(bb.Struct):
     """
     Removed export for a hold.
 
-    :ivar team_log.LegalHoldsExportRemovedDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsExportRemovedDetails.name: Hold name.
-    :ivar team_log.LegalHoldsExportRemovedDetails.export_name: Export name.
+    :ivar LegalHoldsExportRemovedDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsExportRemovedDetails.name:
+        Hold name.
+    :ivar LegalHoldsExportRemovedDetails.export_name:
+        Export name.
     """
 
     __slots__ = [
@@ -66267,8 +66969,10 @@ class LegalHoldsReleaseAHoldDetails(bb.Struct):
     """
     Released a hold.
 
-    :ivar team_log.LegalHoldsReleaseAHoldDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsReleaseAHoldDetails.name: Hold name.
+    :ivar LegalHoldsReleaseAHoldDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsReleaseAHoldDetails.name:
+        Hold name.
     """
 
     __slots__ = [
@@ -66325,8 +67029,10 @@ class LegalHoldsRemoveMembersDetails(bb.Struct):
     """
     Removed members from a hold.
 
-    :ivar team_log.LegalHoldsRemoveMembersDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsRemoveMembersDetails.name: Hold name.
+    :ivar LegalHoldsRemoveMembersDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsRemoveMembersDetails.name:
+        Hold name.
     """
 
     __slots__ = [
@@ -66383,8 +67089,10 @@ class LegalHoldsReportAHoldDetails(bb.Struct):
     """
     Created a summary report for a hold.
 
-    :ivar team_log.LegalHoldsReportAHoldDetails.legal_hold_id: Hold ID.
-    :ivar team_log.LegalHoldsReportAHoldDetails.name: Hold name.
+    :ivar LegalHoldsReportAHoldDetails.legal_hold_id:
+        Hold ID.
+    :ivar LegalHoldsReportAHoldDetails.name:
+        Hold name.
     """
 
     __slots__ = [
@@ -66441,12 +67149,18 @@ class LinkSettingsLogInfo(bb.Struct):
     """
     Link Settings
 
-    :ivar team_log.LinkSettingsLogInfo.name: Link Name.
-    :ivar team_log.LinkSettingsLogInfo.require_email: Email Required.
-    :ivar team_log.LinkSettingsLogInfo.downloadable: Downloadable.
-    :ivar team_log.LinkSettingsLogInfo.expire_at: Expires at.
-    :ivar team_log.LinkSettingsLogInfo.password_required: Password required.
-    :ivar team_log.LinkSettingsLogInfo.url: Link URL.
+    :ivar LinkSettingsLogInfo.name:
+        Link Name.
+    :ivar LinkSettingsLogInfo.require_email:
+        Email Required.
+    :ivar LinkSettingsLogInfo.downloadable:
+        Downloadable.
+    :ivar LinkSettingsLogInfo.expire_at:
+        Expires at.
+    :ivar LinkSettingsLogInfo.password_required:
+        Password required.
+    :ivar LinkSettingsLogInfo.url:
+        Link URL.
     """
 
     __slots__ = [
@@ -66517,15 +67231,18 @@ class LinkedDeviceLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar DesktopDeviceSessionLogInfo
-        LinkedDeviceLogInfo.desktop_device_session: desktop device session's
-        details.
-    :ivar LegacyDeviceSessionLogInfo LinkedDeviceLogInfo.legacy_device_session:
+    :ivar LinkedDeviceLogInfo.desktop_device_session:
+        desktop device session's details.
+    :vartype LinkedDeviceLogInfo.desktop_device_session: DesktopDeviceSessionLogInfo
+    :ivar LinkedDeviceLogInfo.legacy_device_session:
         legacy device session's details.
-    :ivar MobileDeviceSessionLogInfo LinkedDeviceLogInfo.mobile_device_session:
+    :vartype LinkedDeviceLogInfo.legacy_device_session: LegacyDeviceSessionLogInfo
+    :ivar LinkedDeviceLogInfo.mobile_device_session:
         mobile device session's details.
-    :ivar WebDeviceSessionLogInfo LinkedDeviceLogInfo.web_device_session: web
-        device session's details.
+    :vartype LinkedDeviceLogInfo.mobile_device_session: MobileDeviceSessionLogInfo
+    :ivar LinkedDeviceLogInfo.web_device_session:
+        web device session's details.
+    :vartype LinkedDeviceLogInfo.web_device_session: WebDeviceSessionLogInfo
     """
 
     _catch_all = 'other'
@@ -66719,10 +67436,13 @@ class LoginFailDetails(bb.Struct):
     """
     Failed to sign in.
 
-    :ivar team_log.LoginFailDetails.is_emm_managed: Tells if the login device is
-        EMM managed. Might be missing due to historical data gap.
-    :ivar team_log.LoginFailDetails.login_method: Login method.
-    :ivar team_log.LoginFailDetails.error_details: Error details.
+    :ivar LoginFailDetails.is_emm_managed:
+        Tells if the login device is EMM managed. Might be missing due to
+        historical data gap.
+    :ivar LoginFailDetails.login_method:
+        Login method.
+    :ivar LoginFailDetails.error_details:
+        Error details.
     """
 
     __slots__ = [
@@ -66931,9 +67651,11 @@ class LoginSuccessDetails(bb.Struct):
     """
     Signed in.
 
-    :ivar team_log.LoginSuccessDetails.is_emm_managed: Tells if the login device
-        is EMM managed. Might be missing due to historical data gap.
-    :ivar team_log.LoginSuccessDetails.login_method: Login method.
+    :ivar LoginSuccessDetails.is_emm_managed:
+        Tells if the login device is EMM managed. Might be missing due to
+        historical data gap.
+    :ivar LoginSuccessDetails.login_method:
+        Login method.
     """
 
     __slots__ = [
@@ -66990,7 +67712,8 @@ class LogoutDetails(bb.Struct):
     """
     Signed out.
 
-    :ivar team_log.LogoutDetails.login_id: Login session id.
+    :ivar LogoutDetails.login_id:
+        Login session id.
     """
 
     __slots__ = [
@@ -67039,12 +67762,13 @@ class MalwareExclusionState(bb.Struct):
     """
     Malware exclusion list state
 
-    :ivar team_log.MalwareExclusionState.excluded_file_hashes_count: The number
-        of files that are excluded from the monitoring for malware alerts.
-    :ivar team_log.MalwareExclusionState.file_path_from_last_exclusion: The file
-        path of the last exclusion operation.
-    :ivar team_log.MalwareExclusionState.file_path_from_last_inclusion: The file
-        path of the last inclusion operation.
+    :ivar MalwareExclusionState.excluded_file_hashes_count:
+        The number of files that are excluded from the monitoring for malware
+        alerts.
+    :ivar MalwareExclusionState.file_path_from_last_exclusion:
+        The file path of the last exclusion operation.
+    :ivar MalwareExclusionState.file_path_from_last_inclusion:
+        The file path of the last inclusion operation.
     """
 
     __slots__ = [
@@ -67133,8 +67857,9 @@ class MediaHubAddingPeoplePolicyChangedDetails(bb.Struct):
     """
     Changed the policy for adding people to Media Hub content.
 
-    :ivar team_log.MediaHubAddingPeoplePolicyChangedDetails.new_value: To.
-    :ivar team_log.MediaHubAddingPeoplePolicyChangedDetails.previous_value:
+    :ivar MediaHubAddingPeoplePolicyChangedDetails.new_value:
+        To.
+    :ivar MediaHubAddingPeoplePolicyChangedDetails.previous_value:
         From.
     """
 
@@ -67238,8 +67963,10 @@ class MediaHubDownloadPolicyChangedDetails(bb.Struct):
     """
     Changed the policy for downloading Media Hub content.
 
-    :ivar team_log.MediaHubDownloadPolicyChangedDetails.new_value: To.
-    :ivar team_log.MediaHubDownloadPolicyChangedDetails.previous_value: From.
+    :ivar MediaHubDownloadPolicyChangedDetails.new_value:
+        To.
+    :ivar MediaHubDownloadPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -67392,8 +68119,10 @@ class MediaHubLinkSharingPolicyChangedDetails(bb.Struct):
     """
     Changed the policy for sharing Media Hub content.
 
-    :ivar team_log.MediaHubLinkSharingPolicyChangedDetails.new_value: To.
-    :ivar team_log.MediaHubLinkSharingPolicyChangedDetails.previous_value: From.
+    :ivar MediaHubLinkSharingPolicyChangedDetails.new_value:
+        To.
+    :ivar MediaHubLinkSharingPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -67586,10 +68315,10 @@ class MediaHubProjectTeamRoleChangedDetails(bb.Struct):
     """
     Changed member role in Media Hub project.
 
-    :ivar team_log.MediaHubProjectTeamRoleChangedDetails.previous_role: Previous
-        Media Hub project role.
-    :ivar team_log.MediaHubProjectTeamRoleChangedDetails.new_role: New Media Hub
-        project role.
+    :ivar MediaHubProjectTeamRoleChangedDetails.previous_role:
+        Previous Media Hub project role.
+    :ivar MediaHubProjectTeamRoleChangedDetails.new_role:
+        New Media Hub project role.
     """
 
     __slots__ = [
@@ -67702,12 +68431,12 @@ class MediaHubSharedLinkAudienceChangedDetails(bb.Struct):
     """
     Changed Media Hub shared link audience.
 
-    :ivar team_log.MediaHubSharedLinkAudienceChangedDetails.target_type: Media
-        Hub shared link target type.
-    :ivar team_log.MediaHubSharedLinkAudienceChangedDetails.previous_value:
+    :ivar MediaHubSharedLinkAudienceChangedDetails.target_type:
+        Media Hub shared link target type.
+    :ivar MediaHubSharedLinkAudienceChangedDetails.previous_value:
         Previous Media Hub shared link audience.
-    :ivar team_log.MediaHubSharedLinkAudienceChangedDetails.new_value: New Media
-        Hub shared link audience.
+    :ivar MediaHubSharedLinkAudienceChangedDetails.new_value:
+        New Media Hub shared link audience.
     """
 
     __slots__ = [
@@ -67772,10 +68501,10 @@ class MediaHubSharedLinkCreatedDetails(bb.Struct):
     """
     Created Media Hub shared link.
 
-    :ivar team_log.MediaHubSharedLinkCreatedDetails.target_type: Media Hub
-        shared link target type.
-    :ivar team_log.MediaHubSharedLinkCreatedDetails.audience: Media Hub shared
-        link audience.
+    :ivar MediaHubSharedLinkCreatedDetails.target_type:
+        Media Hub shared link target type.
+    :ivar MediaHubSharedLinkCreatedDetails.audience:
+        Media Hub shared link audience.
     """
 
     __slots__ = [
@@ -67878,12 +68607,11 @@ class MediaHubSharedLinkDownloadSettingChangedDetails(bb.Struct):
     """
     Changed Media Hub shared link download setting.
 
-    :ivar team_log.MediaHubSharedLinkDownloadSettingChangedDetails.target_type:
+    :ivar MediaHubSharedLinkDownloadSettingChangedDetails.target_type:
         Media Hub shared link target type.
-    :ivar
-        team_log.MediaHubSharedLinkDownloadSettingChangedDetails.previous_value:
+    :ivar MediaHubSharedLinkDownloadSettingChangedDetails.previous_value:
         Previous Media Hub shared link download setting.
-    :ivar team_log.MediaHubSharedLinkDownloadSettingChangedDetails.new_value:
+    :ivar MediaHubSharedLinkDownloadSettingChangedDetails.new_value:
         New Media Hub shared link download setting.
     """
 
@@ -67949,8 +68677,8 @@ class MediaHubSharedLinkRevokedDetails(bb.Struct):
     """
     Revoked Media Hub shared link.
 
-    :ivar team_log.MediaHubSharedLinkRevokedDetails.target_type: Media Hub
-        shared link target type.
+    :ivar MediaHubSharedLinkRevokedDetails.target_type:
+        Media Hub shared link target type.
     """
 
     __slots__ = [
@@ -68063,7 +68791,7 @@ class MemberAccessDetailsCreateReportFailedDetails(bb.Struct):
     """
     Couldn't generate member access report.
 
-    :ivar team_log.MemberAccessDetailsCreateReportFailedDetails.failure_reason:
+    :ivar MemberAccessDetailsCreateReportFailedDetails.failure_reason:
         Failure reason.
     """
 
@@ -68135,7 +68863,8 @@ class MemberAddExternalIdDetails(bb.Struct):
     """
     Added an external ID for team member.
 
-    :ivar team_log.MemberAddExternalIdDetails.new_value: Current external id.
+    :ivar MemberAddExternalIdDetails.new_value:
+        Current external id.
     """
 
     __slots__ = [
@@ -68184,7 +68913,8 @@ class MemberAddNameDetails(bb.Struct):
     """
     Added team member name.
 
-    :ivar team_log.MemberAddNameDetails.new_value: New user's name.
+    :ivar MemberAddNameDetails.new_value:
+        New user's name.
     """
 
     __slots__ = [
@@ -68233,12 +68963,12 @@ class MemberChangeAdminRoleDetails(bb.Struct):
     """
     Changed team member admin role.
 
-    :ivar team_log.MemberChangeAdminRoleDetails.new_value: New admin role. This
-        field is relevant when the admin role is changed or whenthe user role
-        changes from no admin rights to with admin rights.
-    :ivar team_log.MemberChangeAdminRoleDetails.previous_value: Previous admin
-        role. This field is relevant when the admin role is changed or when the
-        admin role is removed.
+    :ivar MemberChangeAdminRoleDetails.new_value:
+        New admin role. This field is relevant when the admin role is changed or
+        whenthe user role changes from no admin rights to with admin rights.
+    :ivar MemberChangeAdminRoleDetails.previous_value:
+        Previous admin role. This field is relevant when the admin role is
+        changed or when the admin role is removed.
     """
 
     __slots__ = [
@@ -68295,9 +69025,10 @@ class MemberChangeEmailDetails(bb.Struct):
     """
     Changed team member email.
 
-    :ivar team_log.MemberChangeEmailDetails.new_value: New email.
-    :ivar team_log.MemberChangeEmailDetails.previous_value: Previous email.
-        Might be missing due to historical data gap.
+    :ivar MemberChangeEmailDetails.new_value:
+        New email.
+    :ivar MemberChangeEmailDetails.previous_value:
+        Previous email. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -68354,9 +69085,10 @@ class MemberChangeExternalIdDetails(bb.Struct):
     """
     Changed the external ID for team member.
 
-    :ivar team_log.MemberChangeExternalIdDetails.new_value: Current external id.
-    :ivar team_log.MemberChangeExternalIdDetails.previous_value: Old external
-        id.
+    :ivar MemberChangeExternalIdDetails.new_value:
+        Current external id.
+    :ivar MemberChangeExternalIdDetails.previous_value:
+        Old external id.
     """
 
     __slots__ = [
@@ -68413,10 +69145,10 @@ class MemberChangeMembershipTypeDetails(bb.Struct):
     """
     Changed membership type (limited/full) of member.
 
-    :ivar team_log.MemberChangeMembershipTypeDetails.prev_value: Previous
-        membership type.
-    :ivar team_log.MemberChangeMembershipTypeDetails.new_value: New membership
-        type.
+    :ivar MemberChangeMembershipTypeDetails.prev_value:
+        Previous membership type.
+    :ivar MemberChangeMembershipTypeDetails.new_value:
+        New membership type.
     """
 
     __slots__ = [
@@ -68473,9 +69205,10 @@ class MemberChangeNameDetails(bb.Struct):
     """
     Changed team member name.
 
-    :ivar team_log.MemberChangeNameDetails.new_value: New user's name.
-    :ivar team_log.MemberChangeNameDetails.previous_value: Previous user's name.
-        Might be missing due to historical data gap.
+    :ivar MemberChangeNameDetails.new_value:
+        New user's name.
+    :ivar MemberChangeNameDetails.previous_value:
+        Previous user's name. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -68532,11 +69265,12 @@ class MemberChangeResellerRoleDetails(bb.Struct):
     """
     Changed team member reseller role.
 
-    :ivar team_log.MemberChangeResellerRoleDetails.new_value: New reseller role.
-        This field is relevant when the reseller role is changed.
-    :ivar team_log.MemberChangeResellerRoleDetails.previous_value: Previous
-        reseller role. This field is relevant when the reseller role is changed
-        or when the reseller role is removed.
+    :ivar MemberChangeResellerRoleDetails.new_value:
+        New reseller role. This field is relevant when the reseller role is
+        changed.
+    :ivar MemberChangeResellerRoleDetails.previous_value:
+        Previous reseller role. This field is relevant when the reseller role is
+        changed or when the reseller role is removed.
     """
 
     __slots__ = [
@@ -68593,16 +69327,19 @@ class MemberChangeStatusDetails(bb.Struct):
     """
     Changed member status (invited, joined, suspended, etc.).
 
-    :ivar team_log.MemberChangeStatusDetails.previous_value: Previous member
-        status. Might be missing due to historical data gap.
-    :ivar team_log.MemberChangeStatusDetails.new_value: New member status.
-    :ivar team_log.MemberChangeStatusDetails.action: Additional information
-        indicating the action taken that caused status change.
-    :ivar team_log.MemberChangeStatusDetails.new_team: The user's new team name.
-        This field is relevant when the user is transferred off the team.
-    :ivar team_log.MemberChangeStatusDetails.previous_team: The user's previous
-        team name. This field is relevant when the user is transferred onto the
-        team.
+    :ivar MemberChangeStatusDetails.previous_value:
+        Previous member status. Might be missing due to historical data gap.
+    :ivar MemberChangeStatusDetails.new_value:
+        New member status.
+    :ivar MemberChangeStatusDetails.action:
+        Additional information indicating the action taken that caused status
+        change.
+    :ivar MemberChangeStatusDetails.new_team:
+        The user's new team name. This field is relevant when the user is
+        transferred off the team.
+    :ivar MemberChangeStatusDetails.previous_team:
+        The user's previous team name. This field is relevant when the user is
+        transferred onto the team.
     """
 
     __slots__ = [
@@ -68867,8 +69604,8 @@ class MemberRemoveExternalIdDetails(bb.Struct):
     """
     Removed the external ID for team member.
 
-    :ivar team_log.MemberRemoveExternalIdDetails.previous_value: Old external
-        id.
+    :ivar MemberRemoveExternalIdDetails.previous_value:
+        Old external id.
     """
 
     __slots__ = [
@@ -68917,11 +69654,11 @@ class MemberRequestsChangePolicyDetails(bb.Struct):
     """
     Changed whether users can find team when not invited.
 
-    :ivar team_log.MemberRequestsChangePolicyDetails.new_value: New member
-        change requests policy.
-    :ivar team_log.MemberRequestsChangePolicyDetails.previous_value: Previous
-        member change requests policy. Might be missing due to historical data
-        gap.
+    :ivar MemberRequestsChangePolicyDetails.new_value:
+        New member change requests policy.
+    :ivar MemberRequestsChangePolicyDetails.previous_value:
+        Previous member change requests policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -69088,10 +69825,10 @@ class MemberSendInvitePolicyChangedDetails(bb.Struct):
     """
     Changed member send invite policy for team.
 
-    :ivar team_log.MemberSendInvitePolicyChangedDetails.new_value: New team
-        member send invite policy.
-    :ivar team_log.MemberSendInvitePolicyChangedDetails.previous_value: Previous
-        team member send invite policy.
+    :ivar MemberSendInvitePolicyChangedDetails.new_value:
+        New team member send invite policy.
+    :ivar MemberSendInvitePolicyChangedDetails.previous_value:
+        Previous team member send invite policy.
     """
 
     __slots__ = [
@@ -69188,8 +69925,8 @@ class MemberSpaceLimitsAddCustomQuotaDetails(bb.Struct):
     """
     Set custom member space limit.
 
-    :ivar team_log.MemberSpaceLimitsAddCustomQuotaDetails.new_value: New custom
-        quota value in bytes.
+    :ivar MemberSpaceLimitsAddCustomQuotaDetails.new_value:
+        New custom quota value in bytes.
     """
 
     __slots__ = [
@@ -69278,10 +70015,10 @@ class MemberSpaceLimitsChangeCapsTypePolicyDetails(bb.Struct):
     """
     Changed member space limit type for team.
 
-    :ivar team_log.MemberSpaceLimitsChangeCapsTypePolicyDetails.previous_value:
+    :ivar MemberSpaceLimitsChangeCapsTypePolicyDetails.previous_value:
         Previous space limit type.
-    :ivar team_log.MemberSpaceLimitsChangeCapsTypePolicyDetails.new_value: New
-        space limit type.
+    :ivar MemberSpaceLimitsChangeCapsTypePolicyDetails.new_value:
+        New space limit type.
     """
 
     __slots__ = [
@@ -69338,10 +70075,10 @@ class MemberSpaceLimitsChangeCustomQuotaDetails(bb.Struct):
     """
     Changed custom member space limit.
 
-    :ivar team_log.MemberSpaceLimitsChangeCustomQuotaDetails.previous_value:
+    :ivar MemberSpaceLimitsChangeCustomQuotaDetails.previous_value:
         Previous custom quota value in bytes.
-    :ivar team_log.MemberSpaceLimitsChangeCustomQuotaDetails.new_value: New
-        custom quota value in bytes.
+    :ivar MemberSpaceLimitsChangeCustomQuotaDetails.new_value:
+        New custom quota value in bytes.
     """
 
     __slots__ = [
@@ -69398,12 +70135,12 @@ class MemberSpaceLimitsChangePolicyDetails(bb.Struct):
     """
     Changed team default member space limit.
 
-    :ivar team_log.MemberSpaceLimitsChangePolicyDetails.previous_value: Previous
-        team default limit value in bytes. Might be missing due to historical
-        data gap.
-    :ivar team_log.MemberSpaceLimitsChangePolicyDetails.new_value: New team
-        default limit value in bytes. Might be missing due to historical data
-        gap.
+    :ivar MemberSpaceLimitsChangePolicyDetails.previous_value:
+        Previous team default limit value in bytes. Might be missing due to
+        historical data gap.
+    :ivar MemberSpaceLimitsChangePolicyDetails.new_value:
+        New team default limit value in bytes. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -69460,10 +70197,10 @@ class MemberSpaceLimitsChangeStatusDetails(bb.Struct):
     """
     Changed space limit status.
 
-    :ivar team_log.MemberSpaceLimitsChangeStatusDetails.previous_value: Previous
-        storage quota status.
-    :ivar team_log.MemberSpaceLimitsChangeStatusDetails.new_value: New storage
-        quota status.
+    :ivar MemberSpaceLimitsChangeStatusDetails.previous_value:
+        Previous storage quota status.
+    :ivar MemberSpaceLimitsChangeStatusDetails.new_value:
+        New storage quota status.
     """
 
     __slots__ = [
@@ -69684,8 +70421,8 @@ class MemberSuggestDetails(bb.Struct):
     """
     Suggested person to add to team.
 
-    :ivar team_log.MemberSuggestDetails.suggested_members: suggested users
-        emails.
+    :ivar MemberSuggestDetails.suggested_members:
+        suggested users emails.
     """
 
     __slots__ = [
@@ -69734,11 +70471,11 @@ class MemberSuggestionsChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled option for team members to suggest people to add to team.
 
-    :ivar team_log.MemberSuggestionsChangePolicyDetails.new_value: New team
-        member suggestions policy.
-    :ivar team_log.MemberSuggestionsChangePolicyDetails.previous_value: Previous
-        team member suggestions policy. Might be missing due to historical data
-        gap.
+    :ivar MemberSuggestionsChangePolicyDetails.new_value:
+        New team member suggestions policy.
+    :ivar MemberSuggestionsChangePolicyDetails.previous_value:
+        Previous team member suggestions policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -69881,10 +70618,10 @@ class MemberTransferredInternalFields(bb.Struct):
     """
     Internal only - fields for target team computations
 
-    :ivar team_log.MemberTransferredInternalFields.source_team_id: Internal only
-        - team user was moved from.
-    :ivar team_log.MemberTransferredInternalFields.target_team_id: Internal only
-        - team user was moved to.
+    :ivar MemberTransferredInternalFields.source_team_id:
+        Internal only - team user was moved from.
+    :ivar MemberTransferredInternalFields.target_team_id:
+        Internal only - team user was moved to.
     """
 
     __slots__ = [
@@ -69919,10 +70656,11 @@ class MicrosoftLoginChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled Microsoft login for team.
 
-    :ivar team_log.MicrosoftLoginChangePolicyDetails.new_value: New Microsoft
-        login policy.
-    :ivar team_log.MicrosoftLoginChangePolicyDetails.previous_value: Previous
-        Microsoft login policy. Might be missing due to historical data gap.
+    :ivar MicrosoftLoginChangePolicyDetails.new_value:
+        New Microsoft login policy.
+    :ivar MicrosoftLoginChangePolicyDetails.previous_value:
+        Previous Microsoft login policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -70035,9 +70773,9 @@ class MicrosoftOfficeAddinChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled Microsoft Office add-in.
 
-    :ivar team_log.MicrosoftOfficeAddinChangePolicyDetails.new_value: New
-        Microsoft Office addin policy.
-    :ivar team_log.MicrosoftOfficeAddinChangePolicyDetails.previous_value:
+    :ivar MicrosoftOfficeAddinChangePolicyDetails.new_value:
+        New Microsoft Office addin policy.
+    :ivar MicrosoftOfficeAddinChangePolicyDetails.previous_value:
         Previous Microsoft Office addin policy. Might be missing due to
         historical data gap.
     """
@@ -70143,8 +70881,9 @@ class MissingDetails(bb.Struct):
     An indication that an error occurred while retrieving the event. Some
     attributes of the event may be omitted as a result.
 
-    :ivar team_log.MissingDetails.source_event_fields: All the data that could
-        be retrieved and converted from the source event.
+    :ivar MissingDetails.source_event_fields:
+        All the data that could be retrieved and converted from the source
+        event.
     """
 
     __slots__ = [
@@ -70171,17 +70910,18 @@ class MobileDeviceSessionLogInfo(DeviceSessionLogInfo):
     """
     Information about linked Dropbox mobile client sessions
 
-    :ivar team_log.MobileDeviceSessionLogInfo.session_info: Mobile session
-        unique id.
-    :ivar team_log.MobileDeviceSessionLogInfo.device_name: The device name.
-    :ivar team_log.MobileDeviceSessionLogInfo.client_type: The mobile
-        application type.
-    :ivar team_log.MobileDeviceSessionLogInfo.client_version: The Dropbox client
-        version.
-    :ivar team_log.MobileDeviceSessionLogInfo.os_version: The hosting OS
-        version.
-    :ivar team_log.MobileDeviceSessionLogInfo.last_carrier: last carrier used by
-        the device.
+    :ivar MobileDeviceSessionLogInfo.session_info:
+        Mobile session unique id.
+    :ivar MobileDeviceSessionLogInfo.device_name:
+        The device name.
+    :ivar MobileDeviceSessionLogInfo.client_type:
+        The mobile application type.
+    :ivar MobileDeviceSessionLogInfo.client_version:
+        The Dropbox client version.
+    :ivar MobileDeviceSessionLogInfo.os_version:
+        The hosting OS version.
+    :ivar MobileDeviceSessionLogInfo.last_carrier:
+        last carrier used by the device.
     """
 
     __slots__ = [
@@ -70329,9 +71069,9 @@ class MultiTeamIdentityPolicyChangedDetails(bb.Struct):
     """
     Changed multi-team identity policy for team.
 
-    :ivar team_log.MultiTeamIdentityPolicyChangedDetails.new_value: New
-        multi-team identity policy.
-    :ivar team_log.MultiTeamIdentityPolicyChangedDetails.previous_value:
+    :ivar MultiTeamIdentityPolicyChangedDetails.new_value:
+        New multi-team identity policy.
+    :ivar MultiTeamIdentityPolicyChangedDetails.previous_value:
         Previous multi-team identity policy. Might be missing due to historical
         data gap.
     """
@@ -70390,11 +71130,12 @@ class NamespaceRelativePathLogInfo(bb.Struct):
     """
     Namespace relative path details.
 
-    :ivar team_log.NamespaceRelativePathLogInfo.ns_id: Namespace ID.
-    :ivar team_log.NamespaceRelativePathLogInfo.relative_path: A path relative
-        to the specified namespace ID.
-    :ivar team_log.NamespaceRelativePathLogInfo.is_shared_namespace: True if the
-        namespace is shared.
+    :ivar NamespaceRelativePathLogInfo.ns_id:
+        Namespace ID.
+    :ivar NamespaceRelativePathLogInfo.relative_path:
+        A path relative to the specified namespace ID.
+    :ivar NamespaceRelativePathLogInfo.is_shared_namespace:
+        True if the namespace is shared.
     """
 
     __slots__ = [
@@ -70437,10 +71178,11 @@ class NetworkControlChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled network control.
 
-    :ivar team_log.NetworkControlChangePolicyDetails.new_value: New network
-        control policy.
-    :ivar team_log.NetworkControlChangePolicyDetails.previous_value: Previous
-        network control policy. Might be missing due to historical data gap.
+    :ivar NetworkControlChangePolicyDetails.new_value:
+        New network control policy.
+    :ivar NetworkControlChangePolicyDetails.previous_value:
+        Previous network control policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -70543,10 +71285,10 @@ class NoExpirationLinkGenCreateReportDetails(bb.Struct):
     """
     Report created: Links created with no expiration.
 
-    :ivar team_log.NoExpirationLinkGenCreateReportDetails.start_date: Report
-        start date.
-    :ivar team_log.NoExpirationLinkGenCreateReportDetails.end_date: Report end
-        date.
+    :ivar NoExpirationLinkGenCreateReportDetails.start_date:
+        Report start date.
+    :ivar NoExpirationLinkGenCreateReportDetails.end_date:
+        Report end date.
     """
 
     __slots__ = [
@@ -70603,7 +71345,7 @@ class NoExpirationLinkGenReportFailedDetails(bb.Struct):
     """
     Couldn't create report: Links created with no expiration.
 
-    :ivar team_log.NoExpirationLinkGenReportFailedDetails.failure_reason:
+    :ivar NoExpirationLinkGenReportFailedDetails.failure_reason:
         Failure reason.
     """
 
@@ -70653,10 +71395,10 @@ class NoPasswordLinkGenCreateReportDetails(bb.Struct):
     """
     Report created: Links created without passwords.
 
-    :ivar team_log.NoPasswordLinkGenCreateReportDetails.start_date: Report start
-        date.
-    :ivar team_log.NoPasswordLinkGenCreateReportDetails.end_date: Report end
-        date.
+    :ivar NoPasswordLinkGenCreateReportDetails.start_date:
+        Report start date.
+    :ivar NoPasswordLinkGenCreateReportDetails.end_date:
+        Report end date.
     """
 
     __slots__ = [
@@ -70713,8 +71455,8 @@ class NoPasswordLinkGenReportFailedDetails(bb.Struct):
     """
     Couldn't create report: Links created without passwords.
 
-    :ivar team_log.NoPasswordLinkGenReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar NoPasswordLinkGenReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -70763,10 +71505,10 @@ class NoPasswordLinkViewCreateReportDetails(bb.Struct):
     """
     Report created: Views of links without passwords.
 
-    :ivar team_log.NoPasswordLinkViewCreateReportDetails.start_date: Report
-        start date.
-    :ivar team_log.NoPasswordLinkViewCreateReportDetails.end_date: Report end
-        date.
+    :ivar NoPasswordLinkViewCreateReportDetails.start_date:
+        Report start date.
+    :ivar NoPasswordLinkViewCreateReportDetails.end_date:
+        Report end date.
     """
 
     __slots__ = [
@@ -70823,8 +71565,8 @@ class NoPasswordLinkViewReportFailedDetails(bb.Struct):
     """
     Couldn't create report: Views of links without passwords.
 
-    :ivar team_log.NoPasswordLinkViewReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar NoPasswordLinkViewReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -70873,9 +71615,12 @@ class UserLogInfo(bb.Struct):
     """
     User's logged information.
 
-    :ivar team_log.UserLogInfo.account_id: User unique ID.
-    :ivar team_log.UserLogInfo.display_name: User display name.
-    :ivar team_log.UserLogInfo.email: User email address.
+    :ivar UserLogInfo.account_id:
+        User unique ID.
+    :ivar UserLogInfo.display_name:
+        User display name.
+    :ivar UserLogInfo.email:
+        User email address.
     """
 
     __slots__ = [
@@ -70941,8 +71686,8 @@ class NonTrustedTeamDetails(bb.Struct):
     """
     The email to which the request was sent
 
-    :ivar team_log.NonTrustedTeamDetails.team: The email to which the request
-        was sent.
+    :ivar NonTrustedTeamDetails.team:
+        The email to which the request was sent.
     """
 
     __slots__ = [
@@ -71169,8 +71914,8 @@ class ObjectLabelAddedDetails(bb.Struct):
     """
     Added a label.
 
-    :ivar team_log.ObjectLabelAddedDetails.label_type: Labels mark a file or
-        folder.
+    :ivar ObjectLabelAddedDetails.label_type:
+        Labels mark a file or folder.
     """
 
     __slots__ = [
@@ -71219,8 +71964,8 @@ class ObjectLabelRemovedDetails(bb.Struct):
     """
     Removed a label.
 
-    :ivar team_log.ObjectLabelRemovedDetails.label_type: Labels mark a file or
-        folder.
+    :ivar ObjectLabelRemovedDetails.label_type:
+        Labels mark a file or folder.
     """
 
     __slots__ = [
@@ -71269,8 +72014,8 @@ class ObjectLabelUpdatedValueDetails(bb.Struct):
     """
     Updated a label's value.
 
-    :ivar team_log.ObjectLabelUpdatedValueDetails.label_type: Labels mark a file
-        or folder.
+    :ivar ObjectLabelUpdatedValueDetails.label_type:
+        Labels mark a file or folder.
     """
 
     __slots__ = [
@@ -71359,8 +72104,8 @@ class OrganizationDetails(bb.Struct):
     """
     More details about the organization.
 
-    :ivar team_log.OrganizationDetails.organization: The name of the
-        organization.
+    :ivar OrganizationDetails.organization:
+        The name of the organization.
     """
 
     __slots__ = [
@@ -71387,7 +72132,8 @@ class OrganizationName(bb.Struct):
     """
     The name of the organization
 
-    :ivar team_log.OrganizationName.organization: The name of the organization.
+    :ivar OrganizationName.organization:
+        The name of the organization.
     """
 
     __slots__ = [
@@ -71454,9 +72200,10 @@ class OriginLogInfo(bb.Struct):
     """
     The origin from which the actor performed the action.
 
-    :ivar team_log.OriginLogInfo.geo_location: Geographic location details.
-    :ivar team_log.OriginLogInfo.access_method: The method that was used to
-        perform the action.
+    :ivar OriginLogInfo.geo_location:
+        Geographic location details.
+    :ivar OriginLogInfo.access_method:
+        The method that was used to perform the action.
     """
 
     __slots__ = [
@@ -71491,10 +72238,10 @@ class OutdatedLinkViewCreateReportDetails(bb.Struct):
     """
     Report created: Views of old links.
 
-    :ivar team_log.OutdatedLinkViewCreateReportDetails.start_date: Report start
-        date.
-    :ivar team_log.OutdatedLinkViewCreateReportDetails.end_date: Report end
-        date.
+    :ivar OutdatedLinkViewCreateReportDetails.start_date:
+        Report start date.
+    :ivar OutdatedLinkViewCreateReportDetails.end_date:
+        Report end date.
     """
 
     __slots__ = [
@@ -71551,8 +72298,8 @@ class OutdatedLinkViewReportFailedDetails(bb.Struct):
     """
     Couldn't create report: Views of old links.
 
-    :ivar team_log.OutdatedLinkViewReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar OutdatedLinkViewReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -71696,11 +72443,11 @@ class PaperChangeDeploymentPolicyDetails(bb.Struct):
     Changed whether Dropbox Paper, when enabled, is deployed to all members or
     to specific members.
 
-    :ivar team_log.PaperChangeDeploymentPolicyDetails.new_value: New Dropbox
-        Paper deployment policy.
-    :ivar team_log.PaperChangeDeploymentPolicyDetails.previous_value: Previous
-        Dropbox Paper deployment policy. Might be missing due to historical data
-        gap.
+    :ivar PaperChangeDeploymentPolicyDetails.new_value:
+        New Dropbox Paper deployment policy.
+    :ivar PaperChangeDeploymentPolicyDetails.previous_value:
+        Previous Dropbox Paper deployment policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -71757,8 +72504,8 @@ class PaperChangeMemberLinkPolicyDetails(bb.Struct):
     """
     Changed whether non-members can view Paper docs with link.
 
-    :ivar team_log.PaperChangeMemberLinkPolicyDetails.new_value: New paper
-        external link accessibility policy.
+    :ivar PaperChangeMemberLinkPolicyDetails.new_value:
+        New paper external link accessibility policy.
     """
 
     __slots__ = [
@@ -71808,11 +72555,11 @@ class PaperChangeMemberPolicyDetails(bb.Struct):
     Changed whether members can share Paper docs outside team, and if docs are
     accessible only by team members or anyone by default.
 
-    :ivar team_log.PaperChangeMemberPolicyDetails.new_value: New paper external
-        accessibility policy.
-    :ivar team_log.PaperChangeMemberPolicyDetails.previous_value: Previous paper
-        external accessibility policy. Might be missing due to historical data
-        gap.
+    :ivar PaperChangeMemberPolicyDetails.new_value:
+        New paper external accessibility policy.
+    :ivar PaperChangeMemberPolicyDetails.previous_value:
+        Previous paper external accessibility policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -71869,9 +72616,11 @@ class PaperChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled Dropbox Paper for team.
 
-    :ivar team_log.PaperChangePolicyDetails.new_value: New Dropbox Paper policy.
-    :ivar team_log.PaperChangePolicyDetails.previous_value: Previous Dropbox
-        Paper policy. Might be missing due to historical data gap.
+    :ivar PaperChangePolicyDetails.new_value:
+        New Dropbox Paper policy.
+    :ivar PaperChangePolicyDetails.previous_value:
+        Previous Dropbox Paper policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -71928,8 +72677,8 @@ class PaperContentAddMemberDetails(bb.Struct):
     """
     Added users and/or groups to Paper doc/folder.
 
-    :ivar team_log.PaperContentAddMemberDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentAddMemberDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -71978,12 +72727,12 @@ class PaperContentAddToFolderDetails(bb.Struct):
     """
     Added Paper doc/folder to folder.
 
-    :ivar team_log.PaperContentAddToFolderDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperContentAddToFolderDetails.target_asset_index: Target
-        asset position in the Assets list.
-    :ivar team_log.PaperContentAddToFolderDetails.parent_asset_index: Parent
-        asset position in the Assets list.
+    :ivar PaperContentAddToFolderDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperContentAddToFolderDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar PaperContentAddToFolderDetails.parent_asset_index:
+        Parent asset position in the Assets list.
     """
 
     __slots__ = [
@@ -72048,8 +72797,8 @@ class PaperContentArchiveDetails(bb.Struct):
     """
     Archived Paper doc/folder.
 
-    :ivar team_log.PaperContentArchiveDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentArchiveDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72098,8 +72847,8 @@ class PaperContentCreateDetails(bb.Struct):
     """
     Created Paper doc/folder.
 
-    :ivar team_log.PaperContentCreateDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentCreateDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72148,8 +72897,8 @@ class PaperContentPermanentlyDeleteDetails(bb.Struct):
     """
     Permanently deleted Paper doc/folder.
 
-    :ivar team_log.PaperContentPermanentlyDeleteDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentPermanentlyDeleteDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72198,11 +72947,11 @@ class PaperContentRemoveFromFolderDetails(bb.Struct):
     """
     Removed Paper doc/folder from folder.
 
-    :ivar team_log.PaperContentRemoveFromFolderDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperContentRemoveFromFolderDetails.target_asset_index:
+    :ivar PaperContentRemoveFromFolderDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperContentRemoveFromFolderDetails.target_asset_index:
         Target asset position in the Assets list.
-    :ivar team_log.PaperContentRemoveFromFolderDetails.parent_asset_index:
+    :ivar PaperContentRemoveFromFolderDetails.parent_asset_index:
         Parent asset position in the Assets list.
     """
 
@@ -72268,8 +73017,8 @@ class PaperContentRemoveMemberDetails(bb.Struct):
     """
     Removed users and/or groups from Paper doc/folder.
 
-    :ivar team_log.PaperContentRemoveMemberDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentRemoveMemberDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72318,8 +73067,8 @@ class PaperContentRenameDetails(bb.Struct):
     """
     Renamed Paper doc/folder.
 
-    :ivar team_log.PaperContentRenameDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentRenameDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72368,8 +73117,8 @@ class PaperContentRestoreDetails(bb.Struct):
     """
     Restored archived Paper doc/folder.
 
-    :ivar team_log.PaperContentRestoreDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperContentRestoreDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72464,9 +73213,9 @@ class PaperDefaultFolderPolicyChangedDetails(bb.Struct):
     """
     Changed Paper Default Folder Policy setting for team.
 
-    :ivar team_log.PaperDefaultFolderPolicyChangedDetails.new_value: New Paper
-        Default Folder Policy.
-    :ivar team_log.PaperDefaultFolderPolicyChangedDetails.previous_value:
+    :ivar PaperDefaultFolderPolicyChangedDetails.new_value:
+        New Paper Default Folder Policy.
+    :ivar PaperDefaultFolderPolicyChangedDetails.previous_value:
         Previous Paper Default Folder Policy.
     """
 
@@ -72570,10 +73319,10 @@ class PaperDesktopPolicyChangedDetails(bb.Struct):
     """
     Enabled/disabled Paper Desktop for team.
 
-    :ivar team_log.PaperDesktopPolicyChangedDetails.new_value: New Paper Desktop
-        policy.
-    :ivar team_log.PaperDesktopPolicyChangedDetails.previous_value: Previous
-        Paper Desktop policy.
+    :ivar PaperDesktopPolicyChangedDetails.new_value:
+        New Paper Desktop policy.
+    :ivar PaperDesktopPolicyChangedDetails.previous_value:
+        Previous Paper Desktop policy.
     """
 
     __slots__ = [
@@ -72630,9 +73379,10 @@ class PaperDocAddCommentDetails(bb.Struct):
     """
     Added Paper doc comment.
 
-    :ivar team_log.PaperDocAddCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocAddCommentDetails.comment_text: Comment text.
+    :ivar PaperDocAddCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocAddCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -72689,10 +73439,10 @@ class PaperDocChangeMemberRoleDetails(bb.Struct):
     """
     Changed member permissions for Paper doc.
 
-    :ivar team_log.PaperDocChangeMemberRoleDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocChangeMemberRoleDetails.access_type: Paper doc access
-        type.
+    :ivar PaperDocChangeMemberRoleDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocChangeMemberRoleDetails.access_type:
+        Paper doc access type.
     """
 
     __slots__ = [
@@ -72749,11 +73499,11 @@ class PaperDocChangeSharingPolicyDetails(bb.Struct):
     """
     Changed sharing setting for Paper doc.
 
-    :ivar team_log.PaperDocChangeSharingPolicyDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocChangeSharingPolicyDetails.public_sharing_policy:
+    :ivar PaperDocChangeSharingPolicyDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocChangeSharingPolicyDetails.public_sharing_policy:
         Sharing policy with external users.
-    :ivar team_log.PaperDocChangeSharingPolicyDetails.team_sharing_policy:
+    :ivar PaperDocChangeSharingPolicyDetails.team_sharing_policy:
         Sharing policy with team.
     """
 
@@ -72819,12 +73569,11 @@ class PaperDocChangeSubscriptionDetails(bb.Struct):
     """
     Followed/unfollowed Paper doc.
 
-    :ivar team_log.PaperDocChangeSubscriptionDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocChangeSubscriptionDetails.new_subscription_level: New
-        doc subscription level.
-    :ivar
-        team_log.PaperDocChangeSubscriptionDetails.previous_subscription_level:
+    :ivar PaperDocChangeSubscriptionDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocChangeSubscriptionDetails.new_subscription_level:
+        New doc subscription level.
+    :ivar PaperDocChangeSubscriptionDetails.previous_subscription_level:
         Previous doc subscription level. Might be missing due to historical data
         gap.
     """
@@ -72891,9 +73640,10 @@ class PaperDocDeleteCommentDetails(bb.Struct):
     """
     Deleted Paper doc comment.
 
-    :ivar team_log.PaperDocDeleteCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocDeleteCommentDetails.comment_text: Comment text.
+    :ivar PaperDocDeleteCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocDeleteCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -72950,7 +73700,8 @@ class PaperDocDeletedDetails(bb.Struct):
     """
     Archived Paper doc.
 
-    :ivar team_log.PaperDocDeletedDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocDeletedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -72999,9 +73750,10 @@ class PaperDocDownloadDetails(bb.Struct):
     """
     Downloaded Paper doc in specific format.
 
-    :ivar team_log.PaperDocDownloadDetails.event_uuid: Event unique identifier.
-    :ivar team_log.PaperDocDownloadDetails.export_file_format: Export file
-        format.
+    :ivar PaperDocDownloadDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocDownloadDetails.export_file_format:
+        Export file format.
     """
 
     __slots__ = [
@@ -73058,9 +73810,10 @@ class PaperDocEditCommentDetails(bb.Struct):
     """
     Edited Paper doc comment.
 
-    :ivar team_log.PaperDocEditCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocEditCommentDetails.comment_text: Comment text.
+    :ivar PaperDocEditCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocEditCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -73117,7 +73870,8 @@ class PaperDocEditDetails(bb.Struct):
     """
     Edited Paper doc.
 
-    :ivar team_log.PaperDocEditDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocEditDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73166,7 +73920,8 @@ class PaperDocFollowedDetails(bb.Struct):
     """
     Followed Paper doc.
 
-    :ivar team_log.PaperDocFollowedDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocFollowedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73215,7 +73970,8 @@ class PaperDocMentionDetails(bb.Struct):
     """
     Mentioned user in Paper doc.
 
-    :ivar team_log.PaperDocMentionDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocMentionDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73264,11 +74020,12 @@ class PaperDocOwnershipChangedDetails(bb.Struct):
     """
     Transferred ownership of Paper doc.
 
-    :ivar team_log.PaperDocOwnershipChangedDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocOwnershipChangedDetails.old_owner_user_id: Previous
-        owner.
-    :ivar team_log.PaperDocOwnershipChangedDetails.new_owner_user_id: New owner.
+    :ivar PaperDocOwnershipChangedDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocOwnershipChangedDetails.old_owner_user_id:
+        Previous owner.
+    :ivar PaperDocOwnershipChangedDetails.new_owner_user_id:
+        New owner.
     """
 
     __slots__ = [
@@ -73333,8 +74090,8 @@ class PaperDocRequestAccessDetails(bb.Struct):
     """
     Requested access to Paper doc.
 
-    :ivar team_log.PaperDocRequestAccessDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperDocRequestAccessDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73383,9 +74140,10 @@ class PaperDocResolveCommentDetails(bb.Struct):
     """
     Resolved Paper doc comment.
 
-    :ivar team_log.PaperDocResolveCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocResolveCommentDetails.comment_text: Comment text.
+    :ivar PaperDocResolveCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocResolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -73442,7 +74200,8 @@ class PaperDocRevertDetails(bb.Struct):
     """
     Restored Paper doc to previous version.
 
-    :ivar team_log.PaperDocRevertDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocRevertDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73491,8 +74250,8 @@ class PaperDocSlackShareDetails(bb.Struct):
     """
     Shared Paper doc via Slack.
 
-    :ivar team_log.PaperDocSlackShareDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperDocSlackShareDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73541,8 +74300,8 @@ class PaperDocTeamInviteDetails(bb.Struct):
     """
     Shared Paper doc with users and/or groups.
 
-    :ivar team_log.PaperDocTeamInviteDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperDocTeamInviteDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73591,7 +74350,8 @@ class PaperDocTrashedDetails(bb.Struct):
     """
     Deleted Paper doc.
 
-    :ivar team_log.PaperDocTrashedDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocTrashedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73640,9 +74400,10 @@ class PaperDocUnresolveCommentDetails(bb.Struct):
     """
     Unresolved Paper doc comment.
 
-    :ivar team_log.PaperDocUnresolveCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperDocUnresolveCommentDetails.comment_text: Comment text.
+    :ivar PaperDocUnresolveCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperDocUnresolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -73699,7 +74460,8 @@ class PaperDocUntrashedDetails(bb.Struct):
     """
     Restored Paper doc.
 
-    :ivar team_log.PaperDocUntrashedDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocUntrashedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73748,7 +74510,8 @@ class PaperDocViewDetails(bb.Struct):
     """
     Viewed Paper doc.
 
-    :ivar team_log.PaperDocViewDetails.event_uuid: Event unique identifier.
+    :ivar PaperDocViewDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -73797,8 +74560,10 @@ class PaperDocumentLogInfo(bb.Struct):
     """
     Paper document's logged information.
 
-    :ivar team_log.PaperDocumentLogInfo.doc_id: Papers document Id.
-    :ivar team_log.PaperDocumentLogInfo.doc_title: Paper document title.
+    :ivar PaperDocumentLogInfo.doc_id:
+        Papers document Id.
+    :ivar PaperDocumentLogInfo.doc_title:
+        Paper document title.
     """
 
     __slots__ = [
@@ -73977,8 +74742,8 @@ class PaperExternalViewAllowDetails(bb.Struct):
     """
     Changed Paper external sharing setting to anyone.
 
-    :ivar team_log.PaperExternalViewAllowDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperExternalViewAllowDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74027,8 +74792,8 @@ class PaperExternalViewDefaultTeamDetails(bb.Struct):
     """
     Changed Paper external sharing setting to default team.
 
-    :ivar team_log.PaperExternalViewDefaultTeamDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperExternalViewDefaultTeamDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74077,8 +74842,8 @@ class PaperExternalViewForbidDetails(bb.Struct):
     """
     Changed Paper external sharing setting to team-only.
 
-    :ivar team_log.PaperExternalViewForbidDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperExternalViewForbidDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74127,12 +74892,11 @@ class PaperFolderChangeSubscriptionDetails(bb.Struct):
     """
     Followed/unfollowed Paper folder.
 
-    :ivar team_log.PaperFolderChangeSubscriptionDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.PaperFolderChangeSubscriptionDetails.new_subscription_level:
+    :ivar PaperFolderChangeSubscriptionDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperFolderChangeSubscriptionDetails.new_subscription_level:
         New folder subscription level.
-    :ivar
-        team_log.PaperFolderChangeSubscriptionDetails.previous_subscription_level:
+    :ivar PaperFolderChangeSubscriptionDetails.previous_subscription_level:
         Previous folder subscription level. Might be missing due to historical
         data gap.
     """
@@ -74199,8 +74963,8 @@ class PaperFolderDeletedDetails(bb.Struct):
     """
     Archived Paper folder.
 
-    :ivar team_log.PaperFolderDeletedDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperFolderDeletedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74249,8 +75013,8 @@ class PaperFolderFollowedDetails(bb.Struct):
     """
     Followed Paper folder.
 
-    :ivar team_log.PaperFolderFollowedDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperFolderFollowedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74299,8 +75063,10 @@ class PaperFolderLogInfo(bb.Struct):
     """
     Paper folder's logged information.
 
-    :ivar team_log.PaperFolderLogInfo.folder_id: Papers folder Id.
-    :ivar team_log.PaperFolderLogInfo.folder_name: Paper folder name.
+    :ivar PaperFolderLogInfo.folder_id:
+        Papers folder Id.
+    :ivar PaperFolderLogInfo.folder_name:
+        Paper folder name.
     """
 
     __slots__ = [
@@ -74335,8 +75101,8 @@ class PaperFolderTeamInviteDetails(bb.Struct):
     """
     Shared Paper folder with users and/or groups.
 
-    :ivar team_log.PaperFolderTeamInviteDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperFolderTeamInviteDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74441,13 +75207,11 @@ class PaperPublishedLinkChangePermissionDetails(bb.Struct):
     """
     Changed permissions for published doc.
 
-    :ivar team_log.PaperPublishedLinkChangePermissionDetails.event_uuid: Event
-        unique identifier.
-    :ivar
-        team_log.PaperPublishedLinkChangePermissionDetails.new_permission_level:
+    :ivar PaperPublishedLinkChangePermissionDetails.event_uuid:
+        Event unique identifier.
+    :ivar PaperPublishedLinkChangePermissionDetails.new_permission_level:
         New permission level.
-    :ivar
-        team_log.PaperPublishedLinkChangePermissionDetails.previous_permission_level:
+    :ivar PaperPublishedLinkChangePermissionDetails.previous_permission_level:
         Previous permission level.
     """
 
@@ -74513,8 +75277,8 @@ class PaperPublishedLinkCreateDetails(bb.Struct):
     """
     Published doc.
 
-    :ivar team_log.PaperPublishedLinkCreateDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperPublishedLinkCreateDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74563,8 +75327,8 @@ class PaperPublishedLinkDisabledDetails(bb.Struct):
     """
     Unpublished doc.
 
-    :ivar team_log.PaperPublishedLinkDisabledDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperPublishedLinkDisabledDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74613,8 +75377,8 @@ class PaperPublishedLinkViewDetails(bb.Struct):
     """
     Viewed published doc.
 
-    :ivar team_log.PaperPublishedLinkViewDetails.event_uuid: Event unique
-        identifier.
+    :ivar PaperPublishedLinkViewDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -74667,8 +75431,12 @@ class ParticipantLogInfo(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar GroupLogInfo ParticipantLogInfo.group: Group details.
-    :ivar UserLogInfo ParticipantLogInfo.user: A user with a Dropbox account.
+    :ivar ParticipantLogInfo.group:
+        Group details.
+    :vartype ParticipantLogInfo.group: GroupLogInfo
+    :ivar ParticipantLogInfo.user:
+        A user with a Dropbox account.
+    :vartype ParticipantLogInfo.user: UserLogInfo
     """
 
     _catch_all = 'other'
@@ -74904,10 +75672,11 @@ class PasskeyLoginPolicyChangedDetails(bb.Struct):
     """
     Changed passkey login policy for team.
 
-    :ivar team_log.PasskeyLoginPolicyChangedDetails.new_value: New passkey login
-        policy.
-    :ivar team_log.PasskeyLoginPolicyChangedDetails.previous_value: Previous
-        passkey login policy. Might be missing due to historical data gap.
+    :ivar PasskeyLoginPolicyChangedDetails.new_value:
+        New passkey login policy.
+    :ivar PasskeyLoginPolicyChangedDetails.previous_value:
+        Previous passkey login policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -75124,10 +75893,9 @@ class PasswordStrengthRequirementsChangePolicyDetails(bb.Struct):
     """
     Changed team password strength requirements.
 
-    :ivar
-        team_log.PasswordStrengthRequirementsChangePolicyDetails.previous_value:
+    :ivar PasswordStrengthRequirementsChangePolicyDetails.previous_value:
         Old password strength policy.
-    :ivar team_log.PasswordStrengthRequirementsChangePolicyDetails.new_value:
+    :ivar PasswordStrengthRequirementsChangePolicyDetails.new_value:
         New password strength policy.
     """
 
@@ -75185,10 +75953,10 @@ class PathLogInfo(bb.Struct):
     """
     Path's details.
 
-    :ivar team_log.PathLogInfo.contextual: Fully qualified path relative to
-        event's context.
-    :ivar team_log.PathLogInfo.namespace_relative: Path relative to the
-        namespace containing the content.
+    :ivar PathLogInfo.contextual:
+        Fully qualified path relative to event's context.
+    :ivar PathLogInfo.namespace_relative:
+        Path relative to the namespace containing the content.
     """
 
     __slots__ = [
@@ -75223,8 +75991,8 @@ class PendingSecondaryEmailAddedDetails(bb.Struct):
     """
     Added pending secondary email.
 
-    :ivar team_log.PendingSecondaryEmailAddedDetails.secondary_email: New
-        pending secondary email.
+    :ivar PendingSecondaryEmailAddedDetails.secondary_email:
+        New pending secondary email.
     """
 
     __slots__ = [
@@ -75273,11 +76041,11 @@ class PermanentDeleteChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled ability of team members to permanently delete content.
 
-    :ivar team_log.PermanentDeleteChangePolicyDetails.new_value: New permanent
-        delete content policy.
-    :ivar team_log.PermanentDeleteChangePolicyDetails.previous_value: Previous
-        permanent delete content policy. Might be missing due to historical data
-        gap.
+    :ivar PermanentDeleteChangePolicyDetails.new_value:
+        New permanent delete content policy.
+    :ivar PermanentDeleteChangePolicyDetails.previous_value:
+        Previous permanent delete content policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -75528,8 +76296,10 @@ class PreviewsAiPolicyChangedDetails(bb.Struct):
     """
     Changed Dropbox AI policy for team.
 
-    :ivar team_log.PreviewsAiPolicyChangedDetails.new_value: To.
-    :ivar team_log.PreviewsAiPolicyChangedDetails.previous_value: From.
+    :ivar PreviewsAiPolicyChangedDetails.new_value:
+        To.
+    :ivar PreviewsAiPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -75586,10 +76356,10 @@ class PrimaryTeamRequestAcceptedDetails(bb.Struct):
     """
     Team merge request acceptance details shown to the primary team
 
-    :ivar team_log.PrimaryTeamRequestAcceptedDetails.secondary_team: The
-        secondary team name.
-    :ivar team_log.PrimaryTeamRequestAcceptedDetails.sent_by: The name of the
-        secondary team admin who sent the request originally.
+    :ivar PrimaryTeamRequestAcceptedDetails.secondary_team:
+        The secondary team name.
+    :ivar PrimaryTeamRequestAcceptedDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -75624,10 +76394,10 @@ class PrimaryTeamRequestCanceledDetails(bb.Struct):
     """
     Team merge request cancellation details shown to the primary team
 
-    :ivar team_log.PrimaryTeamRequestCanceledDetails.secondary_team: The
-        secondary team name.
-    :ivar team_log.PrimaryTeamRequestCanceledDetails.sent_by: The name of the
-        secondary team admin who sent the request originally.
+    :ivar PrimaryTeamRequestCanceledDetails.secondary_team:
+        The secondary team name.
+    :ivar PrimaryTeamRequestCanceledDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -75662,10 +76432,10 @@ class PrimaryTeamRequestExpiredDetails(bb.Struct):
     """
     Team merge request expiration details shown to the primary team
 
-    :ivar team_log.PrimaryTeamRequestExpiredDetails.secondary_team: The
-        secondary team name.
-    :ivar team_log.PrimaryTeamRequestExpiredDetails.sent_by: The name of the
-        secondary team admin who sent the request originally.
+    :ivar PrimaryTeamRequestExpiredDetails.secondary_team:
+        The secondary team name.
+    :ivar PrimaryTeamRequestExpiredDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -75700,10 +76470,10 @@ class PrimaryTeamRequestReminderDetails(bb.Struct):
     """
     Team merge request reminder details shown to the primary team
 
-    :ivar team_log.PrimaryTeamRequestReminderDetails.secondary_team: The
-        secondary team name.
-    :ivar team_log.PrimaryTeamRequestReminderDetails.sent_to: The name of the
-        primary team admin the request was sent to.
+    :ivar PrimaryTeamRequestReminderDetails.secondary_team:
+        The secondary team name.
+    :ivar PrimaryTeamRequestReminderDetails.sent_to:
+        The name of the primary team admin the request was sent to.
     """
 
     __slots__ = [
@@ -75738,8 +76508,10 @@ class ProductAssignedToMemberDetails(bb.Struct):
     """
     Product assigned to team member.
 
-    :ivar team_log.ProductAssignedToMemberDetails.user_name: User's name.
-    :ivar team_log.ProductAssignedToMemberDetails.product_name: Product name.
+    :ivar ProductAssignedToMemberDetails.user_name:
+        User's name.
+    :ivar ProductAssignedToMemberDetails.product_name:
+        Product name.
     """
 
     __slots__ = [
@@ -75796,7 +76568,8 @@ class ProductLogInfo(bb.Struct):
     """
     Product logged information
 
-    :ivar team_log.ProductLogInfo.product_name: Product name.
+    :ivar ProductLogInfo.product_name:
+        Product name.
     """
 
     __slots__ = [
@@ -75823,8 +76596,10 @@ class ProductRemovedFromMemberDetails(bb.Struct):
     """
     Product removed from team member.
 
-    :ivar team_log.ProductRemovedFromMemberDetails.user_name: User's name.
-    :ivar team_log.ProductRemovedFromMemberDetails.product_name: Product name.
+    :ivar ProductRemovedFromMemberDetails.user_name:
+        User's name.
+    :ivar ProductRemovedFromMemberDetails.product_name:
+        Product name.
     """
 
     __slots__ = [
@@ -75881,10 +76656,10 @@ class ProtectInternalDomainsChangedDetails(bb.Struct):
     """
     Modified Protect internal domains list.
 
-    :ivar team_log.ProtectInternalDomainsChangedDetails.domains_added: Domains
-        added to the internal domains list.
-    :ivar team_log.ProtectInternalDomainsChangedDetails.domains_removed: Domains
-        removed from the internal domains list.
+    :ivar ProtectInternalDomainsChangedDetails.domains_added:
+        Domains added to the internal domains list.
+    :ivar ProtectInternalDomainsChangedDetails.domains_removed:
+        Domains removed from the internal domains list.
     """
 
     __slots__ = [
@@ -76045,7 +76820,7 @@ class RansomwareAlertCreateReportFailedDetails(bb.Struct):
     """
     Couldn't generate ransomware report.
 
-    :ivar team_log.RansomwareAlertCreateReportFailedDetails.failure_reason:
+    :ivar RansomwareAlertCreateReportFailedDetails.failure_reason:
         Failure reason.
     """
 
@@ -76117,13 +76892,11 @@ class RansomwareRestoreProcessCompletedDetails(bb.Struct):
     """
     Completed ransomware restore process.
 
-    :ivar team_log.RansomwareRestoreProcessCompletedDetails.status: The status
-        of the restore process.
-    :ivar
-        team_log.RansomwareRestoreProcessCompletedDetails.restored_files_count:
+    :ivar RansomwareRestoreProcessCompletedDetails.status:
+        The status of the restore process.
+    :ivar RansomwareRestoreProcessCompletedDetails.restored_files_count:
         Restored files count.
-    :ivar
-        team_log.RansomwareRestoreProcessCompletedDetails.restored_files_failed_count:
+    :ivar RansomwareRestoreProcessCompletedDetails.restored_files_failed_count:
         Restored files failed count.
     """
 
@@ -76189,8 +76962,8 @@ class RansomwareRestoreProcessStartedDetails(bb.Struct):
     """
     Started ransomware restore process.
 
-    :ivar team_log.RansomwareRestoreProcessStartedDetails.extension: Ransomware
-        filename extension.
+    :ivar RansomwareRestoreProcessStartedDetails.extension:
+        Ransomware filename extension.
     """
 
     __slots__ = [
@@ -76239,11 +77012,12 @@ class RecipientsConfiguration(bb.Struct):
     """
     Recipients Configuration
 
-    :ivar team_log.RecipientsConfiguration.recipient_setting_type: Recipients
-        setting type.
-    :ivar team_log.RecipientsConfiguration.emails: A list of user emails to
-        notify.
-    :ivar team_log.RecipientsConfiguration.groups: A list of groups to notify.
+    :ivar RecipientsConfiguration.recipient_setting_type:
+        Recipients setting type.
+    :ivar RecipientsConfiguration.emails:
+        A list of user emails to notify.
+    :ivar RecipientsConfiguration.groups:
+        A list of groups to notify.
     """
 
     __slots__ = [
@@ -76287,10 +77061,10 @@ class RelocateAssetReferencesLogInfo(bb.Struct):
     Provides the indices of the source asset and the destination asset for a
     relocate action.
 
-    :ivar team_log.RelocateAssetReferencesLogInfo.src_asset_index: Source asset
-        position in the Assets list.
-    :ivar team_log.RelocateAssetReferencesLogInfo.dest_asset_index: Destination
-        asset position in the Assets list.
+    :ivar RelocateAssetReferencesLogInfo.src_asset_index:
+        Source asset position in the Assets list.
+    :ivar RelocateAssetReferencesLogInfo.dest_asset_index:
+        Destination asset position in the Assets list.
     """
 
     __slots__ = [
@@ -76381,8 +77155,10 @@ class ReplayAddingPeoplePolicyChangedDetails(bb.Struct):
     """
     Changed the policy for adding people to Replay content.
 
-    :ivar team_log.ReplayAddingPeoplePolicyChangedDetails.new_value: To.
-    :ivar team_log.ReplayAddingPeoplePolicyChangedDetails.previous_value: From.
+    :ivar ReplayAddingPeoplePolicyChangedDetails.new_value:
+        To.
+    :ivar ReplayAddingPeoplePolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -76519,11 +77295,11 @@ class ReplayFileSharedLinkCreatedDetails(bb.Struct):
     """
     Created shared link in Replay.
 
-    :ivar team_log.ReplayFileSharedLinkCreatedDetails.is_watermarked: Indicates
-        whether it was a watermark share link.
-    :ivar team_log.ReplayFileSharedLinkCreatedDetails.access: The Replay sharing
-        policy in place when the link was created. Might be missing due to
-        historical data gap.
+    :ivar ReplayFileSharedLinkCreatedDetails.is_watermarked:
+        Indicates whether it was a watermark share link.
+    :ivar ReplayFileSharedLinkCreatedDetails.access:
+        The Replay sharing policy in place when the link was created. Might be
+        missing due to historical data gap.
     """
 
     __slots__ = [
@@ -76580,11 +77356,11 @@ class ReplayFileSharedLinkModifiedDetails(bb.Struct):
     """
     Changed shared link in Replay.
 
-    :ivar team_log.ReplayFileSharedLinkModifiedDetails.is_watermarked: Indicates
-        whether it was a watermark share link.
-    :ivar team_log.ReplayFileSharedLinkModifiedDetails.access: The Replay
-        sharing policy in place when the link was modified. Might be missing due
-        to historical data gap.
+    :ivar ReplayFileSharedLinkModifiedDetails.is_watermarked:
+        Indicates whether it was a watermark share link.
+    :ivar ReplayFileSharedLinkModifiedDetails.access:
+        The Replay sharing policy in place when the link was modified. Might be
+        missing due to historical data gap.
     """
 
     __slots__ = [
@@ -76843,8 +77619,10 @@ class ReplaySharingPolicyChangedDetails(bb.Struct):
     """
     Changed the policy for sharing Replay content.
 
-    :ivar team_log.ReplaySharingPolicyChangedDetails.new_value: To.
-    :ivar team_log.ReplaySharingPolicyChangedDetails.previous_value: From.
+    :ivar ReplaySharingPolicyChangedDetails.new_value:
+        To.
+    :ivar ReplaySharingPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -76901,8 +77679,8 @@ class ReplayTeamProjectCreatedDetails(bb.Struct):
     """
     Created a team project in Replay.
 
-    :ivar team_log.ReplayTeamProjectCreatedDetails.name: Name of the newly
-        created team project.
+    :ivar ReplayTeamProjectCreatedDetails.name:
+        Name of the newly created team project.
     """
 
     __slots__ = [
@@ -76951,8 +77729,10 @@ class ResellerLogInfo(bb.Struct):
     """
     Reseller information.
 
-    :ivar team_log.ResellerLogInfo.reseller_name: Reseller name.
-    :ivar team_log.ResellerLogInfo.reseller_email: Reseller email.
+    :ivar ResellerLogInfo.reseller_name:
+        Reseller name.
+    :ivar ResellerLogInfo.reseller_email:
+        Reseller email.
     """
 
     __slots__ = [
@@ -77031,10 +77811,10 @@ class ResellerSupportChangePolicyDetails(bb.Struct):
     """
     Enabled/disabled reseller support.
 
-    :ivar team_log.ResellerSupportChangePolicyDetails.new_value: New Reseller
-        support policy.
-    :ivar team_log.ResellerSupportChangePolicyDetails.previous_value: Previous
-        Reseller support policy.
+    :ivar ResellerSupportChangePolicyDetails.new_value:
+        New Reseller support policy.
+    :ivar ResellerSupportChangePolicyDetails.previous_value:
+        Previous Reseller support policy.
     """
 
     __slots__ = [
@@ -77218,8 +77998,8 @@ class RewindFolderDetails(bb.Struct):
     """
     Rewound a folder.
 
-    :ivar team_log.RewindFolderDetails.rewind_folder_target_ts_ms: Folder was
-        Rewound to this date.
+    :ivar RewindFolderDetails.rewind_folder_target_ts_ms:
+        Folder was Rewound to this date.
     """
 
     __slots__ = [
@@ -77314,10 +78094,10 @@ class RewindPolicyChangedDetails(bb.Struct):
     """
     Changed Rewind policy for team.
 
-    :ivar team_log.RewindPolicyChangedDetails.new_value: New Dropbox Rewind
-        policy.
-    :ivar team_log.RewindPolicyChangedDetails.previous_value: Previous Dropbox
-        Rewind policy.
+    :ivar RewindPolicyChangedDetails.new_value:
+        New Dropbox Rewind policy.
+    :ivar RewindPolicyChangedDetails.previous_value:
+        Previous Dropbox Rewind policy.
     """
 
     __slots__ = [
@@ -77374,11 +78154,12 @@ class RiscSecurityEventDetails(bb.Struct):
     """
     RISC security event received from external provider.
 
-    :ivar team_log.RiscSecurityEventDetails.event_type: RISC event type (e.g.,
-        account-disabled, token-revoked).
-    :ivar team_log.RiscSecurityEventDetails.reason: Reason for the RISC event.
-    :ivar team_log.RiscSecurityEventDetails.issuer: Identity provider issuer
-        (e.g., https://accounts.google.com).
+    :ivar RiscSecurityEventDetails.event_type:
+        RISC event type (e.g., account-disabled, token-revoked).
+    :ivar RiscSecurityEventDetails.reason:
+        Reason for the RISC event.
+    :ivar RiscSecurityEventDetails.issuer:
+        Identity provider issuer (e.g., https://accounts.google.com).
     """
 
     __slots__ = [
@@ -77443,8 +78224,8 @@ class SecondaryEmailDeletedDetails(bb.Struct):
     """
     Deleted secondary email.
 
-    :ivar team_log.SecondaryEmailDeletedDetails.secondary_email: Deleted
-        secondary email.
+    :ivar SecondaryEmailDeletedDetails.secondary_email:
+        Deleted secondary email.
     """
 
     __slots__ = [
@@ -77493,8 +78274,8 @@ class SecondaryEmailVerifiedDetails(bb.Struct):
     """
     Verified secondary email.
 
-    :ivar team_log.SecondaryEmailVerifiedDetails.secondary_email: Verified
-        secondary email.
+    :ivar SecondaryEmailVerifiedDetails.secondary_email:
+        Verified secondary email.
     """
 
     __slots__ = [
@@ -77587,10 +78368,10 @@ class SecondaryMailsPolicyChangedDetails(bb.Struct):
     """
     Secondary mails policy changed.
 
-    :ivar team_log.SecondaryMailsPolicyChangedDetails.previous_value: Previous
-        secondary mails policy.
-    :ivar team_log.SecondaryMailsPolicyChangedDetails.new_value: New secondary
-        mails policy.
+    :ivar SecondaryMailsPolicyChangedDetails.previous_value:
+        Previous secondary mails policy.
+    :ivar SecondaryMailsPolicyChangedDetails.new_value:
+        New secondary mails policy.
     """
 
     __slots__ = [
@@ -77647,10 +78428,10 @@ class SecondaryTeamRequestAcceptedDetails(bb.Struct):
     """
     Team merge request acceptance details shown to the secondary team
 
-    :ivar team_log.SecondaryTeamRequestAcceptedDetails.primary_team: The primary
-        team name.
-    :ivar team_log.SecondaryTeamRequestAcceptedDetails.sent_by: The name of the
-        secondary team admin who sent the request originally.
+    :ivar SecondaryTeamRequestAcceptedDetails.primary_team:
+        The primary team name.
+    :ivar SecondaryTeamRequestAcceptedDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -77685,10 +78466,10 @@ class SecondaryTeamRequestCanceledDetails(bb.Struct):
     """
     Team merge request cancellation details shown to the secondary team
 
-    :ivar team_log.SecondaryTeamRequestCanceledDetails.sent_to: The email of the
-        primary team admin that the request was sent to.
-    :ivar team_log.SecondaryTeamRequestCanceledDetails.sent_by: The name of the
-        secondary team admin who sent the request originally.
+    :ivar SecondaryTeamRequestCanceledDetails.sent_to:
+        The email of the primary team admin that the request was sent to.
+    :ivar SecondaryTeamRequestCanceledDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -77723,8 +78504,8 @@ class SecondaryTeamRequestExpiredDetails(bb.Struct):
     """
     Team merge request expiration details shown to the secondary team
 
-    :ivar team_log.SecondaryTeamRequestExpiredDetails.sent_to: The email of the
-        primary team admin the request was sent to.
+    :ivar SecondaryTeamRequestExpiredDetails.sent_to:
+        The email of the primary team admin the request was sent to.
     """
 
     __slots__ = [
@@ -77751,8 +78532,8 @@ class SecondaryTeamRequestReminderDetails(bb.Struct):
     """
     Team merge request reminder details shown to the secondary team
 
-    :ivar team_log.SecondaryTeamRequestReminderDetails.sent_to: The email of the
-        primary team admin the request was sent to.
+    :ivar SecondaryTeamRequestReminderDetails.sent_to:
+        The email of the primary team admin the request was sent to.
     """
 
     __slots__ = [
@@ -77819,8 +78600,8 @@ class SendAndTrackFileRenamedDetails(bb.Struct):
     """
     File renamed in Send and Track.
 
-    :ivar team_log.SendAndTrackFileRenamedDetails.previous_value: Previous file
-        name.
+    :ivar SendAndTrackFileRenamedDetails.previous_value:
+        Previous file name.
     """
 
     __slots__ = [
@@ -77909,7 +78690,8 @@ class SendAndTrackLinkCreatedDetails(bb.Struct):
     """
     Link created in Send and Track.
 
-    :ivar team_log.SendAndTrackLinkCreatedDetails.link_settings: Link Settings.
+    :ivar SendAndTrackLinkCreatedDetails.link_settings:
+        Link Settings.
     """
 
     __slots__ = [
@@ -77958,8 +78740,8 @@ class SendAndTrackLinkDeletedDetails(bb.Struct):
     """
     Link deleted in Send and Track.
 
-    :ivar team_log.SendAndTrackLinkDeletedDetails.shared_content_link: Shared
-        content link.
+    :ivar SendAndTrackLinkDeletedDetails.shared_content_link:
+        Shared content link.
     """
 
     __slots__ = [
@@ -78008,9 +78790,10 @@ class SendAndTrackLinkUpdatedDetails(bb.Struct):
     """
     Send and Track Link Updated.
 
-    :ivar team_log.SendAndTrackLinkUpdatedDetails.link_settings: Link Settings.
-    :ivar team_log.SendAndTrackLinkUpdatedDetails.previous_link_name: Previous
-        link name.
+    :ivar SendAndTrackLinkUpdatedDetails.link_settings:
+        Link Settings.
+    :ivar SendAndTrackLinkUpdatedDetails.previous_link_name:
+        Previous link name.
     """
 
     __slots__ = [
@@ -78067,10 +78850,12 @@ class SendAndTrackLinkViewedDetails(bb.Struct):
     """
     Send and Track Link Visited.
 
-    :ivar team_log.SendAndTrackLinkViewedDetails.link_settings: Link Settings.
-    :ivar team_log.SendAndTrackLinkViewedDetails.email_address: Visitor Email
-        address.
-    :ivar team_log.SendAndTrackLinkViewedDetails.link_owner: Link Owner.
+    :ivar SendAndTrackLinkViewedDetails.link_settings:
+        Link Settings.
+    :ivar SendAndTrackLinkViewedDetails.email_address:
+        Visitor Email address.
+    :ivar SendAndTrackLinkViewedDetails.link_owner:
+        Link Owner.
     """
 
     __slots__ = [
@@ -78191,8 +78976,10 @@ class SendAndTrackPolicyChangedDetails(bb.Struct):
     """
     Changed “Send and track” policy for team.
 
-    :ivar team_log.SendAndTrackPolicyChangedDetails.new_value: To.
-    :ivar team_log.SendAndTrackPolicyChangedDetails.previous_value: From.
+    :ivar SendAndTrackPolicyChangedDetails.new_value:
+        To.
+    :ivar SendAndTrackPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -78345,8 +79132,10 @@ class SendExternalSharingPolicyChangedDetails(bb.Struct):
     """
     Changed “Send and track” external sharing policy for team.
 
-    :ivar team_log.SendExternalSharingPolicyChangedDetails.new_value: To.
-    :ivar team_log.SendExternalSharingPolicyChangedDetails.previous_value: From.
+    :ivar SendExternalSharingPolicyChangedDetails.new_value:
+        To.
+    :ivar SendExternalSharingPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -78449,10 +79238,10 @@ class SendForSignaturePolicyChangedDetails(bb.Struct):
     """
     Changed send for signature policy for team.
 
-    :ivar team_log.SendForSignaturePolicyChangedDetails.new_value: New send for
-        signature policy.
-    :ivar team_log.SendForSignaturePolicyChangedDetails.previous_value: Previous
-        send for signature policy.
+    :ivar SendForSignaturePolicyChangedDetails.new_value:
+        New send for signature policy.
+    :ivar SendForSignaturePolicyChangedDetails.previous_value:
+        Previous send for signature policy.
     """
 
     __slots__ = [
@@ -78509,12 +79298,14 @@ class SfAddGroupDetails(bb.Struct):
     """
     Added team to shared folder.
 
-    :ivar team_log.SfAddGroupDetails.target_asset_index: Target asset position
-        in the Assets list.
-    :ivar team_log.SfAddGroupDetails.original_folder_name: Original shared
-        folder name.
-    :ivar team_log.SfAddGroupDetails.sharing_permission: Sharing permission.
-    :ivar team_log.SfAddGroupDetails.team_name: Team name.
+    :ivar SfAddGroupDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfAddGroupDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfAddGroupDetails.sharing_permission:
+        Sharing permission.
+    :ivar SfAddGroupDetails.team_name:
+        Team name.
     """
 
     __slots__ = [
@@ -78587,12 +79378,11 @@ class SfAllowNonMembersToViewSharedLinksDetails(bb.Struct):
     """
     Allowed non-collaborators to view links to files in shared folder.
 
-    :ivar team_log.SfAllowNonMembersToViewSharedLinksDetails.target_asset_index:
+    :ivar SfAllowNonMembersToViewSharedLinksDetails.target_asset_index:
         Target asset position in the Assets list.
-    :ivar
-        team_log.SfAllowNonMembersToViewSharedLinksDetails.original_folder_name:
+    :ivar SfAllowNonMembersToViewSharedLinksDetails.original_folder_name:
         Original shared folder name.
-    :ivar team_log.SfAllowNonMembersToViewSharedLinksDetails.shared_folder_type:
+    :ivar SfAllowNonMembersToViewSharedLinksDetails.shared_folder_type:
         Shared folder type.
     """
 
@@ -78658,13 +79448,13 @@ class SfExternalInviteWarnDetails(bb.Struct):
     """
     Set team members to see warning before sharing folders outside team.
 
-    :ivar team_log.SfExternalInviteWarnDetails.target_asset_index: Target asset
-        position in the Assets list.
-    :ivar team_log.SfExternalInviteWarnDetails.original_folder_name: Original
-        shared folder name.
-    :ivar team_log.SfExternalInviteWarnDetails.new_sharing_permission: New
-        sharing permission.
-    :ivar team_log.SfExternalInviteWarnDetails.previous_sharing_permission:
+    :ivar SfExternalInviteWarnDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfExternalInviteWarnDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfExternalInviteWarnDetails.new_sharing_permission:
+        New sharing permission.
+    :ivar SfExternalInviteWarnDetails.previous_sharing_permission:
         Previous sharing permission.
     """
 
@@ -78738,14 +79528,14 @@ class SfFbInviteChangeRoleDetails(bb.Struct):
     """
     Changed Facebook user's role in shared folder.
 
-    :ivar team_log.SfFbInviteChangeRoleDetails.target_asset_index: Target asset
-        position in the Assets list.
-    :ivar team_log.SfFbInviteChangeRoleDetails.original_folder_name: Original
-        shared folder name.
-    :ivar team_log.SfFbInviteChangeRoleDetails.previous_sharing_permission:
+    :ivar SfFbInviteChangeRoleDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfFbInviteChangeRoleDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfFbInviteChangeRoleDetails.previous_sharing_permission:
         Previous sharing permission.
-    :ivar team_log.SfFbInviteChangeRoleDetails.new_sharing_permission: New
-        sharing permission.
+    :ivar SfFbInviteChangeRoleDetails.new_sharing_permission:
+        New sharing permission.
     """
 
     __slots__ = [
@@ -78818,11 +79608,12 @@ class SfFbInviteDetails(bb.Struct):
     """
     Invited Facebook users to shared folder.
 
-    :ivar team_log.SfFbInviteDetails.target_asset_index: Target asset position
-        in the Assets list.
-    :ivar team_log.SfFbInviteDetails.original_folder_name: Original shared
-        folder name.
-    :ivar team_log.SfFbInviteDetails.sharing_permission: Sharing permission.
+    :ivar SfFbInviteDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfFbInviteDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfFbInviteDetails.sharing_permission:
+        Sharing permission.
     """
 
     __slots__ = [
@@ -78887,10 +79678,10 @@ class SfFbUninviteDetails(bb.Struct):
     """
     Uninvited Facebook user from shared folder.
 
-    :ivar team_log.SfFbUninviteDetails.target_asset_index: Target asset position
-        in the Assets list.
-    :ivar team_log.SfFbUninviteDetails.original_folder_name: Original shared
-        folder name.
+    :ivar SfFbUninviteDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfFbUninviteDetails.original_folder_name:
+        Original shared folder name.
     """
 
     __slots__ = [
@@ -78947,8 +79738,8 @@ class SfInviteGroupDetails(bb.Struct):
     """
     Invited group to shared folder.
 
-    :ivar team_log.SfInviteGroupDetails.target_asset_index: Target asset
-        position in the Assets list.
+    :ivar SfInviteGroupDetails.target_asset_index:
+        Target asset position in the Assets list.
     """
 
     __slots__ = [
@@ -78997,10 +79788,10 @@ class SfTeamGrantAccessDetails(bb.Struct):
     """
     Granted access to shared folder.
 
-    :ivar team_log.SfTeamGrantAccessDetails.target_asset_index: Target asset
-        position in the Assets list.
-    :ivar team_log.SfTeamGrantAccessDetails.original_folder_name: Original
-        shared folder name.
+    :ivar SfTeamGrantAccessDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamGrantAccessDetails.original_folder_name:
+        Original shared folder name.
     """
 
     __slots__ = [
@@ -79057,13 +79848,13 @@ class SfTeamInviteChangeRoleDetails(bb.Struct):
     """
     Changed team member's role in shared folder.
 
-    :ivar team_log.SfTeamInviteChangeRoleDetails.target_asset_index: Target
-        asset position in the Assets list.
-    :ivar team_log.SfTeamInviteChangeRoleDetails.original_folder_name: Original
-        shared folder name.
-    :ivar team_log.SfTeamInviteChangeRoleDetails.new_sharing_permission: New
-        sharing permission.
-    :ivar team_log.SfTeamInviteChangeRoleDetails.previous_sharing_permission:
+    :ivar SfTeamInviteChangeRoleDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamInviteChangeRoleDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfTeamInviteChangeRoleDetails.new_sharing_permission:
+        New sharing permission.
+    :ivar SfTeamInviteChangeRoleDetails.previous_sharing_permission:
         Previous sharing permission.
     """
 
@@ -79137,11 +79928,12 @@ class SfTeamInviteDetails(bb.Struct):
     """
     Invited team members to shared folder.
 
-    :ivar team_log.SfTeamInviteDetails.target_asset_index: Target asset position
-        in the Assets list.
-    :ivar team_log.SfTeamInviteDetails.original_folder_name: Original shared
-        folder name.
-    :ivar team_log.SfTeamInviteDetails.sharing_permission: Sharing permission.
+    :ivar SfTeamInviteDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamInviteDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfTeamInviteDetails.sharing_permission:
+        Sharing permission.
     """
 
     __slots__ = [
@@ -79206,10 +79998,10 @@ class SfTeamJoinDetails(bb.Struct):
     """
     Joined team member's shared folder.
 
-    :ivar team_log.SfTeamJoinDetails.target_asset_index: Target asset position
-        in the Assets list.
-    :ivar team_log.SfTeamJoinDetails.original_folder_name: Original shared
-        folder name.
+    :ivar SfTeamJoinDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamJoinDetails.original_folder_name:
+        Original shared folder name.
     """
 
     __slots__ = [
@@ -79244,14 +80036,14 @@ class SfTeamJoinFromOobLinkDetails(bb.Struct):
     """
     Joined team member's shared folder from link.
 
-    :ivar team_log.SfTeamJoinFromOobLinkDetails.target_asset_index: Target asset
-        position in the Assets list.
-    :ivar team_log.SfTeamJoinFromOobLinkDetails.original_folder_name: Original
-        shared folder name.
-    :ivar team_log.SfTeamJoinFromOobLinkDetails.token_key: Shared link token
-        key.
-    :ivar team_log.SfTeamJoinFromOobLinkDetails.sharing_permission: Sharing
-        permission.
+    :ivar SfTeamJoinFromOobLinkDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamJoinFromOobLinkDetails.original_folder_name:
+        Original shared folder name.
+    :ivar SfTeamJoinFromOobLinkDetails.token_key:
+        Shared link token key.
+    :ivar SfTeamJoinFromOobLinkDetails.sharing_permission:
+        Sharing permission.
     """
 
     __slots__ = [
@@ -79346,10 +80138,10 @@ class SfTeamUninviteDetails(bb.Struct):
     """
     Unshared folder with team member.
 
-    :ivar team_log.SfTeamUninviteDetails.target_asset_index: Target asset
-        position in the Assets list.
-    :ivar team_log.SfTeamUninviteDetails.original_folder_name: Original shared
-        folder name.
+    :ivar SfTeamUninviteDetails.target_asset_index:
+        Target asset position in the Assets list.
+    :ivar SfTeamUninviteDetails.original_folder_name:
+        Original shared folder name.
     """
 
     __slots__ = [
@@ -79406,9 +80198,10 @@ class SharedContentAddInviteesDetails(bb.Struct):
     """
     Invited user to Dropbox and added them to shared file/folder.
 
-    :ivar team_log.SharedContentAddInviteesDetails.shared_content_access_level:
+    :ivar SharedContentAddInviteesDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedContentAddInviteesDetails.invitees: A list of invitees.
+    :ivar SharedContentAddInviteesDetails.invitees:
+        A list of invitees.
     """
 
     __slots__ = [
@@ -79465,9 +80258,9 @@ class SharedContentAddLinkExpiryDetails(bb.Struct):
     """
     Added expiration date to link for shared file/folder.
 
-    :ivar team_log.SharedContentAddLinkExpiryDetails.new_value: New shared
-        content link expiration date. Might be missing due to historical data
-        gap.
+    :ivar SharedContentAddLinkExpiryDetails.new_value:
+        New shared content link expiration date. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -79556,7 +80349,7 @@ class SharedContentAddMemberDetails(bb.Struct):
     """
     Added users and/or groups to shared file/folder.
 
-    :ivar team_log.SharedContentAddMemberDetails.shared_content_access_level:
+    :ivar SharedContentAddMemberDetails.shared_content_access_level:
         Shared content access level.
     """
 
@@ -79606,9 +80399,9 @@ class SharedContentChangeDownloadsPolicyDetails(bb.Struct):
     """
     Changed whether members can download shared file/folder.
 
-    :ivar team_log.SharedContentChangeDownloadsPolicyDetails.new_value: New
-        downloads policy.
-    :ivar team_log.SharedContentChangeDownloadsPolicyDetails.previous_value:
+    :ivar SharedContentChangeDownloadsPolicyDetails.new_value:
+        New downloads policy.
+    :ivar SharedContentChangeDownloadsPolicyDetails.previous_value:
         Previous downloads policy. Might be missing due to historical data gap.
     """
 
@@ -79667,12 +80460,12 @@ class SharedContentChangeInviteeRoleDetails(bb.Struct):
     Changed access type of invitee to shared file/folder before invite was
     accepted.
 
-    :ivar team_log.SharedContentChangeInviteeRoleDetails.previous_access_level:
+    :ivar SharedContentChangeInviteeRoleDetails.previous_access_level:
         Previous access level. Might be missing due to historical data gap.
-    :ivar team_log.SharedContentChangeInviteeRoleDetails.new_access_level: New
-        access level.
-    :ivar team_log.SharedContentChangeInviteeRoleDetails.invitee: The invitee
-        whose role was changed.
+    :ivar SharedContentChangeInviteeRoleDetails.new_access_level:
+        New access level.
+    :ivar SharedContentChangeInviteeRoleDetails.invitee:
+        The invitee whose role was changed.
     """
 
     __slots__ = [
@@ -79737,9 +80530,9 @@ class SharedContentChangeLinkAudienceDetails(bb.Struct):
     """
     Changed link audience of shared file/folder.
 
-    :ivar team_log.SharedContentChangeLinkAudienceDetails.new_value: New link
-        audience value.
-    :ivar team_log.SharedContentChangeLinkAudienceDetails.previous_value:
+    :ivar SharedContentChangeLinkAudienceDetails.new_value:
+        New link audience value.
+    :ivar SharedContentChangeLinkAudienceDetails.previous_value:
         Previous link audience value.
     """
 
@@ -79797,12 +80590,12 @@ class SharedContentChangeLinkExpiryDetails(bb.Struct):
     """
     Changed link expiration of shared file/folder.
 
-    :ivar team_log.SharedContentChangeLinkExpiryDetails.new_value: New shared
-        content link expiration date. Might be missing due to historical data
-        gap.
-    :ivar team_log.SharedContentChangeLinkExpiryDetails.previous_value: Previous
-        shared content link expiration date. Might be missing due to historical
-        data gap.
+    :ivar SharedContentChangeLinkExpiryDetails.new_value:
+        New shared content link expiration date. Might be missing due to
+        historical data gap.
+    :ivar SharedContentChangeLinkExpiryDetails.previous_value:
+        Previous shared content link expiration date. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -79899,10 +80692,10 @@ class SharedContentChangeMemberRoleDetails(bb.Struct):
     """
     Changed access type of shared file/folder member.
 
-    :ivar team_log.SharedContentChangeMemberRoleDetails.previous_access_level:
+    :ivar SharedContentChangeMemberRoleDetails.previous_access_level:
         Previous access level. Might be missing due to historical data gap.
-    :ivar team_log.SharedContentChangeMemberRoleDetails.new_access_level: New
-        access level.
+    :ivar SharedContentChangeMemberRoleDetails.new_access_level:
+        New access level.
     """
 
     __slots__ = [
@@ -79959,9 +80752,9 @@ class SharedContentChangeViewerInfoPolicyDetails(bb.Struct):
     """
     Changed whether members can see who viewed shared file/folder.
 
-    :ivar team_log.SharedContentChangeViewerInfoPolicyDetails.new_value: New
-        viewer info policy.
-    :ivar team_log.SharedContentChangeViewerInfoPolicyDetails.previous_value:
+    :ivar SharedContentChangeViewerInfoPolicyDetails.new_value:
+        New viewer info policy.
+    :ivar SharedContentChangeViewerInfoPolicyDetails.previous_value:
         Previous view info policy.
     """
 
@@ -80019,7 +80812,7 @@ class SharedContentClaimInvitationDetails(bb.Struct):
     """
     Acquired membership of shared file/folder by accepting invite.
 
-    :ivar team_log.SharedContentClaimInvitationDetails.shared_content_link:
+    :ivar SharedContentClaimInvitationDetails.shared_content_link:
         Shared content link.
     """
 
@@ -80069,14 +80862,14 @@ class SharedContentCopyDetails(bb.Struct):
     """
     Copied shared file/folder to own Dropbox.
 
-    :ivar team_log.SharedContentCopyDetails.shared_content_link: Shared content
-        link.
-    :ivar team_log.SharedContentCopyDetails.shared_content_owner: The shared
-        content owner.
-    :ivar team_log.SharedContentCopyDetails.shared_content_access_level: Shared
-        content access level.
-    :ivar team_log.SharedContentCopyDetails.destination_path: The path where the
-        member saved the content.
+    :ivar SharedContentCopyDetails.shared_content_link:
+        Shared content link.
+    :ivar SharedContentCopyDetails.shared_content_owner:
+        The shared content owner.
+    :ivar SharedContentCopyDetails.shared_content_access_level:
+        Shared content access level.
+    :ivar SharedContentCopyDetails.destination_path:
+        The path where the member saved the content.
     """
 
     __slots__ = [
@@ -80149,11 +80942,11 @@ class SharedContentDownloadDetails(bb.Struct):
     """
     Downloaded shared file/folder.
 
-    :ivar team_log.SharedContentDownloadDetails.shared_content_link: Shared
-        content link.
-    :ivar team_log.SharedContentDownloadDetails.shared_content_owner: The shared
-        content owner.
-    :ivar team_log.SharedContentDownloadDetails.shared_content_access_level:
+    :ivar SharedContentDownloadDetails.shared_content_link:
+        Shared content link.
+    :ivar SharedContentDownloadDetails.shared_content_owner:
+        The shared content owner.
+    :ivar SharedContentDownloadDetails.shared_content_access_level:
         Shared content access level.
     """
 
@@ -80259,8 +81052,8 @@ class SharedContentRemoveInviteesDetails(bb.Struct):
     """
     Removed invitee from shared file/folder before invite was accepted.
 
-    :ivar team_log.SharedContentRemoveInviteesDetails.invitees: A list of
-        invitees.
+    :ivar SharedContentRemoveInviteesDetails.invitees:
+        A list of invitees.
     """
 
     __slots__ = [
@@ -80309,9 +81102,9 @@ class SharedContentRemoveLinkExpiryDetails(bb.Struct):
     """
     Removed link expiration date of shared file/folder.
 
-    :ivar team_log.SharedContentRemoveLinkExpiryDetails.previous_value: Previous
-        shared content link expiration date. Might be missing due to historical
-        data gap.
+    :ivar SharedContentRemoveLinkExpiryDetails.previous_value:
+        Previous shared content link expiration date. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -80400,7 +81193,7 @@ class SharedContentRemoveMemberDetails(bb.Struct):
     """
     Removed user/group from shared file/folder.
 
-    :ivar team_log.SharedContentRemoveMemberDetails.shared_content_access_level:
+    :ivar SharedContentRemoveMemberDetails.shared_content_access_level:
         Shared content access level.
     """
 
@@ -80450,8 +81243,8 @@ class SharedContentRequestAccessDetails(bb.Struct):
     """
     Requested access to shared file/folder.
 
-    :ivar team_log.SharedContentRequestAccessDetails.shared_content_link: Shared
-        content link.
+    :ivar SharedContentRequestAccessDetails.shared_content_link:
+        Shared content link.
     """
 
     __slots__ = [
@@ -80500,11 +81293,10 @@ class SharedContentRestoreInviteesDetails(bb.Struct):
     """
     Restored shared file/folder invitees.
 
-    :ivar
-        team_log.SharedContentRestoreInviteesDetails.shared_content_access_level:
+    :ivar SharedContentRestoreInviteesDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedContentRestoreInviteesDetails.invitees: A list of
-        invitees.
+    :ivar SharedContentRestoreInviteesDetails.invitees:
+        A list of invitees.
     """
 
     __slots__ = [
@@ -80561,8 +81353,7 @@ class SharedContentRestoreMemberDetails(bb.Struct):
     """
     Restored users and/or groups to membership of shared file/folder.
 
-    :ivar
-        team_log.SharedContentRestoreMemberDetails.shared_content_access_level:
+    :ivar SharedContentRestoreMemberDetails.shared_content_access_level:
         Shared content access level.
     """
 
@@ -80652,12 +81443,12 @@ class SharedContentViewDetails(bb.Struct):
     """
     Previewed shared file/folder.
 
-    :ivar team_log.SharedContentViewDetails.shared_content_link: Shared content
-        link.
-    :ivar team_log.SharedContentViewDetails.shared_content_owner: The shared
-        content owner.
-    :ivar team_log.SharedContentViewDetails.shared_content_access_level: Shared
-        content access level.
+    :ivar SharedContentViewDetails.shared_content_link:
+        Shared content link.
+    :ivar SharedContentViewDetails.shared_content_owner:
+        The shared content owner.
+    :ivar SharedContentViewDetails.shared_content_access_level:
+        Shared content access level.
     """
 
     __slots__ = [
@@ -80722,10 +81513,11 @@ class SharedFolderChangeLinkPolicyDetails(bb.Struct):
     """
     Changed who can access shared folder via link.
 
-    :ivar team_log.SharedFolderChangeLinkPolicyDetails.new_value: New shared
-        folder link policy.
-    :ivar team_log.SharedFolderChangeLinkPolicyDetails.previous_value: Previous
-        shared folder link policy. Might be missing due to historical data gap.
+    :ivar SharedFolderChangeLinkPolicyDetails.new_value:
+        New shared folder link policy.
+    :ivar SharedFolderChangeLinkPolicyDetails.previous_value:
+        Previous shared folder link policy. Might be missing due to historical
+        data gap.
     """
 
     __slots__ = [
@@ -80782,10 +81574,9 @@ class SharedFolderChangeMembersInheritancePolicyDetails(bb.Struct):
     """
     Changed whether shared folder inherits members from parent folder.
 
-    :ivar team_log.SharedFolderChangeMembersInheritancePolicyDetails.new_value:
+    :ivar SharedFolderChangeMembersInheritancePolicyDetails.new_value:
         New member inheritance policy.
-    :ivar
-        team_log.SharedFolderChangeMembersInheritancePolicyDetails.previous_value:
+    :ivar SharedFolderChangeMembersInheritancePolicyDetails.previous_value:
         Previous member inheritance policy. Might be missing due to historical
         data gap.
     """
@@ -80844,10 +81635,9 @@ class SharedFolderChangeMembersManagementPolicyDetails(bb.Struct):
     """
     Changed who can add/remove members of shared folder.
 
-    :ivar team_log.SharedFolderChangeMembersManagementPolicyDetails.new_value:
+    :ivar SharedFolderChangeMembersManagementPolicyDetails.new_value:
         New members management policy.
-    :ivar
-        team_log.SharedFolderChangeMembersManagementPolicyDetails.previous_value:
+    :ivar SharedFolderChangeMembersManagementPolicyDetails.previous_value:
         Previous members management policy. Might be missing due to historical
         data gap.
     """
@@ -80906,9 +81696,9 @@ class SharedFolderChangeMembersPolicyDetails(bb.Struct):
     """
     Changed who can become member of shared folder.
 
-    :ivar team_log.SharedFolderChangeMembersPolicyDetails.new_value: New
-        external invite policy.
-    :ivar team_log.SharedFolderChangeMembersPolicyDetails.previous_value:
+    :ivar SharedFolderChangeMembersPolicyDetails.new_value:
+        New external invite policy.
+    :ivar SharedFolderChangeMembersPolicyDetails.previous_value:
         Previous external invite policy. Might be missing due to historical data
         gap.
     """
@@ -80967,7 +81757,8 @@ class SharedFolderCreateDetails(bb.Struct):
     """
     Created shared folder.
 
-    :ivar team_log.SharedFolderCreateDetails.target_ns_id: Target namespace ID.
+    :ivar SharedFolderCreateDetails.target_ns_id:
+        Target namespace ID.
     """
 
     __slots__ = [
@@ -81142,13 +81933,14 @@ class SharedFolderNestDetails(bb.Struct):
     """
     Changed parent of shared folder.
 
-    :ivar team_log.SharedFolderNestDetails.previous_parent_ns_id: Previous
-        parent namespace ID.
-    :ivar team_log.SharedFolderNestDetails.new_parent_ns_id: New parent
-        namespace ID.
-    :ivar team_log.SharedFolderNestDetails.previous_ns_path: Previous namespace
-        path.
-    :ivar team_log.SharedFolderNestDetails.new_ns_path: New namespace path.
+    :ivar SharedFolderNestDetails.previous_parent_ns_id:
+        Previous parent namespace ID.
+    :ivar SharedFolderNestDetails.new_parent_ns_id:
+        New parent namespace ID.
+    :ivar SharedFolderNestDetails.previous_ns_path:
+        Previous namespace path.
+    :ivar SharedFolderNestDetails.new_ns_path:
+        New namespace path.
     """
 
     __slots__ = [
@@ -81221,10 +82013,10 @@ class SharedFolderTransferOwnershipDetails(bb.Struct):
     """
     Transferred ownership of shared folder to another member.
 
-    :ivar team_log.SharedFolderTransferOwnershipDetails.previous_owner_email:
+    :ivar SharedFolderTransferOwnershipDetails.previous_owner_email:
         The email address of the previous shared folder owner.
-    :ivar team_log.SharedFolderTransferOwnershipDetails.new_owner_email: The
-        email address of the new shared folder owner.
+    :ivar SharedFolderTransferOwnershipDetails.new_owner_email:
+        The email address of the new shared folder owner.
     """
 
     __slots__ = [
@@ -81339,7 +82131,7 @@ class SharedFoldersCreateReportFailedDetails(bb.Struct):
     """
     Couldn't generate shared folders report.
 
-    :ivar team_log.SharedFoldersCreateReportFailedDetails.failure_reason:
+    :ivar SharedFoldersCreateReportFailedDetails.failure_reason:
         Failure reason.
     """
 
@@ -81467,10 +82259,10 @@ class SharedLinkAddExpiryDetails(bb.Struct):
     """
     Added shared link expiration date.
 
-    :ivar team_log.SharedLinkAddExpiryDetails.new_value: New shared link
-        expiration date.
-    :ivar team_log.SharedLinkAddExpiryDetails.is_consolidation_action: Indicates
-        whether this was a consolidation action by system.
+    :ivar SharedLinkAddExpiryDetails.new_value:
+        New shared link expiration date.
+    :ivar SharedLinkAddExpiryDetails.is_consolidation_action:
+        Indicates whether this was a consolidation action by system.
     """
 
     __slots__ = [
@@ -81527,11 +82319,13 @@ class SharedLinkChangeExpiryDetails(bb.Struct):
     """
     Changed shared link expiration date.
 
-    :ivar team_log.SharedLinkChangeExpiryDetails.new_value: New shared link
-        expiration date. Might be missing due to historical data gap.
-    :ivar team_log.SharedLinkChangeExpiryDetails.previous_value: Previous shared
-        link expiration date. Might be missing due to historical data gap.
-    :ivar team_log.SharedLinkChangeExpiryDetails.is_consolidation_action:
+    :ivar SharedLinkChangeExpiryDetails.new_value:
+        New shared link expiration date. Might be missing due to historical data
+        gap.
+    :ivar SharedLinkChangeExpiryDetails.previous_value:
+        Previous shared link expiration date. Might be missing due to historical
+        data gap.
+    :ivar SharedLinkChangeExpiryDetails.is_consolidation_action:
         Indicates whether this was a consolidation action by system.
     """
 
@@ -81597,11 +82391,12 @@ class SharedLinkChangeVisibilityDetails(bb.Struct):
     """
     Changed visibility of shared link.
 
-    :ivar team_log.SharedLinkChangeVisibilityDetails.new_value: New shared link
-        visibility.
-    :ivar team_log.SharedLinkChangeVisibilityDetails.previous_value: Previous
-        shared link visibility. Might be missing due to historical data gap.
-    :ivar team_log.SharedLinkChangeVisibilityDetails.is_consolidation_action:
+    :ivar SharedLinkChangeVisibilityDetails.new_value:
+        New shared link visibility.
+    :ivar SharedLinkChangeVisibilityDetails.previous_value:
+        Previous shared link visibility. Might be missing due to historical data
+        gap.
+    :ivar SharedLinkChangeVisibilityDetails.is_consolidation_action:
         Indicates whether this was a consolidation action by system.
     """
 
@@ -81667,8 +82462,8 @@ class SharedLinkCopyDetails(bb.Struct):
     """
     Added file/folder to Dropbox from shared link.
 
-    :ivar team_log.SharedLinkCopyDetails.shared_link_owner: Shared link owner
-        details. Might be missing due to historical data gap.
+    :ivar SharedLinkCopyDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -81717,8 +82512,9 @@ class SharedLinkCreateDetails(bb.Struct):
     """
     Created shared link.
 
-    :ivar team_log.SharedLinkCreateDetails.shared_link_access_level: Defines who
-        can access the shared link. Might be missing due to historical data gap.
+    :ivar SharedLinkCreateDetails.shared_link_access_level:
+        Defines who can access the shared link. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -81823,10 +82619,9 @@ class SharedLinkDefaultPermissionsPolicyChangedDetails(bb.Struct):
     """
     Changed shared link default permissions policy for team.
 
-    :ivar team_log.SharedLinkDefaultPermissionsPolicyChangedDetails.new_value:
+    :ivar SharedLinkDefaultPermissionsPolicyChangedDetails.new_value:
         To.
-    :ivar
-        team_log.SharedLinkDefaultPermissionsPolicyChangedDetails.previous_value:
+    :ivar SharedLinkDefaultPermissionsPolicyChangedDetails.previous_value:
         From.
     """
 
@@ -81884,8 +82679,8 @@ class SharedLinkDisableDetails(bb.Struct):
     """
     Removed shared link.
 
-    :ivar team_log.SharedLinkDisableDetails.shared_link_owner: Shared link owner
-        details. Might be missing due to historical data gap.
+    :ivar SharedLinkDisableDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -81934,8 +82729,8 @@ class SharedLinkDownloadDetails(bb.Struct):
     """
     Downloaded file/folder from shared link.
 
-    :ivar team_log.SharedLinkDownloadDetails.shared_link_owner: Shared link
-        owner details. Might be missing due to historical data gap.
+    :ivar SharedLinkDownloadDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -81984,8 +82779,9 @@ class SharedLinkRemoveExpiryDetails(bb.Struct):
     """
     Removed shared link expiration date.
 
-    :ivar team_log.SharedLinkRemoveExpiryDetails.previous_value: Previous shared
-        link expiration date. Might be missing due to historical data gap.
+    :ivar SharedLinkRemoveExpiryDetails.previous_value:
+        Previous shared link expiration date. Might be missing due to historical
+        data gap.
     """
 
     __slots__ = [
@@ -82074,14 +82870,13 @@ class SharedLinkSettingsAddExpirationDetails(bb.Struct):
     """
     Added an expiration date to the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsAddExpirationDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsAddExpirationDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedLinkSettingsAddExpirationDetails.shared_content_link:
+    :ivar SharedLinkSettingsAddExpirationDetails.shared_content_link:
         Shared content link.
-    :ivar team_log.SharedLinkSettingsAddExpirationDetails.new_value: New shared
-        content link expiration date. Might be missing due to historical data
-        gap.
+    :ivar SharedLinkSettingsAddExpirationDetails.new_value:
+        New shared content link expiration date. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -82146,10 +82941,9 @@ class SharedLinkSettingsAddPasswordDetails(bb.Struct):
     """
     Added a password to the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsAddPasswordDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsAddPasswordDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedLinkSettingsAddPasswordDetails.shared_content_link:
+    :ivar SharedLinkSettingsAddPasswordDetails.shared_content_link:
         Shared content link.
     """
 
@@ -82207,11 +83001,9 @@ class SharedLinkSettingsAllowDownloadDisabledDetails(bb.Struct):
     """
     Disabled downloads.
 
-    :ivar
-        team_log.SharedLinkSettingsAllowDownloadDisabledDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsAllowDownloadDisabledDetails.shared_content_access_level:
         Shared content access level.
-    :ivar
-        team_log.SharedLinkSettingsAllowDownloadDisabledDetails.shared_content_link:
+    :ivar SharedLinkSettingsAllowDownloadDisabledDetails.shared_content_link:
         Shared content link.
     """
 
@@ -82269,11 +83061,9 @@ class SharedLinkSettingsAllowDownloadEnabledDetails(bb.Struct):
     """
     Enabled downloads.
 
-    :ivar
-        team_log.SharedLinkSettingsAllowDownloadEnabledDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsAllowDownloadEnabledDetails.shared_content_access_level:
         Shared content access level.
-    :ivar
-        team_log.SharedLinkSettingsAllowDownloadEnabledDetails.shared_content_link:
+    :ivar SharedLinkSettingsAllowDownloadEnabledDetails.shared_content_link:
         Shared content link.
     """
 
@@ -82331,14 +83121,13 @@ class SharedLinkSettingsChangeAudienceDetails(bb.Struct):
     """
     Changed the audience of the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsChangeAudienceDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsChangeAudienceDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedLinkSettingsChangeAudienceDetails.shared_content_link:
+    :ivar SharedLinkSettingsChangeAudienceDetails.shared_content_link:
         Shared content link.
-    :ivar team_log.SharedLinkSettingsChangeAudienceDetails.new_value: New link
-        audience value.
-    :ivar team_log.SharedLinkSettingsChangeAudienceDetails.previous_value:
+    :ivar SharedLinkSettingsChangeAudienceDetails.new_value:
+        New link audience value.
+    :ivar SharedLinkSettingsChangeAudienceDetails.previous_value:
         Previous link audience value.
     """
 
@@ -82412,16 +83201,14 @@ class SharedLinkSettingsChangeExpirationDetails(bb.Struct):
     """
     Changed the expiration date of the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsChangeExpirationDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsChangeExpirationDetails.shared_content_access_level:
         Shared content access level.
-    :ivar
-        team_log.SharedLinkSettingsChangeExpirationDetails.shared_content_link:
+    :ivar SharedLinkSettingsChangeExpirationDetails.shared_content_link:
         Shared content link.
-    :ivar team_log.SharedLinkSettingsChangeExpirationDetails.new_value: New
-        shared content link expiration date. Might be missing due to historical
-        data gap.
-    :ivar team_log.SharedLinkSettingsChangeExpirationDetails.previous_value:
+    :ivar SharedLinkSettingsChangeExpirationDetails.new_value:
+        New shared content link expiration date. Might be missing due to
+        historical data gap.
+    :ivar SharedLinkSettingsChangeExpirationDetails.previous_value:
         Previous shared content link expiration date. Might be missing due to
         historical data gap.
     """
@@ -82496,10 +83283,9 @@ class SharedLinkSettingsChangePasswordDetails(bb.Struct):
     """
     Changed the password of the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsChangePasswordDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsChangePasswordDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedLinkSettingsChangePasswordDetails.shared_content_link:
+    :ivar SharedLinkSettingsChangePasswordDetails.shared_content_link:
         Shared content link.
     """
 
@@ -82557,13 +83343,11 @@ class SharedLinkSettingsRemoveExpirationDetails(bb.Struct):
     """
     Removed the expiration date from the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsRemoveExpirationDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsRemoveExpirationDetails.shared_content_access_level:
         Shared content access level.
-    :ivar
-        team_log.SharedLinkSettingsRemoveExpirationDetails.shared_content_link:
+    :ivar SharedLinkSettingsRemoveExpirationDetails.shared_content_link:
         Shared content link.
-    :ivar team_log.SharedLinkSettingsRemoveExpirationDetails.previous_value:
+    :ivar SharedLinkSettingsRemoveExpirationDetails.previous_value:
         Previous shared link expiration date. Might be missing due to historical
         data gap.
     """
@@ -82630,10 +83414,9 @@ class SharedLinkSettingsRemovePasswordDetails(bb.Struct):
     """
     Removed the password from the shared link.
 
-    :ivar
-        team_log.SharedLinkSettingsRemovePasswordDetails.shared_content_access_level:
+    :ivar SharedLinkSettingsRemovePasswordDetails.shared_content_access_level:
         Shared content access level.
-    :ivar team_log.SharedLinkSettingsRemovePasswordDetails.shared_content_link:
+    :ivar SharedLinkSettingsRemovePasswordDetails.shared_content_link:
         Shared content link.
     """
 
@@ -82691,10 +83474,10 @@ class SharedLinkShareDetails(bb.Struct):
     """
     Added members as audience of shared link.
 
-    :ivar team_log.SharedLinkShareDetails.shared_link_owner: Shared link owner
-        details. Might be missing due to historical data gap.
-    :ivar team_log.SharedLinkShareDetails.external_users: Users without a
-        Dropbox account that were added as shared link audience.
+    :ivar SharedLinkShareDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
+    :ivar SharedLinkShareDetails.external_users:
+        Users without a Dropbox account that were added as shared link audience.
     """
 
     __slots__ = [
@@ -82751,8 +83534,8 @@ class SharedLinkViewDetails(bb.Struct):
     """
     Opened shared link.
 
-    :ivar team_log.SharedLinkViewDetails.shared_link_owner: Shared link owner
-        details. Might be missing due to historical data gap.
+    :ivar SharedLinkViewDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -82907,10 +83690,11 @@ class SharingChangeFolderJoinPolicyDetails(bb.Struct):
     """
     Changed whether team members can join shared folders owned outside team.
 
-    :ivar team_log.SharingChangeFolderJoinPolicyDetails.new_value: New external
-        join policy.
-    :ivar team_log.SharingChangeFolderJoinPolicyDetails.previous_value: Previous
-        external join policy. Might be missing due to historical data gap.
+    :ivar SharingChangeFolderJoinPolicyDetails.new_value:
+        New external join policy.
+    :ivar SharingChangeFolderJoinPolicyDetails.previous_value:
+        Previous external join policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -82968,11 +83752,9 @@ class SharingChangeLinkAllowChangeExpirationPolicyDetails(bb.Struct):
     Changed the allow remove or change expiration policy for the links shared
     outside of the team.
 
-    :ivar
-        team_log.SharingChangeLinkAllowChangeExpirationPolicyDetails.new_value:
+    :ivar SharingChangeLinkAllowChangeExpirationPolicyDetails.new_value:
         To.
-    :ivar
-        team_log.SharingChangeLinkAllowChangeExpirationPolicyDetails.previous_value:
+    :ivar SharingChangeLinkAllowChangeExpirationPolicyDetails.previous_value:
         From.
     """
 
@@ -83030,10 +83812,9 @@ class SharingChangeLinkDefaultExpirationPolicyDetails(bb.Struct):
     """
     Changed the default expiration for the links shared outside of the team.
 
-    :ivar team_log.SharingChangeLinkDefaultExpirationPolicyDetails.new_value:
+    :ivar SharingChangeLinkDefaultExpirationPolicyDetails.new_value:
         To.
-    :ivar
-        team_log.SharingChangeLinkDefaultExpirationPolicyDetails.previous_value:
+    :ivar SharingChangeLinkDefaultExpirationPolicyDetails.previous_value:
         From.
     """
 
@@ -83091,8 +83872,9 @@ class SharingChangeLinkEnforcePasswordPolicyDetails(bb.Struct):
     """
     Changed the password requirement for the links shared outside of the team.
 
-    :ivar team_log.SharingChangeLinkEnforcePasswordPolicyDetails.new_value: To.
-    :ivar team_log.SharingChangeLinkEnforcePasswordPolicyDetails.previous_value:
+    :ivar SharingChangeLinkEnforcePasswordPolicyDetails.new_value:
+        To.
+    :ivar SharingChangeLinkEnforcePasswordPolicyDetails.previous_value:
         From.
     """
 
@@ -83151,11 +83933,11 @@ class SharingChangeLinkPolicyDetails(bb.Struct):
     Changed whether members can share links outside team, and if links are
     accessible only by team members or anyone by default.
 
-    :ivar team_log.SharingChangeLinkPolicyDetails.new_value: New external link
-        accessibility policy.
-    :ivar team_log.SharingChangeLinkPolicyDetails.previous_value: Previous
-        external link accessibility policy. Might be missing due to historical
-        data gap.
+    :ivar SharingChangeLinkPolicyDetails.new_value:
+        New external link accessibility policy.
+    :ivar SharingChangeLinkPolicyDetails.previous_value:
+        Previous external link accessibility policy. Might be missing due to
+        historical data gap.
     """
 
     __slots__ = [
@@ -83212,10 +83994,11 @@ class SharingChangeMemberPolicyDetails(bb.Struct):
     """
     Changed whether members can share files/folders outside team.
 
-    :ivar team_log.SharingChangeMemberPolicyDetails.new_value: New external
-        invite policy.
-    :ivar team_log.SharingChangeMemberPolicyDetails.previous_value: Previous
-        external invite policy. Might be missing due to historical data gap.
+    :ivar SharingChangeMemberPolicyDetails.new_value:
+        New external invite policy.
+    :ivar SharingChangeMemberPolicyDetails.previous_value:
+        Previous external invite policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -83441,8 +84224,8 @@ class ShmodelDisableDownloadsDetails(bb.Struct):
     """
     Disabled downloads for link.
 
-    :ivar team_log.ShmodelDisableDownloadsDetails.shared_link_owner: Shared link
-        owner details. Might be missing due to historical data gap.
+    :ivar ShmodelDisableDownloadsDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -83491,8 +84274,8 @@ class ShmodelEnableDownloadsDetails(bb.Struct):
     """
     Enabled downloads for link.
 
-    :ivar team_log.ShmodelEnableDownloadsDetails.shared_link_owner: Shared link
-        owner details. Might be missing due to historical data gap.
+    :ivar ShmodelEnableDownloadsDetails.shared_link_owner:
+        Shared link owner details. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -83581,8 +84364,8 @@ class ShowcaseAccessGrantedDetails(bb.Struct):
     """
     Granted access to showcase.
 
-    :ivar team_log.ShowcaseAccessGrantedDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseAccessGrantedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -83631,7 +84414,8 @@ class ShowcaseAddMemberDetails(bb.Struct):
     """
     Added member to showcase.
 
-    :ivar team_log.ShowcaseAddMemberDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseAddMemberDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -83680,7 +84464,8 @@ class ShowcaseArchivedDetails(bb.Struct):
     """
     Archived showcase.
 
-    :ivar team_log.ShowcaseArchivedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseArchivedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -83729,10 +84514,10 @@ class ShowcaseChangeDownloadPolicyDetails(bb.Struct):
     """
     Enabled/disabled downloading files from Dropbox Showcase for team.
 
-    :ivar team_log.ShowcaseChangeDownloadPolicyDetails.new_value: New Dropbox
-        Showcase download policy.
-    :ivar team_log.ShowcaseChangeDownloadPolicyDetails.previous_value: Previous
-        Dropbox Showcase download policy.
+    :ivar ShowcaseChangeDownloadPolicyDetails.new_value:
+        New Dropbox Showcase download policy.
+    :ivar ShowcaseChangeDownloadPolicyDetails.previous_value:
+        Previous Dropbox Showcase download policy.
     """
 
     __slots__ = [
@@ -83789,10 +84574,10 @@ class ShowcaseChangeEnabledPolicyDetails(bb.Struct):
     """
     Enabled/disabled Dropbox Showcase for team.
 
-    :ivar team_log.ShowcaseChangeEnabledPolicyDetails.new_value: New Dropbox
-        Showcase policy.
-    :ivar team_log.ShowcaseChangeEnabledPolicyDetails.previous_value: Previous
-        Dropbox Showcase policy.
+    :ivar ShowcaseChangeEnabledPolicyDetails.new_value:
+        New Dropbox Showcase policy.
+    :ivar ShowcaseChangeEnabledPolicyDetails.previous_value:
+        Previous Dropbox Showcase policy.
     """
 
     __slots__ = [
@@ -83849,9 +84634,9 @@ class ShowcaseChangeExternalSharingPolicyDetails(bb.Struct):
     """
     Enabled/disabled sharing Dropbox Showcase externally for team.
 
-    :ivar team_log.ShowcaseChangeExternalSharingPolicyDetails.new_value: New
-        Dropbox Showcase external sharing policy.
-    :ivar team_log.ShowcaseChangeExternalSharingPolicyDetails.previous_value:
+    :ivar ShowcaseChangeExternalSharingPolicyDetails.new_value:
+        New Dropbox Showcase external sharing policy.
+    :ivar ShowcaseChangeExternalSharingPolicyDetails.previous_value:
         Previous Dropbox Showcase external sharing policy.
     """
 
@@ -83909,7 +84694,8 @@ class ShowcaseCreatedDetails(bb.Struct):
     """
     Created showcase.
 
-    :ivar team_log.ShowcaseCreatedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseCreatedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -83958,9 +84744,10 @@ class ShowcaseDeleteCommentDetails(bb.Struct):
     """
     Deleted showcase comment.
 
-    :ivar team_log.ShowcaseDeleteCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcaseDeleteCommentDetails.comment_text: Comment text.
+    :ivar ShowcaseDeleteCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcaseDeleteCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -84017,9 +84804,10 @@ class ShowcaseDocumentLogInfo(bb.Struct):
     """
     Showcase document's logged information.
 
-    :ivar team_log.ShowcaseDocumentLogInfo.showcase_id: Showcase document Id.
-    :ivar team_log.ShowcaseDocumentLogInfo.showcase_title: Showcase document
-        title.
+    :ivar ShowcaseDocumentLogInfo.showcase_id:
+        Showcase document Id.
+    :ivar ShowcaseDocumentLogInfo.showcase_title:
+        Showcase document title.
     """
 
     __slots__ = [
@@ -84101,9 +84889,10 @@ class ShowcaseEditCommentDetails(bb.Struct):
     """
     Edited showcase comment.
 
-    :ivar team_log.ShowcaseEditCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcaseEditCommentDetails.comment_text: Comment text.
+    :ivar ShowcaseEditCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcaseEditCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -84160,7 +84949,8 @@ class ShowcaseEditedDetails(bb.Struct):
     """
     Edited showcase.
 
-    :ivar team_log.ShowcaseEditedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseEditedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84301,7 +85091,8 @@ class ShowcaseFileAddedDetails(bb.Struct):
     """
     Added file to showcase.
 
-    :ivar team_log.ShowcaseFileAddedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseFileAddedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84350,10 +85141,10 @@ class ShowcaseFileDownloadDetails(bb.Struct):
     """
     Downloaded file from showcase.
 
-    :ivar team_log.ShowcaseFileDownloadDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcaseFileDownloadDetails.download_type: Showcase download
-        type.
+    :ivar ShowcaseFileDownloadDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcaseFileDownloadDetails.download_type:
+        Showcase download type.
     """
 
     __slots__ = [
@@ -84410,8 +85201,8 @@ class ShowcaseFileRemovedDetails(bb.Struct):
     """
     Removed file from showcase.
 
-    :ivar team_log.ShowcaseFileRemovedDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseFileRemovedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84460,7 +85251,8 @@ class ShowcaseFileViewDetails(bb.Struct):
     """
     Viewed file in showcase.
 
-    :ivar team_log.ShowcaseFileViewDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseFileViewDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84509,8 +85301,8 @@ class ShowcasePermanentlyDeletedDetails(bb.Struct):
     """
     Permanently deleted showcase.
 
-    :ivar team_log.ShowcasePermanentlyDeletedDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcasePermanentlyDeletedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84559,9 +85351,10 @@ class ShowcasePostCommentDetails(bb.Struct):
     """
     Added showcase comment.
 
-    :ivar team_log.ShowcasePostCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcasePostCommentDetails.comment_text: Comment text.
+    :ivar ShowcasePostCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcasePostCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -84618,8 +85411,8 @@ class ShowcaseRemoveMemberDetails(bb.Struct):
     """
     Removed member from showcase.
 
-    :ivar team_log.ShowcaseRemoveMemberDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseRemoveMemberDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84668,7 +85461,8 @@ class ShowcaseRenamedDetails(bb.Struct):
     """
     Renamed showcase.
 
-    :ivar team_log.ShowcaseRenamedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseRenamedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84717,8 +85511,8 @@ class ShowcaseRequestAccessDetails(bb.Struct):
     """
     Requested access to showcase.
 
-    :ivar team_log.ShowcaseRequestAccessDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseRequestAccessDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84767,9 +85561,10 @@ class ShowcaseResolveCommentDetails(bb.Struct):
     """
     Resolved showcase comment.
 
-    :ivar team_log.ShowcaseResolveCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcaseResolveCommentDetails.comment_text: Comment text.
+    :ivar ShowcaseResolveCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcaseResolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -84826,7 +85621,8 @@ class ShowcaseRestoredDetails(bb.Struct):
     """
     Unarchived showcase.
 
-    :ivar team_log.ShowcaseRestoredDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseRestoredDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84875,8 +85671,8 @@ class ShowcaseTrashedDeprecatedDetails(bb.Struct):
     """
     Deleted showcase (old version).
 
-    :ivar team_log.ShowcaseTrashedDeprecatedDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseTrashedDeprecatedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84925,7 +85721,8 @@ class ShowcaseTrashedDetails(bb.Struct):
     """
     Deleted showcase.
 
-    :ivar team_log.ShowcaseTrashedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseTrashedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -84974,9 +85771,10 @@ class ShowcaseUnresolveCommentDetails(bb.Struct):
     """
     Unresolved showcase comment.
 
-    :ivar team_log.ShowcaseUnresolveCommentDetails.event_uuid: Event unique
-        identifier.
-    :ivar team_log.ShowcaseUnresolveCommentDetails.comment_text: Comment text.
+    :ivar ShowcaseUnresolveCommentDetails.event_uuid:
+        Event unique identifier.
+    :ivar ShowcaseUnresolveCommentDetails.comment_text:
+        Comment text.
     """
 
     __slots__ = [
@@ -85033,8 +85831,8 @@ class ShowcaseUntrashedDeprecatedDetails(bb.Struct):
     """
     Restored showcase (old version).
 
-    :ivar team_log.ShowcaseUntrashedDeprecatedDetails.event_uuid: Event unique
-        identifier.
+    :ivar ShowcaseUntrashedDeprecatedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -85083,7 +85881,8 @@ class ShowcaseUntrashedDetails(bb.Struct):
     """
     Restored showcase.
 
-    :ivar team_log.ShowcaseUntrashedDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseUntrashedDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -85132,7 +85931,8 @@ class ShowcaseViewDetails(bb.Struct):
     """
     Viewed showcase.
 
-    :ivar team_log.ShowcaseViewDetails.event_uuid: Event unique identifier.
+    :ivar ShowcaseViewDetails.event_uuid:
+        Event unique identifier.
     """
 
     __slots__ = [
@@ -85237,8 +86037,10 @@ class SignExternalSharingPolicyChangedDetails(bb.Struct):
     """
     Changed Signatures external sharing policy for team.
 
-    :ivar team_log.SignExternalSharingPolicyChangedDetails.new_value: To.
-    :ivar team_log.SignExternalSharingPolicyChangedDetails.previous_value: From.
+    :ivar SignExternalSharingPolicyChangedDetails.new_value:
+        To.
+    :ivar SignExternalSharingPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -85375,10 +86177,10 @@ class SignSignatureRequestCanceledDetails(bb.Struct):
     """
     Canceled signature request.
 
-    :ivar team_log.SignSignatureRequestCanceledDetails.recipient: The recipient
-        of the signature request.
-    :ivar team_log.SignSignatureRequestCanceledDetails.file_name: The name of
-        the related file.
+    :ivar SignSignatureRequestCanceledDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestCanceledDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85435,10 +86237,10 @@ class SignSignatureRequestCompletedDetails(bb.Struct):
     """
     Completed signature request.
 
-    :ivar team_log.SignSignatureRequestCompletedDetails.recipient: The recipient
-        of the signature request.
-    :ivar team_log.SignSignatureRequestCompletedDetails.file_name: The name of
-        the related file.
+    :ivar SignSignatureRequestCompletedDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestCompletedDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85495,10 +86297,10 @@ class SignSignatureRequestDeclinedDetails(bb.Struct):
     """
     Declined signature request.
 
-    :ivar team_log.SignSignatureRequestDeclinedDetails.recipient: The recipient
-        of the signature request.
-    :ivar team_log.SignSignatureRequestDeclinedDetails.file_name: The name of
-        the related file.
+    :ivar SignSignatureRequestDeclinedDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestDeclinedDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85555,10 +86357,10 @@ class SignSignatureRequestOpenedDetails(bb.Struct):
     """
     Opened signature request.
 
-    :ivar team_log.SignSignatureRequestOpenedDetails.recipient: The recipient of
-        the signature request.
-    :ivar team_log.SignSignatureRequestOpenedDetails.file_name: The name of the
-        related file.
+    :ivar SignSignatureRequestOpenedDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestOpenedDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85615,10 +86417,10 @@ class SignSignatureRequestReminderSentDetails(bb.Struct):
     """
     Sent signature request reminder.
 
-    :ivar team_log.SignSignatureRequestReminderSentDetails.recipient: The
-        recipient of the signature request.
-    :ivar team_log.SignSignatureRequestReminderSentDetails.file_name: The name
-        of the related file.
+    :ivar SignSignatureRequestReminderSentDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestReminderSentDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85675,10 +86477,10 @@ class SignSignatureRequestSentDetails(bb.Struct):
     """
     Sent signature request.
 
-    :ivar team_log.SignSignatureRequestSentDetails.recipient: The recipient of
-        the signature request.
-    :ivar team_log.SignSignatureRequestSentDetails.file_name: The name of the
-        related file.
+    :ivar SignSignatureRequestSentDetails.recipient:
+        The recipient of the signature request.
+    :ivar SignSignatureRequestSentDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85735,10 +86537,10 @@ class SignTemplateCreatedDetails(bb.Struct):
     """
     Created template.
 
-    :ivar team_log.SignTemplateCreatedDetails.access_level: The access level of
-        the template.
-    :ivar team_log.SignTemplateCreatedDetails.file_name: The name of the related
-        file.
+    :ivar SignTemplateCreatedDetails.access_level:
+        The access level of the template.
+    :ivar SignTemplateCreatedDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85795,9 +86597,9 @@ class SignTemplateCreationPermissionChangedDetails(bb.Struct):
     """
     Changed template creation permission.
 
-    :ivar team_log.SignTemplateCreationPermissionChangedDetails.new_value: New
-        template creation permission policy.
-    :ivar team_log.SignTemplateCreationPermissionChangedDetails.previous_value:
+    :ivar SignTemplateCreationPermissionChangedDetails.new_value:
+        New template creation permission policy.
+    :ivar SignTemplateCreationPermissionChangedDetails.previous_value:
         Previous template creation permission policy.
     """
 
@@ -85901,10 +86703,10 @@ class SignTemplateSharedDetails(bb.Struct):
     """
     Shared template.
 
-    :ivar team_log.SignTemplateSharedDetails.access_level: The access level of
-        the template.
-    :ivar team_log.SignTemplateSharedDetails.file_name: The name of the related
-        file.
+    :ivar SignTemplateSharedDetails.access_level:
+        The access level of the template.
+    :ivar SignTemplateSharedDetails.file_name:
+        The name of the related file.
     """
 
     __slots__ = [
@@ -85961,10 +86763,10 @@ class SmartSyncChangePolicyDetails(bb.Struct):
     """
     Changed default Smart Sync setting for team members.
 
-    :ivar team_log.SmartSyncChangePolicyDetails.new_value: New smart sync
-        policy.
-    :ivar team_log.SmartSyncChangePolicyDetails.previous_value: Previous smart
-        sync policy.
+    :ivar SmartSyncChangePolicyDetails.new_value:
+        New smart sync policy.
+    :ivar SmartSyncChangePolicyDetails.previous_value:
+        Previous smart sync policy.
     """
 
     __slots__ = [
@@ -86061,10 +86863,10 @@ class SmartSyncNotOptOutDetails(bb.Struct):
     """
     Opted team into Smart Sync.
 
-    :ivar team_log.SmartSyncNotOptOutDetails.previous_value: Previous Smart Sync
-        opt out policy.
-    :ivar team_log.SmartSyncNotOptOutDetails.new_value: New Smart Sync opt out
-        policy.
+    :ivar SmartSyncNotOptOutDetails.previous_value:
+        Previous Smart Sync opt out policy.
+    :ivar SmartSyncNotOptOutDetails.new_value:
+        New Smart Sync opt out policy.
     """
 
     __slots__ = [
@@ -86121,10 +86923,10 @@ class SmartSyncOptOutDetails(bb.Struct):
     """
     Opted team out of Smart Sync.
 
-    :ivar team_log.SmartSyncOptOutDetails.previous_value: Previous Smart Sync
-        opt out policy.
-    :ivar team_log.SmartSyncOptOutDetails.new_value: New Smart Sync opt out
-        policy.
+    :ivar SmartSyncOptOutDetails.previous_value:
+        Previous Smart Sync opt out policy.
+    :ivar SmartSyncOptOutDetails.new_value:
+        New Smart Sync opt out policy.
     """
 
     __slots__ = [
@@ -86225,10 +87027,10 @@ class SmarterSmartSyncPolicyChangedDetails(bb.Struct):
     """
     Changed automatic Smart Sync setting for team.
 
-    :ivar team_log.SmarterSmartSyncPolicyChangedDetails.previous_value: Previous
-        automatic Smart Sync setting.
-    :ivar team_log.SmarterSmartSyncPolicyChangedDetails.new_value: New automatic
-        Smart Sync setting.
+    :ivar SmarterSmartSyncPolicyChangedDetails.previous_value:
+        Previous automatic Smart Sync setting.
+    :ivar SmarterSmartSyncPolicyChangedDetails.new_value:
+        New automatic Smart Sync setting.
     """
 
     __slots__ = [
@@ -86395,8 +87197,8 @@ class SsoAddCertDetails(bb.Struct):
     """
     Added X.509 certificate for SSO.
 
-    :ivar team_log.SsoAddCertDetails.certificate_details: SSO certificate
-        details.
+    :ivar SsoAddCertDetails.certificate_details:
+        SSO certificate details.
     """
 
     __slots__ = [
@@ -86445,8 +87247,8 @@ class SsoAddLoginUrlDetails(bb.Struct):
     """
     Added sign-in URL for SSO.
 
-    :ivar team_log.SsoAddLoginUrlDetails.new_value: New single sign-on login
-        URL.
+    :ivar SsoAddLoginUrlDetails.new_value:
+        New single sign-on login URL.
     """
 
     __slots__ = [
@@ -86495,8 +87297,8 @@ class SsoAddLogoutUrlDetails(bb.Struct):
     """
     Added sign-out URL for SSO.
 
-    :ivar team_log.SsoAddLogoutUrlDetails.new_value: New single sign-on logout
-        URL.
+    :ivar SsoAddLogoutUrlDetails.new_value:
+        New single sign-on logout URL.
     """
 
     __slots__ = [
@@ -86545,10 +87347,11 @@ class SsoChangeCertDetails(bb.Struct):
     """
     Changed X.509 certificate for SSO.
 
-    :ivar team_log.SsoChangeCertDetails.previous_certificate_details: Previous
-        SSO certificate details. Might be missing due to historical data gap.
-    :ivar team_log.SsoChangeCertDetails.new_certificate_details: New SSO
-        certificate details.
+    :ivar SsoChangeCertDetails.previous_certificate_details:
+        Previous SSO certificate details. Might be missing due to historical
+        data gap.
+    :ivar SsoChangeCertDetails.new_certificate_details:
+        New SSO certificate details.
     """
 
     __slots__ = [
@@ -86605,10 +87408,10 @@ class SsoChangeLoginUrlDetails(bb.Struct):
     """
     Changed sign-in URL for SSO.
 
-    :ivar team_log.SsoChangeLoginUrlDetails.previous_value: Previous single
-        sign-on login URL.
-    :ivar team_log.SsoChangeLoginUrlDetails.new_value: New single sign-on login
-        URL.
+    :ivar SsoChangeLoginUrlDetails.previous_value:
+        Previous single sign-on login URL.
+    :ivar SsoChangeLoginUrlDetails.new_value:
+        New single sign-on login URL.
     """
 
     __slots__ = [
@@ -86665,10 +87468,11 @@ class SsoChangeLogoutUrlDetails(bb.Struct):
     """
     Changed sign-out URL for SSO.
 
-    :ivar team_log.SsoChangeLogoutUrlDetails.previous_value: Previous single
-        sign-on logout URL. Might be missing due to historical data gap.
-    :ivar team_log.SsoChangeLogoutUrlDetails.new_value: New single sign-on
-        logout URL.
+    :ivar SsoChangeLogoutUrlDetails.previous_value:
+        Previous single sign-on logout URL. Might be missing due to historical
+        data gap.
+    :ivar SsoChangeLogoutUrlDetails.new_value:
+        New single sign-on logout URL.
     """
 
     __slots__ = [
@@ -86725,9 +87529,11 @@ class SsoChangePolicyDetails(bb.Struct):
     """
     Changed single sign-on setting for team.
 
-    :ivar team_log.SsoChangePolicyDetails.new_value: New single sign-on policy.
-    :ivar team_log.SsoChangePolicyDetails.previous_value: Previous single
-        sign-on policy. Might be missing due to historical data gap.
+    :ivar SsoChangePolicyDetails.new_value:
+        New single sign-on policy.
+    :ivar SsoChangePolicyDetails.previous_value:
+        Previous single sign-on policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -86784,10 +87590,10 @@ class SsoChangeSamlIdentityModeDetails(bb.Struct):
     """
     Changed SAML identity mode for SSO.
 
-    :ivar team_log.SsoChangeSamlIdentityModeDetails.previous_value: Previous
-        single sign-on identity mode.
-    :ivar team_log.SsoChangeSamlIdentityModeDetails.new_value: New single
-        sign-on identity mode.
+    :ivar SsoChangeSamlIdentityModeDetails.previous_value:
+        Previous single sign-on identity mode.
+    :ivar SsoChangeSamlIdentityModeDetails.new_value:
+        New single sign-on identity mode.
     """
 
     __slots__ = [
@@ -86844,7 +87650,8 @@ class SsoErrorDetails(bb.Struct):
     """
     Failed to sign in via SSO.
 
-    :ivar team_log.SsoErrorDetails.error_details: Error details.
+    :ivar SsoErrorDetails.error_details:
+        Error details.
     """
 
     __slots__ = [
@@ -86933,8 +87740,8 @@ class SsoRemoveLoginUrlDetails(bb.Struct):
     """
     Removed sign-in URL for SSO.
 
-    :ivar team_log.SsoRemoveLoginUrlDetails.previous_value: Previous single
-        sign-on login URL.
+    :ivar SsoRemoveLoginUrlDetails.previous_value:
+        Previous single sign-on login URL.
     """
 
     __slots__ = [
@@ -86983,8 +87790,8 @@ class SsoRemoveLogoutUrlDetails(bb.Struct):
     """
     Removed sign-out URL for SSO.
 
-    :ivar team_log.SsoRemoveLogoutUrlDetails.previous_value: Previous single
-        sign-on logout URL.
+    :ivar SsoRemoveLogoutUrlDetails.previous_value:
+        Previous single sign-on logout URL.
     """
 
     __slots__ = [
@@ -87090,9 +87897,9 @@ class StackCrossTeamAccessPolicyChangedDetails(bb.Struct):
     """
     Changed cross-team Stack access policy for team.
 
-    :ivar team_log.StackCrossTeamAccessPolicyChangedDetails.new_value: New
-        cross-team Stack access policy.
-    :ivar team_log.StackCrossTeamAccessPolicyChangedDetails.previous_value:
+    :ivar StackCrossTeamAccessPolicyChangedDetails.new_value:
+        New cross-team Stack access policy.
+    :ivar StackCrossTeamAccessPolicyChangedDetails.previous_value:
         Previous cross-team Stack access policy. Might be missing due to
         historical data gap.
     """
@@ -87151,8 +87958,7 @@ class StartedEnterpriseAdminSessionDetails(bb.Struct):
     """
     Started enterprise admin session.
 
-    :ivar
-        team_log.StartedEnterpriseAdminSessionDetails.federation_extra_details:
+    :ivar StartedEnterpriseAdminSessionDetails.federation_extra_details:
         More information about the organization or team.
     """
 
@@ -87202,9 +88008,10 @@ class TeamActivityCreateReportDetails(bb.Struct):
     """
     Created team activity report.
 
-    :ivar team_log.TeamActivityCreateReportDetails.start_date: Report start
-        date.
-    :ivar team_log.TeamActivityCreateReportDetails.end_date: Report end date.
+    :ivar TeamActivityCreateReportDetails.start_date:
+        Report start date.
+    :ivar TeamActivityCreateReportDetails.end_date:
+        Report end date.
     """
 
     __slots__ = [
@@ -87239,8 +88046,8 @@ class TeamActivityCreateReportFailDetails(bb.Struct):
     """
     Couldn't generate team activity report.
 
-    :ivar team_log.TeamActivityCreateReportFailDetails.failure_reason: Failure
-        reason.
+    :ivar TeamActivityCreateReportFailDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -87357,10 +88164,10 @@ class TeamBrandingPolicyChangedDetails(bb.Struct):
     """
     Changed team branding policy for team.
 
-    :ivar team_log.TeamBrandingPolicyChangedDetails.new_value: New team branding
-        policy.
-    :ivar team_log.TeamBrandingPolicyChangedDetails.previous_value: Previous
-        team branding policy.
+    :ivar TeamBrandingPolicyChangedDetails.new_value:
+        New team branding policy.
+    :ivar TeamBrandingPolicyChangedDetails.previous_value:
+        Previous team branding policy.
     """
 
     __slots__ = [
@@ -87417,7 +88224,8 @@ class TeamDetails(bb.Struct):
     """
     More details about the team.
 
-    :ivar team_log.TeamDetails.team: The name of the team.
+    :ivar TeamDetails.team:
+        The name of the team.
     """
 
     __slots__ = [
@@ -87444,8 +88252,8 @@ class TeamEncryptionKeyActivateKeyDetails(bb.Struct):
     """
     Activated team encryption key.
 
-    :ivar team_log.TeamEncryptionKeyActivateKeyDetails.key_management_type: Type
-        of key management.
+    :ivar TeamEncryptionKeyActivateKeyDetails.key_management_type:
+        Type of key management.
     """
 
     __slots__ = [
@@ -87814,32 +88622,34 @@ class TeamEvent(bb.Struct):
     """
     An audit log event.
 
-    :ivar team_log.TeamEvent.timestamp: The Dropbox timestamp representing when
-        the action was taken.
-    :ivar team_log.TeamEvent.event_category: The category that this type of
-        action belongs to.
-    :ivar team_log.TeamEvent.actor: The entity who actually performed the
-        action.
-    :ivar team_log.TeamEvent.origin: The origin from which the actor performed
-        the action including information about host, ip address, location,
-        session, etc. If the action was performed programmatically via the API
-        the origin represents the API client.
-    :ivar team_log.TeamEvent.involve_non_team_member: True if the action
-        involved a non team member either as the actor or as one of the affected
-        users.
-    :ivar team_log.TeamEvent.context: The user or team on whose behalf the actor
-        performed the action.
-    :ivar team_log.TeamEvent.participants: Zero or more users and/or groups that
-        are affected by the action. Note that this list doesn't include any
-        actors or users in context.
-    :ivar team_log.TeamEvent.assets: Zero or more content assets involved in the
-        action. Currently these include Dropbox files and folders but in the
-        future we might add other asset types such as Paper documents, folders,
-        projects, etc.
-    :ivar team_log.TeamEvent.event_type: The particular type of action taken.
-    :ivar team_log.TeamEvent.details: The variable event schema applicable to
-        this type of action, instantiated with respect to this particular
-        action.
+    :ivar TeamEvent.timestamp:
+        The Dropbox timestamp representing when the action was taken.
+    :ivar TeamEvent.event_category:
+        The category that this type of action belongs to.
+    :ivar TeamEvent.actor:
+        The entity who actually performed the action.
+    :ivar TeamEvent.origin:
+        The origin from which the actor performed the action including
+        information about host, ip address, location, session, etc. If the
+        action was performed programmatically via the API the origin represents
+        the API client.
+    :ivar TeamEvent.involve_non_team_member:
+        True if the action involved a non team member either as the actor or as
+        one of the affected users.
+    :ivar TeamEvent.context:
+        The user or team on whose behalf the actor performed the action.
+    :ivar TeamEvent.participants:
+        Zero or more users and/or groups that are affected by the action. Note
+        that this list doesn't include any actors or users in context.
+    :ivar TeamEvent.assets:
+        Zero or more content assets involved in the action. Currently these
+        include Dropbox files and folders but in the future we might add other
+        asset types such as Paper documents, folders, projects, etc.
+    :ivar TeamEvent.event_type:
+        The particular type of action taken.
+    :ivar TeamEvent.details:
+        The variable event schema applicable to this type of action,
+        instantiated with respect to this particular action.
     """
 
     __slots__ = [
@@ -87984,10 +88794,10 @@ class TeamExtensionsPolicyChangedDetails(bb.Struct):
     """
     Changed App Integrations setting for team.
 
-    :ivar team_log.TeamExtensionsPolicyChangedDetails.new_value: New Extensions
-        policy.
-    :ivar team_log.TeamExtensionsPolicyChangedDetails.previous_value: Previous
-        Extensions policy.
+    :ivar TeamExtensionsPolicyChangedDetails.new_value:
+        New Extensions policy.
+    :ivar TeamExtensionsPolicyChangedDetails.previous_value:
+        Previous Extensions policy.
     """
 
     __slots__ = [
@@ -88044,10 +88854,11 @@ class TeamFolderChangeStatusDetails(bb.Struct):
     """
     Changed archival status of team folder.
 
-    :ivar team_log.TeamFolderChangeStatusDetails.new_value: New team folder
-        status.
-    :ivar team_log.TeamFolderChangeStatusDetails.previous_value: Previous team
-        folder status. Might be missing due to historical data gap.
+    :ivar TeamFolderChangeStatusDetails.new_value:
+        New team folder status.
+    :ivar TeamFolderChangeStatusDetails.previous_value:
+        Previous team folder status. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -88144,8 +88955,8 @@ class TeamFolderDowngradeDetails(bb.Struct):
     """
     Downgraded team folder to regular shared folder.
 
-    :ivar team_log.TeamFolderDowngradeDetails.target_asset_index: Target asset
-        position in the Assets list.
+    :ivar TeamFolderDowngradeDetails.target_asset_index:
+        Target asset position in the Assets list.
     """
 
     __slots__ = [
@@ -88300,9 +89111,10 @@ class TeamFolderRenameDetails(bb.Struct):
     """
     Renamed active/archived team folder.
 
-    :ivar team_log.TeamFolderRenameDetails.previous_folder_name: Previous folder
-        name.
-    :ivar team_log.TeamFolderRenameDetails.new_folder_name: New folder name.
+    :ivar TeamFolderRenameDetails.previous_folder_name:
+        Previous folder name.
+    :ivar TeamFolderRenameDetails.new_folder_name:
+        New folder name.
     """
 
     __slots__ = [
@@ -88415,11 +89227,10 @@ class TeamFolderSpaceLimitsChangeCapsTypeDetails(bb.Struct):
     """
     Changed team folder space limit enforcement type.
 
-    :ivar
-        team_log.TeamFolderSpaceLimitsChangeCapsTypeDetails.previous_caps_type:
+    :ivar TeamFolderSpaceLimitsChangeCapsTypeDetails.previous_caps_type:
         Previous enforcement type.
-    :ivar team_log.TeamFolderSpaceLimitsChangeCapsTypeDetails.new_caps_type: New
-        enforcement type.
+    :ivar TeamFolderSpaceLimitsChangeCapsTypeDetails.new_caps_type:
+        New enforcement type.
     """
 
     __slots__ = [
@@ -88476,10 +89287,10 @@ class TeamFolderSpaceLimitsChangeLimitDetails(bb.Struct):
     """
     Changed team folder space limit.
 
-    :ivar team_log.TeamFolderSpaceLimitsChangeLimitDetails.previous_limit_bytes:
+    :ivar TeamFolderSpaceLimitsChangeLimitDetails.previous_limit_bytes:
         Previous limit in bytes.
-    :ivar team_log.TeamFolderSpaceLimitsChangeLimitDetails.new_limit_bytes: New
-        limit in bytes.
+    :ivar TeamFolderSpaceLimitsChangeLimitDetails.new_limit_bytes:
+        New limit in bytes.
     """
 
     __slots__ = [
@@ -88536,11 +89347,9 @@ class TeamFolderSpaceLimitsChangeNotificationTargetDetails(bb.Struct):
     """
     Changed team folder space limit notification target.
 
-    :ivar
-        team_log.TeamFolderSpaceLimitsChangeNotificationTargetDetails.previous_target:
+    :ivar TeamFolderSpaceLimitsChangeNotificationTargetDetails.previous_target:
         Previous notification target.
-    :ivar
-        team_log.TeamFolderSpaceLimitsChangeNotificationTargetDetails.new_target:
+    :ivar TeamFolderSpaceLimitsChangeNotificationTargetDetails.new_target:
         New notification target.
     """
 
@@ -88616,8 +89425,8 @@ class TeamFoldersCreateReportFailedDetails(bb.Struct):
     """
     Couldn't generate team folders report.
 
-    :ivar team_log.TeamFoldersCreateReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar TeamFoldersCreateReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -88688,10 +89497,10 @@ class TeamInviteDetails(bb.Struct):
     """
     Details about team invites
 
-    :ivar team_log.TeamInviteDetails.invite_method: How the user was invited to
-        the team.
-    :ivar team_log.TeamInviteDetails.additional_license_purchase: True if the
-        invitation incurred an additional license purchase.
+    :ivar TeamInviteDetails.invite_method:
+        How the user was invited to the team.
+    :ivar TeamInviteDetails.additional_license_purchase:
+        True if the invitation incurred an additional license purchase.
     """
 
     __slots__ = [
@@ -88747,7 +89556,8 @@ class TeamLogInfo(bb.Struct):
     """
     Team's logged information.
 
-    :ivar team_log.TeamLogInfo.display_name: Team display name.
+    :ivar TeamLogInfo.display_name:
+        Team display name.
     """
 
     __slots__ = [
@@ -88774,11 +89584,12 @@ class TeamMemberLogInfo(UserLogInfo):
     """
     Team member's logged information.
 
-    :ivar team_log.TeamMemberLogInfo.team_member_id: Team member ID.
-    :ivar team_log.TeamMemberLogInfo.member_external_id: Team member external
-        ID.
-    :ivar team_log.TeamMemberLogInfo.team: Details about this user&#x2019s team
-        for enterprise event.
+    :ivar TeamMemberLogInfo.team_member_id:
+        Team member ID.
+    :ivar TeamMemberLogInfo.member_external_id:
+        Team member external ID.
+    :ivar TeamMemberLogInfo.team:
+        Details about this user&#x2019s team for enterprise event.
     """
 
     __slots__ = [
@@ -88884,9 +89695,9 @@ class TeamMemberStorageRequestPolicyChangedDetails(bb.Struct):
     """
     Changed team member storage request policy for team.
 
-    :ivar team_log.TeamMemberStorageRequestPolicyChangedDetails.new_value: New
-        team member storage request policy.
-    :ivar team_log.TeamMemberStorageRequestPolicyChangedDetails.previous_value:
+    :ivar TeamMemberStorageRequestPolicyChangedDetails.new_value:
+        New team member storage request policy.
+    :ivar TeamMemberStorageRequestPolicyChangedDetails.previous_value:
         Previous team member storage request policy. Might be missing due to
         historical data gap.
     """
@@ -88999,8 +89810,8 @@ class TeamMergeFromDetails(bb.Struct):
     """
     Merged another team into this team.
 
-    :ivar team_log.TeamMergeFromDetails.team_name: The name of the team that was
-        merged into this team.
+    :ivar TeamMergeFromDetails.team_name:
+        The name of the team that was merged into this team.
     """
 
     __slots__ = [
@@ -89049,7 +89860,7 @@ class TeamMergeRequestAcceptedDetails(bb.Struct):
     """
     Accepted a team merge request.
 
-    :ivar team_log.TeamMergeRequestAcceptedDetails.request_accepted_details:
+    :ivar TeamMergeRequestAcceptedDetails.request_accepted_details:
         Team merge request acceptance details.
     """
 
@@ -89081,12 +89892,12 @@ class TeamMergeRequestAcceptedExtraDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar PrimaryTeamRequestAcceptedDetails
-        TeamMergeRequestAcceptedExtraDetails.primary_team: Team merge request
-        accepted details shown to the primary team
-    :ivar SecondaryTeamRequestAcceptedDetails
-        TeamMergeRequestAcceptedExtraDetails.secondary_team: Team merge request
-        accepted details shown to the secondary team
+    :ivar TeamMergeRequestAcceptedExtraDetails.primary_team:
+        Team merge request accepted details shown to the primary team
+    :vartype TeamMergeRequestAcceptedExtraDetails.primary_team: PrimaryTeamRequestAcceptedDetails
+    :ivar TeamMergeRequestAcceptedExtraDetails.secondary_team:
+        Team merge request accepted details shown to the secondary team
+    :vartype TeamMergeRequestAcceptedExtraDetails.secondary_team: SecondaryTeamRequestAcceptedDetails
     """
 
     _catch_all = 'other'
@@ -89172,10 +89983,9 @@ class TeamMergeRequestAcceptedShownToPrimaryTeamDetails(bb.Struct):
     """
     Accepted a team merge request.
 
-    :ivar
-        team_log.TeamMergeRequestAcceptedShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestAcceptedShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestAcceptedShownToPrimaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestAcceptedShownToPrimaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89233,10 +90043,9 @@ class TeamMergeRequestAcceptedShownToSecondaryTeamDetails(bb.Struct):
     """
     Accepted a team merge request.
 
-    :ivar
-        team_log.TeamMergeRequestAcceptedShownToSecondaryTeamDetails.primary_team:
+    :ivar TeamMergeRequestAcceptedShownToSecondaryTeamDetails.primary_team:
         The primary team name.
-    :ivar team_log.TeamMergeRequestAcceptedShownToSecondaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestAcceptedShownToSecondaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89316,8 +90125,8 @@ class TeamMergeRequestAutoCanceledDetails(bb.Struct):
     """
     Automatically canceled team merge request.
 
-    :ivar team_log.TeamMergeRequestAutoCanceledDetails.details: The cancellation
-        reason.
+    :ivar TeamMergeRequestAutoCanceledDetails.details:
+        The cancellation reason.
     """
 
     __slots__ = [
@@ -89366,7 +90175,7 @@ class TeamMergeRequestCanceledDetails(bb.Struct):
     """
     Canceled a team merge request.
 
-    :ivar team_log.TeamMergeRequestCanceledDetails.request_canceled_details:
+    :ivar TeamMergeRequestCanceledDetails.request_canceled_details:
         Team merge request cancellation details.
     """
 
@@ -89398,12 +90207,12 @@ class TeamMergeRequestCanceledExtraDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar PrimaryTeamRequestCanceledDetails
-        TeamMergeRequestCanceledExtraDetails.primary_team: Team merge request
-        cancellation details shown to the primary team
-    :ivar SecondaryTeamRequestCanceledDetails
-        TeamMergeRequestCanceledExtraDetails.secondary_team: Team merge request
-        cancellation details shown to the secondary team
+    :ivar TeamMergeRequestCanceledExtraDetails.primary_team:
+        Team merge request cancellation details shown to the primary team
+    :vartype TeamMergeRequestCanceledExtraDetails.primary_team: PrimaryTeamRequestCanceledDetails
+    :ivar TeamMergeRequestCanceledExtraDetails.secondary_team:
+        Team merge request cancellation details shown to the secondary team
+    :vartype TeamMergeRequestCanceledExtraDetails.secondary_team: SecondaryTeamRequestCanceledDetails
     """
 
     _catch_all = 'other'
@@ -89489,10 +90298,9 @@ class TeamMergeRequestCanceledShownToPrimaryTeamDetails(bb.Struct):
     """
     Canceled a team merge request.
 
-    :ivar
-        team_log.TeamMergeRequestCanceledShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestCanceledShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestCanceledShownToPrimaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestCanceledShownToPrimaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89550,9 +90358,9 @@ class TeamMergeRequestCanceledShownToSecondaryTeamDetails(bb.Struct):
     """
     Canceled a team merge request.
 
-    :ivar team_log.TeamMergeRequestCanceledShownToSecondaryTeamDetails.sent_to:
+    :ivar TeamMergeRequestCanceledShownToSecondaryTeamDetails.sent_to:
         The email of the primary team admin that the request was sent to.
-    :ivar team_log.TeamMergeRequestCanceledShownToSecondaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestCanceledShownToSecondaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89632,8 +90440,8 @@ class TeamMergeRequestExpiredDetails(bb.Struct):
     """
     Team merge request expired.
 
-    :ivar team_log.TeamMergeRequestExpiredDetails.request_expired_details: Team
-        merge request expiration details.
+    :ivar TeamMergeRequestExpiredDetails.request_expired_details:
+        Team merge request expiration details.
     """
 
     __slots__ = [
@@ -89664,12 +90472,12 @@ class TeamMergeRequestExpiredExtraDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar PrimaryTeamRequestExpiredDetails
-        TeamMergeRequestExpiredExtraDetails.primary_team: Team merge request
-        canceled details shown to the primary team
-    :ivar SecondaryTeamRequestExpiredDetails
-        TeamMergeRequestExpiredExtraDetails.secondary_team: Team merge request
-        canceled details shown to the secondary team
+    :ivar TeamMergeRequestExpiredExtraDetails.primary_team:
+        Team merge request canceled details shown to the primary team
+    :vartype TeamMergeRequestExpiredExtraDetails.primary_team: PrimaryTeamRequestExpiredDetails
+    :ivar TeamMergeRequestExpiredExtraDetails.secondary_team:
+        Team merge request canceled details shown to the secondary team
+    :vartype TeamMergeRequestExpiredExtraDetails.secondary_team: SecondaryTeamRequestExpiredDetails
     """
 
     _catch_all = 'other'
@@ -89755,11 +90563,10 @@ class TeamMergeRequestExpiredShownToPrimaryTeamDetails(bb.Struct):
     """
     Team merge request expired.
 
-    :ivar
-        team_log.TeamMergeRequestExpiredShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestExpiredShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestExpiredShownToPrimaryTeamDetails.sent_by: The
-        name of the secondary team admin who sent the request originally.
+    :ivar TeamMergeRequestExpiredShownToPrimaryTeamDetails.sent_by:
+        The name of the secondary team admin who sent the request originally.
     """
 
     __slots__ = [
@@ -89816,7 +90623,7 @@ class TeamMergeRequestExpiredShownToSecondaryTeamDetails(bb.Struct):
     """
     Team merge request expired.
 
-    :ivar team_log.TeamMergeRequestExpiredShownToSecondaryTeamDetails.sent_to:
+    :ivar TeamMergeRequestExpiredShownToSecondaryTeamDetails.sent_to:
         The email of the primary team admin the request was sent to.
     """
 
@@ -89888,10 +90695,9 @@ class TeamMergeRequestRejectedShownToPrimaryTeamDetails(bb.Struct):
     """
     Rejected a team merge request.
 
-    :ivar
-        team_log.TeamMergeRequestRejectedShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestRejectedShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestRejectedShownToPrimaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestRejectedShownToPrimaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89949,7 +90755,7 @@ class TeamMergeRequestRejectedShownToSecondaryTeamDetails(bb.Struct):
     """
     Rejected a team merge request.
 
-    :ivar team_log.TeamMergeRequestRejectedShownToSecondaryTeamDetails.sent_by:
+    :ivar TeamMergeRequestRejectedShownToSecondaryTeamDetails.sent_by:
         The name of the secondary team admin who sent the request originally.
     """
 
@@ -89999,7 +90805,7 @@ class TeamMergeRequestReminderDetails(bb.Struct):
     """
     Sent a team merge request reminder.
 
-    :ivar team_log.TeamMergeRequestReminderDetails.request_reminder_details:
+    :ivar TeamMergeRequestReminderDetails.request_reminder_details:
         Team merge request reminder details.
     """
 
@@ -90031,12 +90837,12 @@ class TeamMergeRequestReminderExtraDetails(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar PrimaryTeamRequestReminderDetails
-        TeamMergeRequestReminderExtraDetails.primary_team: Team merge request
-        reminder details shown to the primary team
-    :ivar SecondaryTeamRequestReminderDetails
-        TeamMergeRequestReminderExtraDetails.secondary_team: Team merge request
-        reminder details shown to the secondary team
+    :ivar TeamMergeRequestReminderExtraDetails.primary_team:
+        Team merge request reminder details shown to the primary team
+    :vartype TeamMergeRequestReminderExtraDetails.primary_team: PrimaryTeamRequestReminderDetails
+    :ivar TeamMergeRequestReminderExtraDetails.secondary_team:
+        Team merge request reminder details shown to the secondary team
+    :vartype TeamMergeRequestReminderExtraDetails.secondary_team: SecondaryTeamRequestReminderDetails
     """
 
     _catch_all = 'other'
@@ -90122,10 +90928,9 @@ class TeamMergeRequestReminderShownToPrimaryTeamDetails(bb.Struct):
     """
     Sent a team merge request reminder.
 
-    :ivar
-        team_log.TeamMergeRequestReminderShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestReminderShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestReminderShownToPrimaryTeamDetails.sent_to:
+    :ivar TeamMergeRequestReminderShownToPrimaryTeamDetails.sent_to:
         The name of the primary team admin the request was sent to.
     """
 
@@ -90183,7 +90988,7 @@ class TeamMergeRequestReminderShownToSecondaryTeamDetails(bb.Struct):
     """
     Sent a team merge request reminder.
 
-    :ivar team_log.TeamMergeRequestReminderShownToSecondaryTeamDetails.sent_to:
+    :ivar TeamMergeRequestReminderShownToSecondaryTeamDetails.sent_to:
         The email of the primary team admin the request was sent to.
     """
 
@@ -90255,8 +91060,8 @@ class TeamMergeRequestRevokedDetails(bb.Struct):
     """
     Canceled the team merge.
 
-    :ivar team_log.TeamMergeRequestRevokedDetails.team: The name of the other
-        team.
+    :ivar TeamMergeRequestRevokedDetails.team:
+        The name of the other team.
     """
 
     __slots__ = [
@@ -90305,10 +91110,10 @@ class TeamMergeRequestSentShownToPrimaryTeamDetails(bb.Struct):
     """
     Requested to merge their Dropbox team into yours.
 
-    :ivar team_log.TeamMergeRequestSentShownToPrimaryTeamDetails.secondary_team:
+    :ivar TeamMergeRequestSentShownToPrimaryTeamDetails.secondary_team:
         The secondary team name.
-    :ivar team_log.TeamMergeRequestSentShownToPrimaryTeamDetails.sent_to: The
-        name of the primary team admin the request was sent to.
+    :ivar TeamMergeRequestSentShownToPrimaryTeamDetails.sent_to:
+        The name of the primary team admin the request was sent to.
     """
 
     __slots__ = [
@@ -90365,8 +91170,8 @@ class TeamMergeRequestSentShownToSecondaryTeamDetails(bb.Struct):
     """
     Requested to merge your team into another Dropbox team.
 
-    :ivar team_log.TeamMergeRequestSentShownToSecondaryTeamDetails.sent_to: The
-        email of the primary team admin the request was sent to.
+    :ivar TeamMergeRequestSentShownToSecondaryTeamDetails.sent_to:
+        The email of the primary team admin the request was sent to.
     """
 
     __slots__ = [
@@ -90415,8 +91220,8 @@ class TeamMergeToDetails(bb.Struct):
     """
     Merged this team into another team.
 
-    :ivar team_log.TeamMergeToDetails.team_name: The name of the team that this
-        team was merged into.
+    :ivar TeamMergeToDetails.team_name:
+        The name of the team that this team was merged into.
     """
 
     __slots__ = [
@@ -90465,8 +91270,10 @@ class TeamName(bb.Struct):
     """
     Team name details
 
-    :ivar team_log.TeamName.team_display_name: Team's display name.
-    :ivar team_log.TeamName.team_legal_name: Team's legal name.
+    :ivar TeamName.team_display_name:
+        Team's display name.
+    :ivar TeamName.team_legal_name:
+        Team's legal name.
     """
 
     __slots__ = [
@@ -90621,9 +91428,9 @@ class TeamProfileChangeDefaultLanguageDetails(bb.Struct):
     """
     Changed default language for team.
 
-    :ivar team_log.TeamProfileChangeDefaultLanguageDetails.new_value: New team's
-        default language.
-    :ivar team_log.TeamProfileChangeDefaultLanguageDetails.previous_value:
+    :ivar TeamProfileChangeDefaultLanguageDetails.new_value:
+        New team's default language.
+    :ivar TeamProfileChangeDefaultLanguageDetails.previous_value:
         Previous team's default language.
     """
 
@@ -90721,9 +91528,10 @@ class TeamProfileChangeNameDetails(bb.Struct):
     """
     Changed team name.
 
-    :ivar team_log.TeamProfileChangeNameDetails.previous_value: Previous teams
-        name. Might be missing due to historical data gap.
-    :ivar team_log.TeamProfileChangeNameDetails.new_value: New team name.
+    :ivar TeamProfileChangeNameDetails.previous_value:
+        Previous teams name. Might be missing due to historical data gap.
+    :ivar TeamProfileChangeNameDetails.new_value:
+        New team name.
     """
 
     __slots__ = [
@@ -90906,9 +91714,9 @@ class TeamSelectiveSyncPolicyChangedDetails(bb.Struct):
     """
     Enabled/disabled Team Selective Sync for team.
 
-    :ivar team_log.TeamSelectiveSyncPolicyChangedDetails.new_value: New Team
-        Selective Sync policy.
-    :ivar team_log.TeamSelectiveSyncPolicyChangedDetails.previous_value:
+    :ivar TeamSelectiveSyncPolicyChangedDetails.new_value:
+        New Team Selective Sync policy.
+    :ivar TeamSelectiveSyncPolicyChangedDetails.previous_value:
         Previous Team Selective Sync policy.
     """
 
@@ -90966,9 +91774,10 @@ class TeamSelectiveSyncSettingsChangedDetails(bb.Struct):
     """
     Changed sync default.
 
-    :ivar team_log.TeamSelectiveSyncSettingsChangedDetails.previous_value:
+    :ivar TeamSelectiveSyncSettingsChangedDetails.previous_value:
         Previous value.
-    :ivar team_log.TeamSelectiveSyncSettingsChangedDetails.new_value: New value.
+    :ivar TeamSelectiveSyncSettingsChangedDetails.new_value:
+        New value.
     """
 
     __slots__ = [
@@ -91025,11 +91834,9 @@ class TeamSharingWhitelistSubjectsChangedDetails(bb.Struct):
     """
     Edited the approved list for sharing externally.
 
-    :ivar
-        team_log.TeamSharingWhitelistSubjectsChangedDetails.added_whitelist_subjects:
+    :ivar TeamSharingWhitelistSubjectsChangedDetails.added_whitelist_subjects:
         Domains or emails added to the approved list for sharing externally.
-    :ivar
-        team_log.TeamSharingWhitelistSubjectsChangedDetails.removed_whitelist_subjects:
+    :ivar TeamSharingWhitelistSubjectsChangedDetails.removed_whitelist_subjects:
         Domains or emails removed from the approved list for sharing externally.
     """
 
@@ -91105,8 +91912,8 @@ class TeamStorageCreateReportFailedDetails(bb.Struct):
     """
     Couldn't generate team storage report.
 
-    :ivar team_log.TeamStorageCreateReportFailedDetails.failure_reason: Failure
-        reason.
+    :ivar TeamStorageCreateReportFailedDetails.failure_reason:
+        Failure reason.
     """
 
     __slots__ = [
@@ -91337,9 +92144,10 @@ class TfaChangePolicyDetails(bb.Struct):
     """
     Changed two-factor authentication setting for team.
 
-    :ivar team_log.TfaChangePolicyDetails.new_value: New change policy.
-    :ivar team_log.TfaChangePolicyDetails.previous_value: Previous change
-        policy. Might be missing due to historical data gap.
+    :ivar TfaChangePolicyDetails.new_value:
+        New change policy.
+    :ivar TfaChangePolicyDetails.previous_value:
+        Previous change policy. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -91396,14 +92204,14 @@ class TfaChangeStatusDetails(bb.Struct):
     """
     Enabled/disabled/changed two-factor authentication setting.
 
-    :ivar team_log.TfaChangeStatusDetails.new_value: The new two factor
-        authentication configuration.
-    :ivar team_log.TfaChangeStatusDetails.previous_value: The previous two
-        factor authentication configuration. Might be missing due to historical
-        data gap.
-    :ivar team_log.TfaChangeStatusDetails.used_rescue_code: Used two factor
-        authentication rescue code. This flag is relevant when the two factor
-        authentication configuration is disabled.
+    :ivar TfaChangeStatusDetails.new_value:
+        The new two factor authentication configuration.
+    :ivar TfaChangeStatusDetails.previous_value:
+        The previous two factor authentication configuration. Might be missing
+        due to historical data gap.
+    :ivar TfaChangeStatusDetails.used_rescue_code:
+        Used two factor authentication rescue code. This flag is relevant when
+        the two factor authentication configuration is disabled.
     """
 
     __slots__ = [
@@ -91846,8 +92654,10 @@ class TopLevelContentPolicyChangedDetails(bb.Struct):
     """
     Changed top level content setting for team.
 
-    :ivar team_log.TopLevelContentPolicyChangedDetails.new_value: To.
-    :ivar team_log.TopLevelContentPolicyChangedDetails.previous_value: From.
+    :ivar TopLevelContentPolicyChangedDetails.new_value:
+        To.
+    :ivar TopLevelContentPolicyChangedDetails.previous_value:
+        From.
     """
 
     __slots__ = [
@@ -91904,10 +92714,10 @@ class TrustedNonTeamMemberLogInfo(UserLogInfo):
     """
     User that is not a member of the team but considered trusted.
 
-    :ivar team_log.TrustedNonTeamMemberLogInfo.trusted_non_team_member_type:
+    :ivar TrustedNonTeamMemberLogInfo.trusted_non_team_member_type:
         Indicates the type of the member of a trusted team.
-    :ivar team_log.TrustedNonTeamMemberLogInfo.team: Details about this user's
-        trusted team.
+    :ivar TrustedNonTeamMemberLogInfo.team:
+        Details about this user's trusted team.
     """
 
     __slots__ = [
@@ -92121,10 +92931,11 @@ class TwoAccountChangePolicyDetails(bb.Struct):
     Enabled/disabled option for members to link personal Dropbox account and
     team account to same computer.
 
-    :ivar team_log.TwoAccountChangePolicyDetails.new_value: New two account
-        policy.
-    :ivar team_log.TwoAccountChangePolicyDetails.previous_value: Previous two
-        account policy. Might be missing due to historical data gap.
+    :ivar TwoAccountChangePolicyDetails.new_value:
+        New two account policy.
+    :ivar TwoAccountChangePolicyDetails.previous_value:
+        Previous two account policy. Might be missing due to historical data
+        gap.
     """
 
     __slots__ = [
@@ -92328,10 +93139,12 @@ class UserNameLogInfo(bb.Struct):
     """
     User's name logged information
 
-    :ivar team_log.UserNameLogInfo.given_name: Given name.
-    :ivar team_log.UserNameLogInfo.surname: Surname.
-    :ivar team_log.UserNameLogInfo.locale: Locale. Might be missing due to
-        historical data gap.
+    :ivar UserNameLogInfo.given_name:
+        Given name.
+    :ivar UserNameLogInfo.surname:
+        Surname.
+    :ivar UserNameLogInfo.locale:
+        Locale. Might be missing due to historical data gap.
     """
 
     __slots__ = [
@@ -92396,7 +93209,8 @@ class UserTagsAddedDetails(bb.Struct):
     """
     Tagged a file.
 
-    :ivar team_log.UserTagsAddedDetails.values: values.
+    :ivar UserTagsAddedDetails.values:
+        values.
     """
 
     __slots__ = [
@@ -92445,7 +93259,8 @@ class UserTagsRemovedDetails(bb.Struct):
     """
     Removed tags.
 
-    :ivar team_log.UserTagsRemovedDetails.values: values.
+    :ivar UserTagsRemovedDetails.values:
+        values.
     """
 
     __slots__ = [
@@ -92494,10 +93309,10 @@ class ViewerInfoPolicyChangedDetails(bb.Struct):
     """
     Changed team policy for viewer info.
 
-    :ivar team_log.ViewerInfoPolicyChangedDetails.previous_value: Previous
-        Viewer Info policy.
-    :ivar team_log.ViewerInfoPolicyChangedDetails.new_value: New Viewer Info
-        policy.
+    :ivar ViewerInfoPolicyChangedDetails.previous_value:
+        Previous Viewer Info policy.
+    :ivar ViewerInfoPolicyChangedDetails.new_value:
+        New Viewer Info policy.
     """
 
     __slots__ = [
@@ -92600,10 +93415,10 @@ class WatermarkingPolicyChangedDetails(bb.Struct):
     """
     Changed watermarking policy for team.
 
-    :ivar team_log.WatermarkingPolicyChangedDetails.new_value: New watermarking
-        policy.
-    :ivar team_log.WatermarkingPolicyChangedDetails.previous_value: Previous
-        watermarking policy.
+    :ivar WatermarkingPolicyChangedDetails.new_value:
+        New watermarking policy.
+    :ivar WatermarkingPolicyChangedDetails.previous_value:
+        Previous watermarking policy.
     """
 
     __slots__ = [
@@ -92660,13 +93475,14 @@ class WebDeviceSessionLogInfo(DeviceSessionLogInfo):
     """
     Information on active web sessions
 
-    :ivar team_log.WebDeviceSessionLogInfo.session_info: Web session unique id.
-    :ivar team_log.WebDeviceSessionLogInfo.user_agent: Information on the
-        hosting device.
-    :ivar team_log.WebDeviceSessionLogInfo.os: Information on the hosting
-        operating system.
-    :ivar team_log.WebDeviceSessionLogInfo.browser: Information on the browser
-        used for this web session.
+    :ivar WebDeviceSessionLogInfo.session_info:
+        Web session unique id.
+    :ivar WebDeviceSessionLogInfo.user_agent:
+        Information on the hosting device.
+    :ivar WebDeviceSessionLogInfo.os:
+        Information on the hosting operating system.
+    :ivar WebDeviceSessionLogInfo.browser:
+        Information on the browser used for this web session.
     """
 
     __slots__ = [
@@ -92742,10 +93558,10 @@ class WebSessionsChangeActiveSessionLimitDetails(bb.Struct):
     """
     Changed limit on active sessions per member.
 
-    :ivar team_log.WebSessionsChangeActiveSessionLimitDetails.previous_value:
+    :ivar WebSessionsChangeActiveSessionLimitDetails.previous_value:
         Previous max number of concurrent active sessions policy.
-    :ivar team_log.WebSessionsChangeActiveSessionLimitDetails.new_value: New max
-        number of concurrent active sessions policy.
+    :ivar WebSessionsChangeActiveSessionLimitDetails.new_value:
+        New max number of concurrent active sessions policy.
     """
 
     __slots__ = [
@@ -92802,9 +93618,9 @@ class WebSessionsChangeFixedLengthPolicyDetails(bb.Struct):
     """
     Changed how long members can stay signed in to Dropbox.com.
 
-    :ivar team_log.WebSessionsChangeFixedLengthPolicyDetails.new_value: New
-        session length policy. Might be missing due to historical data gap.
-    :ivar team_log.WebSessionsChangeFixedLengthPolicyDetails.previous_value:
+    :ivar WebSessionsChangeFixedLengthPolicyDetails.new_value:
+        New session length policy. Might be missing due to historical data gap.
+    :ivar WebSessionsChangeFixedLengthPolicyDetails.previous_value:
         Previous session length policy. Might be missing due to historical data
         gap.
     """
@@ -92863,9 +93679,9 @@ class WebSessionsChangeIdleLengthPolicyDetails(bb.Struct):
     """
     Changed how long team members can be idle while signed in to Dropbox.com.
 
-    :ivar team_log.WebSessionsChangeIdleLengthPolicyDetails.new_value: New idle
-        length policy. Might be missing due to historical data gap.
-    :ivar team_log.WebSessionsChangeIdleLengthPolicyDetails.previous_value:
+    :ivar WebSessionsChangeIdleLengthPolicyDetails.new_value:
+        New idle length policy. Might be missing due to historical data gap.
+    :ivar WebSessionsChangeIdleLengthPolicyDetails.previous_value:
         Previous idle length policy. Might be missing due to historical data
         gap.
     """
@@ -92928,10 +93744,11 @@ class WebSessionsFixedLengthPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar DurationLogInfo WebSessionsFixedLengthPolicy.defined: Defined fixed
-        session length.
-    :ivar team_log.WebSessionsFixedLengthPolicy.undefined: Undefined fixed
-        session length.
+    :ivar WebSessionsFixedLengthPolicy.defined:
+        Defined fixed session length.
+    :vartype WebSessionsFixedLengthPolicy.defined: DurationLogInfo
+    :ivar WebSessionsFixedLengthPolicy.undefined:
+        Undefined fixed session length.
     """
 
     _catch_all = 'other'
@@ -93000,10 +93817,11 @@ class WebSessionsIdleLengthPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar DurationLogInfo WebSessionsIdleLengthPolicy.defined: Defined idle
-        session length.
-    :ivar team_log.WebSessionsIdleLengthPolicy.undefined: Undefined idle session
-        length.
+    :ivar WebSessionsIdleLengthPolicy.defined:
+        Defined idle session length.
+    :vartype WebSessionsIdleLengthPolicy.defined: DurationLogInfo
+    :ivar WebSessionsIdleLengthPolicy.undefined:
+        Undefined idle session length.
     """
 
     _catch_all = 'other'

--- a/dropbox/team_policies.py
+++ b/dropbox/team_policies.py
@@ -13,10 +13,10 @@ class CameraUploadsPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.CameraUploadsPolicyState.disabled: Background camera
-        uploads are disabled.
-    :ivar team_policies.CameraUploadsPolicyState.enabled: Background camera
-        uploads are allowed.
+    :ivar CameraUploadsPolicyState.disabled:
+        Background camera uploads are disabled.
+    :ivar CameraUploadsPolicyState.enabled:
+        Background camera uploads are allowed.
     """
 
     _catch_all = 'other'
@@ -62,12 +62,13 @@ class ComputerBackupPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.ComputerBackupPolicyState.disabled: Computer Backup
-        feature is disabled.
-    :ivar team_policies.ComputerBackupPolicyState.enabled: Computer Backup
-        feature is enabled.
-    :ivar team_policies.ComputerBackupPolicyState.default: Computer Backup
-        defaults to ON for SSB teams, and OFF for Enterprise teams.
+    :ivar ComputerBackupPolicyState.disabled:
+        Computer Backup feature is disabled.
+    :ivar ComputerBackupPolicyState.enabled:
+        Computer Backup feature is enabled.
+    :ivar ComputerBackupPolicyState.default:
+        Computer Backup defaults to ON for SSB teams, and OFF for Enterprise
+        teams.
     """
 
     _catch_all = 'other'
@@ -126,22 +127,22 @@ class DefaultLinkExpirationDaysPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.none: New links shared
-        outside the team default to no expiration date.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_1: New links shared
-        outside the team default to expire in one day.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_3: New links shared
-        outside the team default to expire in three days.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_7: New links shared
-        outside the team default to expire in seven days.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_30: New links shared
-        outside the team default to expire in 30 days.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_90: New links shared
-        outside the team default to expire in 90 days.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.day_180: New links
-        shared outside the team default to expire in 180 days.
-    :ivar team_policies.DefaultLinkExpirationDaysPolicy.year_1: New links shared
-        outside the team default to expire in 365 days.
+    :ivar DefaultLinkExpirationDaysPolicy.none:
+        New links shared outside the team default to no expiration date.
+    :ivar DefaultLinkExpirationDaysPolicy.day_1:
+        New links shared outside the team default to expire in one day.
+    :ivar DefaultLinkExpirationDaysPolicy.day_3:
+        New links shared outside the team default to expire in three days.
+    :ivar DefaultLinkExpirationDaysPolicy.day_7:
+        New links shared outside the team default to expire in seven days.
+    :ivar DefaultLinkExpirationDaysPolicy.day_30:
+        New links shared outside the team default to expire in 30 days.
+    :ivar DefaultLinkExpirationDaysPolicy.day_90:
+        New links shared outside the team default to expire in 90 days.
+    :ivar DefaultLinkExpirationDaysPolicy.day_180:
+        New links shared outside the team default to expire in 180 days.
+    :ivar DefaultLinkExpirationDaysPolicy.year_1:
+        New links shared outside the team default to expire in 365 days.
     """
 
     _catch_all = 'other'
@@ -247,9 +248,12 @@ class EmmState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.EmmState.disabled: Emm token is disabled.
-    :ivar team_policies.EmmState.optional: Emm token is optional.
-    :ivar team_policies.EmmState.required: Emm token is required.
+    :ivar EmmState.disabled:
+        Emm token is disabled.
+    :ivar EmmState.optional:
+        Emm token is optional.
+    :ivar EmmState.required:
+        Emm token is required.
     """
 
     _catch_all = 'other'
@@ -308,10 +312,10 @@ class EnforceLinkPasswordPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.EnforceLinkPasswordPolicy.optional: New links shared
-        outside the team do not require passwords.
-    :ivar team_policies.EnforceLinkPasswordPolicy.required: New links shared
-        outside the team require passwords.
+    :ivar EnforceLinkPasswordPolicy.optional:
+        New links shared outside the team do not require passwords.
+    :ivar EnforceLinkPasswordPolicy.required:
+        New links shared outside the team require passwords.
     """
 
     _catch_all = 'other'
@@ -357,12 +361,12 @@ class ExternalDriveBackupPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.ExternalDriveBackupPolicyState.disabled: External Drive
-        Backup feature is disabled.
-    :ivar team_policies.ExternalDriveBackupPolicyState.enabled: External Drive
-        Backup feature is enabled.
-    :ivar team_policies.ExternalDriveBackupPolicyState.default: External Drive
-        Backup default value based on team tier.
+    :ivar ExternalDriveBackupPolicyState.disabled:
+        External Drive Backup feature is disabled.
+    :ivar ExternalDriveBackupPolicyState.enabled:
+        External Drive Backup feature is enabled.
+    :ivar ExternalDriveBackupPolicyState.default:
+        External Drive Backup default value based on team tier.
     """
 
     _catch_all = 'other'
@@ -418,10 +422,10 @@ class FileLockingPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.FileLockingPolicyState.disabled: File locking feature is
-        disabled.
-    :ivar team_policies.FileLockingPolicyState.enabled: File locking feature is
-        allowed.
+    :ivar FileLockingPolicyState.disabled:
+        File locking feature is disabled.
+    :ivar FileLockingPolicyState.enabled:
+        File locking feature is allowed.
     """
 
     _catch_all = 'other'
@@ -467,14 +471,16 @@ class FileProviderMigrationPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.FileProviderMigrationPolicyState.disabled: Team admin
-        has opted out of File Provider Migration for team members.
-    :ivar team_policies.FileProviderMigrationPolicyState.enabled: Team admin has
-        not opted out of File Provider Migration for team members.
-    :ivar team_policies.FileProviderMigrationPolicyState.default: Team admin has
-        default value based on team tier.
-    :ivar team_policies.FileProviderMigrationPolicyState.immediate: Team admin
-        has chosen to do File Provider Migration immediately for the team.
+    :ivar FileProviderMigrationPolicyState.disabled:
+        Team admin has opted out of File Provider Migration for team members.
+    :ivar FileProviderMigrationPolicyState.enabled:
+        Team admin has not opted out of File Provider Migration for team
+        members.
+    :ivar FileProviderMigrationPolicyState.default:
+        Team admin has default value based on team tier.
+    :ivar FileProviderMigrationPolicyState.immediate:
+        Team admin has chosen to do File Provider Migration immediately for the
+        team.
     """
 
     _catch_all = 'other'
@@ -540,10 +546,10 @@ class GroupCreation(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.GroupCreation.admins_and_members: Team admins and
-        members can create groups.
-    :ivar team_policies.GroupCreation.admins_only: Only team admins can create
-        groups.
+    :ivar GroupCreation.admins_and_members:
+        Team admins and members can create groups.
+    :ivar GroupCreation.admins_only:
+        Only team admins can create groups.
     """
 
     _catch_all = None
@@ -579,8 +585,10 @@ class OfficeAddInPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.OfficeAddInPolicy.disabled: Office Add-In is disabled.
-    :ivar team_policies.OfficeAddInPolicy.enabled: Office Add-In is enabled.
+    :ivar OfficeAddInPolicy.disabled:
+        Office Add-In is disabled.
+    :ivar OfficeAddInPolicy.enabled:
+        Office Add-In is enabled.
     """
 
     _catch_all = 'other'
@@ -626,10 +634,11 @@ class PaperDefaultFolderPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PaperDefaultFolderPolicy.everyone_in_team: Everyone in
-        team will be the default option when creating a folder in Paper.
-    :ivar team_policies.PaperDefaultFolderPolicy.invite_only: Invite only will
-        be the default option when creating a folder in Paper.
+    :ivar PaperDefaultFolderPolicy.everyone_in_team:
+        Everyone in team will be the default option when creating a folder in
+        Paper.
+    :ivar PaperDefaultFolderPolicy.invite_only:
+        Invite only will be the default option when creating a folder in Paper.
     """
 
     _catch_all = 'other'
@@ -675,11 +684,11 @@ class PaperDeploymentPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PaperDeploymentPolicy.full: All team members have access
-        to Paper.
-    :ivar team_policies.PaperDeploymentPolicy.partial: Only whitelisted team
-        members can access Paper. To see which user is whitelisted, check
-        'is_paper_whitelisted' on 'account/info'.
+    :ivar PaperDeploymentPolicy.full:
+        All team members have access to Paper.
+    :ivar PaperDeploymentPolicy.partial:
+        Only whitelisted team members can access Paper. To see which user is
+        whitelisted, check 'is_paper_whitelisted' on 'account/info'.
     """
 
     _catch_all = 'other'
@@ -725,10 +734,10 @@ class PaperDesktopPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PaperDesktopPolicy.disabled: Do not allow team members
-        to use Paper Desktop.
-    :ivar team_policies.PaperDesktopPolicy.enabled: Allow team members to use
-        Paper Desktop.
+    :ivar PaperDesktopPolicy.disabled:
+        Do not allow team members to use Paper Desktop.
+    :ivar PaperDesktopPolicy.enabled:
+        Allow team members to use Paper Desktop.
     """
 
     _catch_all = 'other'
@@ -774,9 +783,12 @@ class PaperEnabledPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PaperEnabledPolicy.disabled: Paper is disabled.
-    :ivar team_policies.PaperEnabledPolicy.enabled: Paper is enabled.
-    :ivar team_policies.PaperEnabledPolicy.unspecified: Unspecified policy.
+    :ivar PaperEnabledPolicy.disabled:
+        Paper is disabled.
+    :ivar PaperEnabledPolicy.enabled:
+        Paper is enabled.
+    :ivar PaperEnabledPolicy.unspecified:
+        Unspecified policy.
     """
 
     _catch_all = 'other'
@@ -832,8 +844,10 @@ class PasswordControlMode(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PasswordControlMode.disabled: Password is disabled.
-    :ivar team_policies.PasswordControlMode.enabled: Password is enabled.
+    :ivar PasswordControlMode.disabled:
+        Password is disabled.
+    :ivar PasswordControlMode.enabled:
+        Password is enabled.
     """
 
     _catch_all = 'other'
@@ -879,16 +893,16 @@ class PasswordStrengthPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.PasswordStrengthPolicy.minimal_requirements: User
-        passwords will not adhere to a password strength policy.
-    :ivar team_policies.PasswordStrengthPolicy.moderate_password: User passwords
-        will adhere to the strong password strength policy. Note that product
-        surfaces refer to this as the strong policy but the value must be kept
-        as is for backwards compatability.
-    :ivar team_policies.PasswordStrengthPolicy.strong_password: User passwords
-        will adhere to the very strong password strength policy. Note that
-        product surfaces refer to this as the very strong policy but the value
+    :ivar PasswordStrengthPolicy.minimal_requirements:
+        User passwords will not adhere to a password strength policy.
+    :ivar PasswordStrengthPolicy.moderate_password:
+        User passwords will adhere to the strong password strength policy. Note
+        that product surfaces refer to this as the strong policy but the value
         must be kept as is for backwards compatability.
+    :ivar PasswordStrengthPolicy.strong_password:
+        User passwords will adhere to the very strong password strength policy.
+        Note that product surfaces refer to this as the very strong policy but
+        the value must be kept as is for backwards compatability.
     """
 
     _catch_all = 'other'
@@ -944,11 +958,12 @@ class RolloutMethod(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.RolloutMethod.unlink_all: Unlink all.
-    :ivar team_policies.RolloutMethod.unlink_most_inactive: Unlink devices with
-        the most inactivity.
-    :ivar team_policies.RolloutMethod.add_member_to_exceptions: Add member to
-        Exceptions.
+    :ivar RolloutMethod.unlink_all:
+        Unlink all.
+    :ivar RolloutMethod.unlink_most_inactive:
+        Unlink devices with the most inactivity.
+    :ivar RolloutMethod.add_member_to_exceptions:
+        Add member to Exceptions.
     """
 
     _catch_all = None
@@ -997,10 +1012,11 @@ class SharedFolderBlanketLinkRestrictionPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SharedFolderBlanketLinkRestrictionPolicy.members: Only
-        members of shared folders can access folder content via shared link.
-    :ivar team_policies.SharedFolderBlanketLinkRestrictionPolicy.anyone: Anyone
-        can access folder content via shared link.
+    :ivar SharedFolderBlanketLinkRestrictionPolicy.members:
+        Only members of shared folders can access folder content via shared
+        link.
+    :ivar SharedFolderBlanketLinkRestrictionPolicy.anyone:
+        Anyone can access folder content via shared link.
     """
 
     _catch_all = 'other'
@@ -1048,11 +1064,11 @@ class SharedFolderJoinPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SharedFolderJoinPolicy.from_team_only: Team members can
-        only join folders shared by teammates.
-    :ivar team_policies.SharedFolderJoinPolicy.from_anyone: Team members can
-        join any shared folder, including those shared by users outside the
-        team.
+    :ivar SharedFolderJoinPolicy.from_team_only:
+        Team members can only join folders shared by teammates.
+    :ivar SharedFolderJoinPolicy.from_anyone:
+        Team members can join any shared folder, including those shared by users
+        outside the team.
     """
 
     _catch_all = 'other'
@@ -1100,13 +1116,13 @@ class SharedFolderMemberPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SharedFolderMemberPolicy.team: Only a teammate can be a
-        member of a folder shared by a team member.
-    :ivar team_policies.SharedFolderMemberPolicy.anyone: Anyone can be a member
-        of a folder shared by a team member.
-    :ivar team_policies.SharedFolderMemberPolicy.team_and_approved: Only a
-        teammate and approved people can be a member of a folder shared by a
-        team member.
+    :ivar SharedFolderMemberPolicy.team:
+        Only a teammate can be a member of a folder shared by a team member.
+    :ivar SharedFolderMemberPolicy.anyone:
+        Anyone can be a member of a folder shared by a team member.
+    :ivar SharedFolderMemberPolicy.team_and_approved:
+        Only a teammate and approved people can be a member of a folder shared
+        by a team member.
     """
 
     _catch_all = 'other'
@@ -1165,18 +1181,19 @@ class SharedLinkCreatePolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SharedLinkCreatePolicy.default_public: By default,
-        anyone can access newly created shared links. No login will be required
-        to access the shared links unless overridden.
-    :ivar team_policies.SharedLinkCreatePolicy.default_team_only: By default,
-        only members of the same team can access newly created shared links.
-        Login will be required to access the shared links unless overridden.
-    :ivar team_policies.SharedLinkCreatePolicy.team_only: Only members of the
-        same team can access all shared links. Login will be required to access
-        all shared links.
-    :ivar team_policies.SharedLinkCreatePolicy.default_no_one: Only people
-        invited can access newly created links. Login will be required to access
-        the shared links unless overridden.
+    :ivar SharedLinkCreatePolicy.default_public:
+        By default, anyone can access newly created shared links. No login will
+        be required to access the shared links unless overridden.
+    :ivar SharedLinkCreatePolicy.default_team_only:
+        By default, only members of the same team can access newly created
+        shared links. Login will be required to access the shared links unless
+        overridden.
+    :ivar SharedLinkCreatePolicy.team_only:
+        Only members of the same team can access all shared links. Login will be
+        required to access all shared links.
+    :ivar SharedLinkCreatePolicy.default_no_one:
+        Only people invited can access newly created links. Login will be
+        required to access the shared links unless overridden.
     """
 
     _catch_all = 'other'
@@ -1242,12 +1259,12 @@ class SharedLinkDefaultPermissionsPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SharedLinkDefaultPermissionsPolicy.default: No team
-        default. Member defaults used instead.
-    :ivar team_policies.SharedLinkDefaultPermissionsPolicy.edit: Default to edit
-        when creating new sharing links
-    :ivar team_policies.SharedLinkDefaultPermissionsPolicy.view: Default to
-        view-only when creating new sharing links
+    :ivar SharedLinkDefaultPermissionsPolicy.default:
+        No team default. Member defaults used instead.
+    :ivar SharedLinkDefaultPermissionsPolicy.edit:
+        Default to edit when creating new sharing links
+    :ivar SharedLinkDefaultPermissionsPolicy.view:
+        Default to view-only when creating new sharing links
     """
 
     _catch_all = 'other'
@@ -1303,10 +1320,10 @@ class ShowcaseDownloadPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.ShowcaseDownloadPolicy.disabled: Do not allow files to
-        be downloaded from Showcases.
-    :ivar team_policies.ShowcaseDownloadPolicy.enabled: Allow files to be
-        downloaded from Showcases.
+    :ivar ShowcaseDownloadPolicy.disabled:
+        Do not allow files to be downloaded from Showcases.
+    :ivar ShowcaseDownloadPolicy.enabled:
+        Allow files to be downloaded from Showcases.
     """
 
     _catch_all = 'other'
@@ -1352,8 +1369,10 @@ class ShowcaseEnabledPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.ShowcaseEnabledPolicy.disabled: Showcase is disabled.
-    :ivar team_policies.ShowcaseEnabledPolicy.enabled: Showcase is enabled.
+    :ivar ShowcaseEnabledPolicy.disabled:
+        Showcase is disabled.
+    :ivar ShowcaseEnabledPolicy.enabled:
+        Showcase is enabled.
     """
 
     _catch_all = 'other'
@@ -1399,10 +1418,10 @@ class ShowcaseExternalSharingPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.ShowcaseExternalSharingPolicy.disabled: Do not allow
-        showcases to be shared with people not on the team.
-    :ivar team_policies.ShowcaseExternalSharingPolicy.enabled: Allow showcases
-        to be shared with people not on the team.
+    :ivar ShowcaseExternalSharingPolicy.disabled:
+        Do not allow showcases to be shared with people not on the team.
+    :ivar ShowcaseExternalSharingPolicy.enabled:
+        Allow showcases to be shared with people not on the team.
     """
 
     _catch_all = 'other'
@@ -1448,10 +1467,10 @@ class SmartSyncPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SmartSyncPolicy.local: The specified content will be
-        synced as local files by default.
-    :ivar team_policies.SmartSyncPolicy.on_demand: The specified content will be
-        synced as on-demand files by default.
+    :ivar SmartSyncPolicy.local:
+        The specified content will be synced as local files by default.
+    :ivar SmartSyncPolicy.on_demand:
+        The specified content will be synced as on-demand files by default.
     """
 
     _catch_all = 'other'
@@ -1497,10 +1516,10 @@ class SmarterSmartSyncPolicyState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SmarterSmartSyncPolicyState.disabled: Smarter Smart Sync
-        feature is disabled.
-    :ivar team_policies.SmarterSmartSyncPolicyState.enabled: Smarter Smart Sync
-        feature is enabled.
+    :ivar SmarterSmartSyncPolicyState.disabled:
+        Smarter Smart Sync feature is disabled.
+    :ivar SmarterSmartSyncPolicyState.enabled:
+        Smarter Smart Sync feature is enabled.
     """
 
     _catch_all = 'other'
@@ -1546,12 +1565,13 @@ class SsoPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SsoPolicy.disabled: Users will be able to sign in with
-        their Dropbox credentials.
-    :ivar team_policies.SsoPolicy.optional: Users will be able to sign in with
-        either their Dropbox or single sign-on credentials.
-    :ivar team_policies.SsoPolicy.required: Users will be required to sign in
-        with their single sign-on credentials.
+    :ivar SsoPolicy.disabled:
+        Users will be able to sign in with their Dropbox credentials.
+    :ivar SsoPolicy.optional:
+        Users will be able to sign in with either their Dropbox or single
+        sign-on credentials.
+    :ivar SsoPolicy.required:
+        Users will be required to sign in with their single sign-on credentials.
     """
 
     _catch_all = 'other'
@@ -1607,10 +1627,10 @@ class SuggestMembersPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.SuggestMembersPolicy.disabled: Suggest members is
-        disabled.
-    :ivar team_policies.SuggestMembersPolicy.enabled: Suggest members is
-        enabled.
+    :ivar SuggestMembersPolicy.disabled:
+        Suggest members is disabled.
+    :ivar SuggestMembersPolicy.enabled:
+        Suggest members is enabled.
     """
 
     _catch_all = 'other'
@@ -1654,22 +1674,23 @@ class TeamMemberPolicies(bb.Struct):
     """
     Policies governing team members.
 
-    :ivar team_policies.TeamMemberPolicies.sharing: Policies governing sharing.
-    :ivar team_policies.TeamMemberPolicies.emm_state: This describes the
-        Enterprise Mobility Management (EMM) state for this team. This
-        information can be used to understand if an organization is integrating
-        with a third-party EMM vendor to further manage and apply restrictions
-        upon the team's Dropbox usage on mobile devices. This is a new feature
-        and in the future we'll be adding more new fields and additional
-        documentation.
-    :ivar team_policies.TeamMemberPolicies.office_addin: The admin policy around
-        the Dropbox Office Add-In for this team.
-    :ivar team_policies.TeamMemberPolicies.suggest_members_policy: The team
-        policy on if teammembers are allowed to suggest users for admins to
-        invite to the team.
-    :ivar team_policies.TeamMemberPolicies.top_level_content_policy: Policy for
-        deciding whether members can edit team folders at the top level of the
-        team space.
+    :ivar TeamMemberPolicies.sharing:
+        Policies governing sharing.
+    :ivar TeamMemberPolicies.emm_state:
+        This describes the Enterprise Mobility Management (EMM) state for this
+        team. This information can be used to understand if an organization is
+        integrating with a third-party EMM vendor to further manage and apply
+        restrictions upon the team's Dropbox usage on mobile devices. This is a
+        new feature and in the future we'll be adding more new fields and
+        additional documentation.
+    :ivar TeamMemberPolicies.office_addin:
+        The admin policy around the Dropbox Office Add-In for this team.
+    :ivar TeamMemberPolicies.suggest_members_policy:
+        The team policy on if teammembers are allowed to suggest users for
+        admins to invite to the team.
+    :ivar TeamMemberPolicies.top_level_content_policy:
+        Policy for deciding whether members can edit team folders at the top
+        level of the team space.
     """
 
     __slots__ = [
@@ -1728,23 +1749,21 @@ class TeamSharingPolicies(bb.Struct):
     """
     Policies governing sharing within and outside of the team.
 
-    :ivar team_policies.TeamSharingPolicies.shared_folder_member_policy: Who can
-        join folders shared by team members.
-    :ivar team_policies.TeamSharingPolicies.shared_folder_join_policy: Which
-        shared folders team members can join.
-    :ivar team_policies.TeamSharingPolicies.shared_link_create_policy: Who can
-        view shared links owned by team members.
-    :ivar team_policies.TeamSharingPolicies.group_creation_policy: Who can
-        create groups.
-    :ivar
-        team_policies.TeamSharingPolicies.shared_folder_link_restriction_policy:
+    :ivar TeamSharingPolicies.shared_folder_member_policy:
+        Who can join folders shared by team members.
+    :ivar TeamSharingPolicies.shared_folder_join_policy:
+        Which shared folders team members can join.
+    :ivar TeamSharingPolicies.shared_link_create_policy:
+        Who can view shared links owned by team members.
+    :ivar TeamSharingPolicies.group_creation_policy:
+        Who can create groups.
+    :ivar TeamSharingPolicies.shared_folder_link_restriction_policy:
         Who can view links to content in shared folders.
-    :ivar team_policies.TeamSharingPolicies.enforce_link_password_policy: If
-        passwords are required for new links shared outside the team.
-    :ivar team_policies.TeamSharingPolicies.default_link_expiration_days_policy:
+    :ivar TeamSharingPolicies.enforce_link_password_policy:
+        If passwords are required for new links shared outside the team.
+    :ivar TeamSharingPolicies.default_link_expiration_days_policy:
         Default expiration date for new links shared outside the team.
-    :ivar
-        team_policies.TeamSharingPolicies.shared_link_default_permissions_policy:
+    :ivar TeamSharingPolicies.shared_link_default_permissions_policy:
         Default access level for new links shared by team members.
     """
 
@@ -1830,10 +1849,11 @@ class TopLevelContentPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.TopLevelContentPolicy.admin_only: Only admins can edit
-        team folders at the top level of the team space.
-    :ivar team_policies.TopLevelContentPolicy.everyone: Everyone on the team can
-        edit team folders at the top level of the team space.
+    :ivar TopLevelContentPolicy.admin_only:
+        Only admins can edit team folders at the top level of the team space.
+    :ivar TopLevelContentPolicy.everyone:
+        Everyone on the team can edit team folders at the top level of the team
+        space.
     """
 
     _catch_all = 'other'
@@ -1879,10 +1899,10 @@ class TwoStepVerificationPolicy(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.TwoStepVerificationPolicy.require_tfa_enable: Enabled
-        require two factor authorization.
-    :ivar team_policies.TwoStepVerificationPolicy.require_tfa_disable: Disabled
-        require two factor authorization.
+    :ivar TwoStepVerificationPolicy.require_tfa_enable:
+        Enabled require two factor authorization.
+    :ivar TwoStepVerificationPolicy.require_tfa_disable:
+        Disabled require two factor authorization.
     """
 
     _catch_all = 'other'
@@ -1928,12 +1948,12 @@ class TwoStepVerificationState(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar team_policies.TwoStepVerificationState.required: Enabled require two
-        factor authorization.
-    :ivar team_policies.TwoStepVerificationState.optional: Optional require two
-        factor authorization.
-    :ivar team_policies.TwoStepVerificationState.disabled: Disabled require two
-        factor authorization.
+    :ivar TwoStepVerificationState.required:
+        Enabled require two factor authorization.
+    :ivar TwoStepVerificationState.optional:
+        Optional require two factor authorization.
+    :ivar TwoStepVerificationState.disabled:
+        Disabled require two factor authorization.
     """
 
     _catch_all = 'other'

--- a/dropbox/users.py
+++ b/dropbox/users.py
@@ -21,16 +21,20 @@ class Account(bb.Struct):
     The amount of detail revealed about an account depends on the user being
     queried and the user making the query.
 
-    :ivar users.Account.account_id: The user's unique Dropbox ID.
-    :ivar users.Account.name: Details of a user's name.
-    :ivar users.Account.email: The user's email address. Do not rely on this
-        without checking the ``email_verified`` field. Even then, it's possible
-        that the user has since lost access to their email.
-    :ivar users.Account.email_verified: Whether the user has verified their
-        email address.
-    :ivar users.Account.profile_photo_url: URL for the photo representing the
-        user, if one is set.
-    :ivar users.Account.disabled: Whether the user has been disabled.
+    :ivar Account.account_id:
+        The user's unique Dropbox ID.
+    :ivar Account.name:
+        Details of a user's name.
+    :ivar Account.email:
+        The user's email address. Do not rely on this without checking the
+        ``email_verified`` field. Even then, it's possible that the user has
+        since lost access to their email.
+    :ivar Account.email_verified:
+        Whether the user has verified their email address.
+    :ivar Account.profile_photo_url:
+        URL for the photo representing the user, if one is set.
+    :ivar Account.disabled:
+        Whether the user has been disabled.
     """
 
     __slots__ = [
@@ -97,12 +101,12 @@ class BasicAccount(Account):
     """
     Basic information about any account.
 
-    :ivar users.BasicAccount.is_teammate: Whether this user is a teammate of the
-        current user. If this account is the current user's account, then this
-        will be ``True``.
-    :ivar users.BasicAccount.team_member_id: The user's unique team member id.
-        This field will only be present if the user is part of a team and
-        ``is_teammate`` is ``True``.
+    :ivar BasicAccount.is_teammate:
+        Whether this user is a teammate of the current user. If this account is
+        the current user's account, then this will be ``True``.
+    :ivar BasicAccount.team_member_id:
+        The user's unique team member id. This field will only be present if the
+        user is part of a team and ``is_teammate`` is ``True``.
     """
 
     __slots__ = [
@@ -153,9 +157,10 @@ class DistinctMemberHomeValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool users.DistinctMemberHomeValue.enabled: When this value is True,
-        the user have distinct home and root ns. When the value is False the
-        user's home ns and root ns are the same.
+    :ivar DistinctMemberHomeValue.enabled:
+        When this value is True, the user have distinct home and root ns. When
+        the value is False the user's home ns and root ns are the same.
+    :vartype DistinctMemberHomeValue.enabled: bool
     """
 
     _catch_all = 'other'
@@ -215,10 +220,11 @@ class FileLockingValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool users.FileLockingValue.enabled: When this value is True, the user
-        can lock files in shared directories. When the value is False the user
-        can unlock the files they have locked or request to unlock files locked
-        by others.
+    :ivar FileLockingValue.enabled:
+        When this value is True, the user can lock files in shared directories.
+        When the value is False the user can unlock the files they have locked
+        or request to unlock files locked by others.
+    :vartype FileLockingValue.enabled: bool
     """
 
     _catch_all = 'other'
@@ -275,23 +281,27 @@ class FullAccount(Account):
     """
     Detailed information about the current user's account.
 
-    :ivar users.FullAccount.country: The user's two-letter country code, if
-        available. Country codes are based on `ISO 3166-1
-        <http://en.wikipedia.org/wiki/ISO_3166-1>`_.
-    :ivar users.FullAccount.locale: The language that the user specified. Locale
-        tags will be `IETF language tags
-        <http://en.wikipedia.org/wiki/IETF_language_tag>`_.
-    :ivar users.FullAccount.referral_link: The user's `referral link
-        <https://www.dropbox.com/referrals>`_.
-    :ivar users.FullAccount.team: If this account is a member of a team,
-        information about that team.
-    :ivar users.FullAccount.team_member_id: This account's unique team member
-        id. This field will only be present if ``team`` is present.
-    :ivar users.FullAccount.is_paired: Whether the user has a personal and work
-        account. If the current account is personal, then ``team`` will always
-        be None, but ``is_paired`` will indicate if a work account is linked.
-    :ivar users.FullAccount.account_type: What type of account this user has.
-    :ivar users.FullAccount.root_info: The root info for this account.
+    :ivar FullAccount.country:
+        The user's two-letter country code, if available. Country codes are
+        based on `ISO 3166-1 <http://en.wikipedia.org/wiki/ISO_3166-1>`_.
+    :ivar FullAccount.locale:
+        The language that the user specified. Locale tags will be `IETF language
+        tags <http://en.wikipedia.org/wiki/IETF_language_tag>`_.
+    :ivar FullAccount.referral_link:
+        The user's `referral link <https://www.dropbox.com/referrals>`_.
+    :ivar FullAccount.team:
+        If this account is a member of a team, information about that team.
+    :ivar FullAccount.team_member_id:
+        This account's unique team member id. This field will only be present if
+        ``team`` is present.
+    :ivar FullAccount.is_paired:
+        Whether the user has a personal and work account. If the current account
+        is personal, then ``team`` will always be None, but ``is_paired`` will
+        indicate if a work account is linked.
+    :ivar FullAccount.account_type:
+        What type of account this user has.
+    :ivar FullAccount.root_info:
+        The root info for this account.
     """
 
     __slots__ = [
@@ -386,8 +396,10 @@ class Team(bb.Struct):
     """
     Information about a team.
 
-    :ivar users.Team.id: The team's unique ID.
-    :ivar users.Team.name: The name of the team.
+    :ivar Team.id:
+        The team's unique ID.
+    :ivar Team.name:
+        The name of the team.
     """
 
     __slots__ = [
@@ -422,11 +434,13 @@ class FullTeam(Team):
     """
     Detailed information about a team.
 
-    :ivar users.FullTeam.sharing_policies: Team policies governing sharing.
-    :ivar users.FullTeam.office_addin_policy: Team policy governing the use of
-        the Office Add-In.
-    :ivar users.FullTeam.top_level_content_policy: Team policy governing whether
-        members can edit team folders at the top level of the team space.
+    :ivar FullTeam.sharing_policies:
+        Team policies governing sharing.
+    :ivar FullTeam.office_addin_policy:
+        Team policy governing the use of the Office Add-In.
+    :ivar FullTeam.top_level_content_policy:
+        Team policy governing whether members can edit team folders at the top
+        level of the team space.
     """
 
     __slots__ = [
@@ -471,7 +485,8 @@ FullTeam_validator = bv.Struct(FullTeam)
 
 class GetAccountArg(bb.Struct):
     """
-    :ivar users.GetAccountArg.account_id: A user's account identifier.
+    :ivar GetAccountArg.account_id:
+        A user's account identifier.
     """
 
     __slots__ = [
@@ -496,8 +511,9 @@ GetAccountArg_validator = bv.Struct(GetAccountArg)
 
 class GetAccountBatchArg(bb.Struct):
     """
-    :ivar users.GetAccountBatchArg.account_ids: List of user account
-        identifiers.  Should not contain any duplicate account IDs.
+    :ivar GetAccountBatchArg.account_ids:
+        List of user account identifiers.  Should not contain any duplicate
+        account IDs.
     """
 
     __slots__ = [
@@ -526,9 +542,10 @@ class GetAccountBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar str users.GetAccountBatchError.no_account: The value is an account ID
-        specified in :field:`GetAccountBatchArg.account_ids` that does not
-        exist.
+    :ivar GetAccountBatchError.no_account:
+        The value is an account ID specified in
+        ``GetAccountBatchArg.account_ids`` that does not exist.
+    :vartype GetAccountBatchError.no_account: str
     """
 
     _catch_all = 'other'
@@ -586,8 +603,8 @@ class GetAccountError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar users.GetAccountError.no_account: The specified
-        ``GetAccountArg.account_id`` does not exist.
+    :ivar GetAccountError.no_account:
+        The specified ``GetAccountArg.account_id`` does not exist.
     """
 
     _catch_all = 'other'
@@ -619,8 +636,8 @@ GetAccountError_validator = bv.Union(GetAccountError)
 
 class IndividualSpaceAllocation(bb.Struct):
     """
-    :ivar users.IndividualSpaceAllocation.allocated: The total space allocated
-        to the user's account (bytes).
+    :ivar IndividualSpaceAllocation.allocated:
+        The total space allocated to the user's account (bytes).
     """
 
     __slots__ = [
@@ -647,15 +664,20 @@ class Name(bb.Struct):
     """
     Representations for a person's name to assist with internationalization.
 
-    :ivar users.Name.given_name: Also known as a first name.
-    :ivar users.Name.surname: Also known as a last name or family name.
-    :ivar users.Name.familiar_name: Locale-dependent name. In the US, a person's
-        familiar name is their ``given_name``, but elsewhere, it could be any
-        combination of a person's ``given_name`` and ``surname``.
-    :ivar users.Name.display_name: A name that can be used directly to represent
-        the name of a user's Dropbox account.
-    :ivar users.Name.abbreviated_name: An abbreviated form of the person's name.
-        Their initials in most locales.
+    :ivar Name.given_name:
+        Also known as a first name.
+    :ivar Name.surname:
+        Also known as a last name or family name.
+    :ivar Name.familiar_name:
+        Locale-dependent name. In the US, a person's familiar name is their
+        ``given_name``, but elsewhere, it could be any combination of a person's
+        ``given_name`` and ``surname``.
+    :ivar Name.display_name:
+        A name that can be used directly to represent the name of a user's
+        Dropbox account.
+    :ivar Name.abbreviated_name:
+        An abbreviated form of the person's name. Their initials in most
+        locales.
     """
 
     __slots__ = [
@@ -718,11 +740,13 @@ class PaperAsFilesValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool users.PaperAsFilesValue.enabled: When this value is true, the
-        user's Paper docs are accessible in Dropbox with the .paper extension
-        and must be accessed via the /files endpoints.  When this value is
-        false, the user's Paper docs are stored separate from Dropbox files and
-        folders and should be accessed via the /paper endpoints.
+    :ivar PaperAsFilesValue.enabled:
+        When this value is true, the user's Paper docs are accessible in Dropbox
+        with the .paper extension and must be accessed via the /files endpoints.
+        When this value is false, the user's Paper docs are stored separate from
+        Dropbox files and folders and should be accessed via the /paper
+        endpoints.
+    :vartype PaperAsFilesValue.enabled: bool
     """
 
     _catch_all = 'other'
@@ -785,10 +809,12 @@ class SpaceAllocation(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar IndividualSpaceAllocation SpaceAllocation.individual: The user's space
-        allocation applies only to their individual account.
-    :ivar TeamSpaceAllocation SpaceAllocation.team: The user shares space with
-        other members of their team.
+    :ivar SpaceAllocation.individual:
+        The user's space allocation applies only to their individual account.
+    :vartype SpaceAllocation.individual: IndividualSpaceAllocation
+    :ivar SpaceAllocation.team:
+        The user shares space with other members of their team.
+    :vartype SpaceAllocation.team: TeamSpaceAllocation
     """
 
     _catch_all = 'other'
@@ -874,8 +900,10 @@ class SpaceUsage(bb.Struct):
     """
     Information about a user's space usage and quota.
 
-    :ivar users.SpaceUsage.used: The user's total space usage (bytes).
-    :ivar users.SpaceUsage.allocation: The user's space allocation.
+    :ivar SpaceUsage.used:
+        The user's total space usage (bytes).
+    :ivar SpaceUsage.allocation:
+        The user's space allocation.
     """
 
     __slots__ = [
@@ -914,9 +942,10 @@ class TeamSharedDropboxValue(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar bool users.TeamSharedDropboxValue.enabled: When this value is True,
-        the user have a shared team root. When the value is False the user have
-        distinct root.
+    :ivar TeamSharedDropboxValue.enabled:
+        When this value is True, the user have a shared team root. When the
+        value is False the user have distinct root.
+    :vartype TeamSharedDropboxValue.enabled: bool
     """
 
     _catch_all = 'other'
@@ -970,18 +999,19 @@ TeamSharedDropboxValue_validator = bv.Union(TeamSharedDropboxValue)
 
 class TeamSpaceAllocation(bb.Struct):
     """
-    :ivar users.TeamSpaceAllocation.used: The total space currently used by the
-        user's team (bytes).
-    :ivar users.TeamSpaceAllocation.allocated: The total space allocated to the
-        user's team (bytes).
-    :ivar users.TeamSpaceAllocation.user_within_team_space_allocated: The total
-        space allocated to the user within its team allocated space (0 means
-        that no restriction is imposed on the user's quota within its team).
-    :ivar users.TeamSpaceAllocation.user_within_team_space_limit_type: The type
-        of the space limit imposed on the team member (off, alert_only,
+    :ivar TeamSpaceAllocation.used:
+        The total space currently used by the user's team (bytes).
+    :ivar TeamSpaceAllocation.allocated:
+        The total space allocated to the user's team (bytes).
+    :ivar TeamSpaceAllocation.user_within_team_space_allocated:
+        The total space allocated to the user within its team allocated space (0
+        means that no restriction is imposed on the user's quota within its
+        team).
+    :ivar TeamSpaceAllocation.user_within_team_space_limit_type:
+        The type of the space limit imposed on the team member (off, alert_only,
         stop_sync).
-    :ivar users.TeamSpaceAllocation.user_within_team_space_used_cached: An
-        accurate cached calculation of a team member's total space usage
+    :ivar TeamSpaceAllocation.user_within_team_space_used_cached:
+        An accurate cached calculation of a team member's total space usage
         (bytes).
     """
 
@@ -1045,16 +1075,18 @@ class UserFeature(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar users.UserFeature.paper_as_files: This feature contains information
-        about how the user's Paper files are stored.
-    :ivar users.UserFeature.file_locking: This feature allows users to lock
-        files in order to restrict other users from editing them.
-    :ivar users.UserFeature.team_shared_dropbox: This feature contains
-        information about whether or not the user is part of a team with a
-        shared team root.
-    :ivar users.UserFeature.distinct_member_home: This feature contains
-        information about whether or not the user's home namespace is distinct
-        from their root namespace.
+    :ivar UserFeature.paper_as_files:
+        This feature contains information about how the user's Paper files are
+        stored.
+    :ivar UserFeature.file_locking:
+        This feature allows users to lock files in order to restrict other users
+        from editing them.
+    :ivar UserFeature.team_shared_dropbox:
+        This feature contains information about whether or not the user is part
+        of a team with a shared team root.
+    :ivar UserFeature.distinct_member_home:
+        This feature contains information about whether or not the user's home
+        namespace is distinct from their root namespace.
     """
 
     _catch_all = 'other'
@@ -1258,9 +1290,9 @@ UserFeatureValue_validator = bv.Union(UserFeatureValue)
 
 class UserFeaturesGetValuesBatchArg(bb.Struct):
     """
-    :ivar users.UserFeaturesGetValuesBatchArg.features: A list of features in
-        :class:`UserFeature`. If the list is empty, this route will return
-        :class:`UserFeaturesGetValuesBatchError`.
+    :ivar UserFeaturesGetValuesBatchArg.features:
+        A list of features in :class:`UserFeature`. If the list is empty, this
+        route will return :class:`UserFeaturesGetValuesBatchError`.
     """
 
     __slots__ = [
@@ -1289,8 +1321,8 @@ class UserFeaturesGetValuesBatchError(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar users.UserFeaturesGetValuesBatchError.empty_features_list: At least
-        one :class:`UserFeature` must be included in the
+    :ivar UserFeaturesGetValuesBatchError.empty_features_list:
+        At least one :class:`UserFeature` must be included in the
         :class:`UserFeaturesGetValuesBatchArg`.features list.
     """
 

--- a/dropbox/users_common.py
+++ b/dropbox/users_common.py
@@ -19,9 +19,12 @@ class AccountType(bb.Union):
     return true. To get the associated value of a tag (if one exists), use the
     corresponding ``get_*`` method.
 
-    :ivar users_common.AccountType.basic: The basic account type.
-    :ivar users_common.AccountType.pro: The Dropbox Pro account type.
-    :ivar users_common.AccountType.business: The Dropbox Business account type.
+    :ivar AccountType.basic:
+        The basic account type.
+    :ivar AccountType.pro:
+        The Dropbox Pro account type.
+    :ivar AccountType.business:
+        The Dropbox Business account type.
     """
 
     _catch_all = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "Dropbox", email = "dev-platform@dropbox.com" }]
 dependencies = [
     "requests>=2.16.2",
-    "stone>=3.5.1,<4",
+    "stone>=3.5.2,<4",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -34,7 +34,7 @@ Homepage = "http://www.dropbox.com/developers"
 Source = "https://github.com/dropbox/dropbox-sdk-python"
 
 [project.optional-dependencies]
-test = ["pytest", "mock", "pytest-mock", "coverage", "stone>=3.5.1,<4"]
+test = ["pytest", "mock", "pytest-mock", "coverage", "stone>=3.5.2,<4"]
 docs = ["sphinx", "sphinx_rtd_theme"]
 dev = ["flake8", "twine", "wheel", "build"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies required for installation (keep in sync with pyproject.toml)
 requests>=2.16.2
-stone>=3.5.1,<4
+stone>=3.5.2,<4
 # Other dependencies for development
 pytest
 sphinx

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,4 +2,4 @@ pytest
 mock
 pytest-mock
 coverage
-stone>=3.4.0,<4
+stone>=3.5.2,<4


### PR DESCRIPTION
Bumps stone to 3.5.2 (pyproject.toml, requirements.txt, test/requirements.txt) and regenerates the client.

Picks up the doc-generation fix (dropbox/stone#375), eliminating the sphinx warnings reported in #359 (380 → 2). Also fixes a malformed `:param` in dropbox_client.py.

API surface unchanged — only docstrings differ.