### PR TITLE
CI: run on push to main and set least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
+
+permissions:  # least privilege; jobs needing OIDC override this
+  contents: read
 
 jobs:
   CI:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 0 0 * * *
 
+permissions:  # least privilege; jobs needing OIDC override this
+  contents: read
+
 jobs:
   Coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [spec_update]
 
+permissions:  # least privilege; PR creation uses the SPEC_UPDATE_TOKEN PAT
+  contents: read
+
 jobs:
   Update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Two related CI hardening fixes:

1. **Run CI on merge to `main`.** `ci.yml` was triggered on `pull_request` only, so the full matrix (lint + unit + integration) never re-ran on the merge commit — `main` could break undetected (e.g. a PR green against a stale base, or two PRs that conflict only once both land). Add a `push: [main]` trigger, matching [`dropbox-sdk-dotnet`](https://github.com/dropbox/dropbox-sdk-dotnet)'s `ci.yml`.

2. **Set least-privilege `GITHUB_TOKEN` permissions.** Resolves the CodeQL `actions/missing-workflow-permissions` alert (#5). Add a top-level `permissions: contents: read` to both `ci.yml` and `coverage.yml`. Jobs that use OIDC keep their existing job-level `id-token: write` override, so credential fetching is unaffected.
