### PR TITLE
Link to new PR when closing stale spec-update PRs

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -85,16 +85,6 @@ jobs:
           pip install -r requirements.txt
           python generate_base_client.py
 
-      - name: Close Old Pull Requests
-        if: steps.git-diff-num.outputs.num-diff != 0
-        run: |
-          gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number' | while read -r pr_num; do
-            echo "Closing old PR #$pr_num"
-            gh pr close "$pr_num" --delete-branch
-          done
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v8
@@ -112,6 +102,19 @@ jobs:
           labels: |
             automated-spec-update
           draft: false
+
+      - name: Close Old Pull Requests
+        if: steps.create-pr.outputs.pull-request-number
+        run: |
+          gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number' | while read -r pr_num; do
+            if [ "$pr_num" != "${{ steps.create-pr.outputs.pull-request-number }}" ]; then
+              echo "Closing old PR #$pr_num"
+              gh pr comment "$pr_num" --body "Superseded by #${{ steps.create-pr.outputs.pull-request-number }}"
+              gh pr close "$pr_num" --delete-branch
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # - name: Enable Pull Request Automerge
       #   if: steps.create-pr.outputs.pull-request-number


### PR DESCRIPTION
## Summary
- Move the "Close Old Pull Requests" step to run after PR creation
- Comment "Superseded by #<new>" on each old PR before closing it
- Skip the newly created PR when iterating open PRs

## Test plan
- [ ] Trigger the workflow with an existing open spec-update PR
- [ ] Verify the old PR gets a "Superseded by #<new>" comment and is closed
- [ ] Verify the new PR remains open

🤖 Generated with [Claude Code](https://claude.com/claude-code)