### PR TITLE
Close stale spec-update PRs and include date in title

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -105,7 +105,7 @@ jobs:
             ${{ steps.git-diff.outputs.commit}}
           branch: ${{ steps.git-branch.outputs.branch }}
           delete-branch: true
-          title: 'Automated Spec Update'
+          title: 'Automated Spec Update - ${{ steps.current-time.outputs.formattedTime }}'
           body: |
             ${{ steps.git-diff.outputs.commit}}
           base: 'main'

--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -84,6 +84,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           python generate_base_client.py
+
+      - name: Close Old Pull Requests
+        if: steps.git-diff-num.outputs.num-diff != 0
+        run: |
+          gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number' | while read -r pr_num; do
+            echo "Closing old PR #$pr_num"
+            gh pr close "$pr_num" --delete-branch
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -98,9 +109,8 @@ jobs:
           body: |
             ${{ steps.git-diff.outputs.commit}}
           base: 'main'
-          team-reviewers: |
-            owners
-            maintainers
+          labels: |
+            automated-spec-update
           draft: false
 
       # - name: Enable Pull Request Automerge


### PR DESCRIPTION
## Summary
- Close any existing open PRs labeled "automated-spec-update" before creating a new one, preventing stale PRs from accumulating
- Include the formatted date in the PR title (e.g. "Automated Spec Update - 2026_07_17")
- Label new spec-update PRs with "automated-spec-update" for identification
- Remove team-reviewers since the app token cannot request team reviews

## Test plan
- [ ] Trigger the workflow and verify old spec-update PRs are closed
- [ ] Confirm the new PR title includes the date
- [ ] Confirm the "automated-spec-update" label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)