### PR TITLE
CI: add CodeQL workflow and harden Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: 0 0 * * 1
+  workflow_dispatch:  # allow on-demand manual scans
+
+permissions:  # least privilege
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # required to upload CodeQL results
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["actions", "python"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pypiupload.yml
+++ b/.github/workflows/pypiupload.yml
@@ -8,6 +8,9 @@ on:
     types: [created]
   workflow_dispatch:  # Allow manual trigger for testing
 
+permissions:  # least privilege; the deploy job overrides this for OIDC
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -28,25 +28,35 @@ jobs:
           git submodule update --remote --recursive
       - name: Generate Branch Name
         id: git-branch
+        env:
+          FORMATTED_TIME: ${{ steps.current-time.outputs.formattedTime }}
         run: |
-          echo "::set-output name=branch::spec_update_${{ steps.current-time.outputs.formattedTime }}"
+          echo "branch=spec_update_${FORMATTED_TIME}" >> "$GITHUB_OUTPUT"
       - name: Generate Num Diffs
         id: git-diff-num
         run: |
           diffs=$(git diff --submodule spec | grep ">" | wc -l)
           echo "Number of Spec diffs: $diffs"
-          echo "::set-output name=num-diff::$diffs"
+          echo "num-diff=$diffs" >> "$GITHUB_OUTPUT"
       - name: Generate Diff
         id: git-diff
+        env:
+          NUM_DIFF: ${{ steps.git-diff-num.outputs.num-diff }}
         run: |
           cd spec
-          gitdiff=$(git log -n ${{ steps.git-diff-num.outputs.num-diff }} --pretty="format:%n %H %n%n %b")
+          gitdiff=$(git log -n "$NUM_DIFF" --pretty="format:%n %H %n%n %b")
           commit="Automated Spec Update $gitdiff"
-          commit="${commit//'%'/'%25'}"
-          commit="${commit//$'\n'/'%0A'}"
-          commit="${commit//$'\r'/'%0D'}"
-          echo "Commit Message: $commit"
-          echo "::set-output name=commit::$commit"
+          while true; do
+            delimiter="SPEC_UPDATE_EOF_$(python -c 'import uuid; print(uuid.uuid4())')"
+            if ! grep -Fxq "$delimiter" <<< "$commit"; then
+              break
+            fi
+          done
+          {
+            printf 'commit<<%s\n' "$delimiter"
+            printf '%s\n' "$commit"
+            printf '%s\n' "$delimiter"
+          } >> "$GITHUB_OUTPUT"
           cd ..
       - name: Generate New Routes
         run: |


### PR DESCRIPTION
Fixes CodeQL `language:actions` findings and adds a real scanning workflow.

## Changes
- **codeql.yml** (new): scans `actions` + `python` on push/PR to main and weekly (Mon 00:00 UTC). Replaces reliance on stale default-setup scans.
- **spec_update.yml**: migrate deprecated `::set-output` (disabled by GitHub in 2023) to `$GITHUB_OUTPUT`; pass interpolated `${{ }}` values via `env:` to close shell-injection findings.
- **pypiupload.yml**: add top-level least-privilege `permissions: contents: read`, matching the other workflows.

## Verification
- All workflow YAML parses.
- `actionlint` clean (no injection/permission/set-output errors).
- Simulated the new `$GITHUB_OUTPUT` heredoc with a multiline commit body containing `%`, `$`, backticks — preserved literally, confirming the old escaping is no longer needed.