### PR TITLE
Run ruff format and check after code generation in spec_update

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -83,7 +83,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install ruff
           python generate_base_client.py
+          ruff format dropbox
+          ruff check --fix dropbox
 
       - name: Close Old Pull Requests
         id: close-old-prs


### PR DESCRIPTION
## Summary
- Install `ruff` and run `ruff format dropbox` + `ruff check --fix dropbox` after `generate_base_client.py`
- CI enforces `ruff format --check` and `ruff check` on the `dropbox` package, so generated code must be formatted before the PR is created

Fixes CI failures on #566

## Test plan
- [ ] Re-trigger `spec_update` workflow and confirm the resulting PR passes CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)