### PR TITLE
Fix closed PR output lost in pipe subshell

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -90,12 +90,13 @@ jobs:
         if: steps.git-diff-num.outputs.num-diff != 0
         run: |
           closed=""
-          gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number' | while read -r pr_num; do
+          while read -r pr_num; do
             echo "Closing old PR #$pr_num"
             gh pr close "$pr_num" --delete-branch
             closed="${closed:+$closed,}$pr_num"
-          done
+          done < <(gh pr list --label "automated-spec-update" --state open --json number --jq '.[].number')
           echo "closed=$closed" >> "$GITHUB_OUTPUT"
+        shell: bash
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Summary
- The pipe-to-while pattern (`cmd | while read`) runs the loop in a subshell, so the `closed` variable was always empty when written to `GITHUB_OUTPUT`
- Use process substitution (`< <(cmd)`) so the loop runs in the current shell and the output is preserved
- Add `shell: bash` since process substitution requires bash

## Test plan
- [ ] Trigger the workflow with an existing open spec-update PR
- [ ] Verify the "Comment on closed PRs" step is no longer skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)