### PR TITLE
Fix spec-update automerge: use --squash instead of --merge

### DIFF
--- a/.github/workflows/spec_update.yml
+++ b/.github/workflows/spec_update.yml
@@ -133,6 +133,6 @@ jobs:
 
       - name: Enable Pull Request Automerge
         if: steps.create-pr.outputs.pull-request-number
-        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
The `Enable Pull Request Automerge` step in `spec_update.yml` runs `gh pr merge --merge --auto`, but this repo only permits squash merges (`allow_merge_commit=false`, `allow_squash_merge=true`). As a result the enable-automerge step fails and auto-merge is never set on the generated spec-update PRs (e.g. #570 shows no auto-merge armed despite checks running).

Switches the flag to `--squash` to match the repo's allowed merge method. This is python-specific — the other SDK repos permit merge commits, so their workflows are unaffected.